### PR TITLE
Removed v1beta1 disclaimer for jobs, since jobs are now part of batch/v1

### DIFF
--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -88,9 +88,9 @@ the same schema as a [pod](/docs/user-guide/pods), except it is nested and does 
 `kind`.
 
 In addition to required fields for a Pod, a pod template in a job must specify appropriate
-labels (see [pod selector](#pod-selector) and an appropriate restart policy.
+labels (see [pod selector](#pod-selector)) and an appropriate restart policy.
 
-Only a [`RestartPolicy`](/docs/user-guide/pod-states) equal to `Never` or `OnFailure` are allowed.
+Only a [`RestartPolicy`](/docs/user-guide/pod-states/#restartpolicy) equal to `Never` or `OnFailure` are allowed.
 
 ### Pod Selector
 
@@ -330,14 +330,6 @@ driver, and then cleans up.
 
 An advantage of this approach is that the overall process gets the completion guarantee of a Job
 object, but complete control over what pods are created and how work is assigned to them.
-
-## Caveats
-
-Job objects are in the [`extensions` API Group](/docs/api/#api-groups).
-
-Job objects have [API version `v1beta1`](/docs/api/)#api-versioning).  Beta objects may
-undergo changes to their schema and/or semantics in future software releases, but
-similar functionality will be supported.
 
 ## Future work
 


### PR DESCRIPTION
Jobs recently moved from unsupported `extensions/v1beta1` to `batch/v1`, that's why it's reasonable to remove the caveats section.

fyi @erictune 