### PR TITLE
vSphere cluster documentation for networks/nodes

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -59,6 +59,11 @@ govc datastore.ls ./kube/
 Take a look at the file `cluster/vsphere/config-common.sh` fill in the required
 parameters. The guest login for the image that you imported is `kube:kube`.
 
+Also take a look at the file `cluster/vsphere/config-default.sh` and
+make any needed changes. You can configure the number of minion nodes
+as well as the IP subnets you have made availble to Kubernetes, pods,
+and services.
+
 ### Starting a cluster
 
 Now, let's continue with deploying Kubernetes.


### PR DESCRIPTION
Added a note to the getting started guide for vSphere to point users
at the right place to configure the number of minion nodes and the
IP ranges used by Kubernetes.