### PR TITLE
head-header: Fix missing "View On Github" link

### DIFF
--- a/_includes/head-header.html
+++ b/_includes/head-header.html
@@ -42,7 +42,7 @@
 		<main data-auto-burger="primary">
 			<div class="left">
 				<h5 class="github-invite">Interested in hacking on the core Kubernetes code base?</h5>
-				<a href="" class="button" data-auto-burger-exclude>View On Github</a>
+				<a href="https://github.com/kubernetes/kubernetes" class="button" data-auto-burger-exclude>View On Github</a>
 			</div>
 
 			<div class="right">


### PR DESCRIPTION
Without this commit, the button goes to kubernetes.io home page.