### PR TITLE
Fix instructions for ruby install via rvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Then load it into your environment
 
 Then install Ruby 2.2 or higher
 
-	rvm install 2.2
-	rvm use 2.2 --default
+	rvm install ruby-2.2.4
+	rvm use ruby-2.2.4 --default
 	
 Verify that this new version is running (optional)
 

--- a/docs/editdocs.md
+++ b/docs/editdocs.md
@@ -70,8 +70,8 @@ source /Users/(USERNAME)/.rvm/scripts/rvm (or whatever is prompted by the instal
 Then install Ruby 2.2 or higher
 
 ```shell
-rvm install 2.2
-rvm use 2.2 --default
+rvm install ruby-2.2.4
+rvm use ruby-2.2.4 --default
 ```
 
 Verify that this new version is running (optional)


### PR DESCRIPTION
I was getting the error below while following the instructions to install ruby `2.2` with rvm `1.25.23`. It seems to work with the latest rvm but some users may not have the latest version installed and it isn't a great user experience to get started with the project. Feel free to ignore though :)

> Unknown ruby string (do not know how to handle): 2.2.