### PR TITLE
Fix kube-controller-manager description

### DIFF
--- a/docs/admin/cluster-components.md
+++ b/docs/admin/cluster-components.md
@@ -44,15 +44,11 @@ process.
 
 These controllers include:
 
-* Node Controller
- * Responsible for noticing & responding when nodes go down.
-* Replication Controller
- * Responsible for maintaining the correct number of pods for every replication
-   controller object in the system.
-* Endpoints Controller
- * Populates the Endpoints object (i.e., join Services & Pods).
-* Service Account & Token Controllers
- * Create default accounts and API access tokens for new namespaces.
+* Node Controller: Responsible for noticing & responding when nodes go down.
+* Replication Controller: Responsible for maintaining the correct number of pods for every replication
+  controller object in the system.
+* Endpoints Controller: Populates the Endpoints object (i.e., join Services & Pods).
+* Service Account & Token Controllers: Create default accounts and API access tokens for new namespaces.
 * ... and others.
 
 ### kube-scheduler


### PR DESCRIPTION
The item and their description was shown as different items at the same
indentation level. This just moves de description so it's clear it is not a new
item and is just the description of the previous item.