### PR TITLE
docs/admin: add current-context to authz webhook example kubeconfig

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -161,6 +161,14 @@ users:
     user:
       client-certificate: /path/to/cert.pem # cert for the webhook plugin to use
       client-key: /path/to/key.pem          # key matching the cert
+
+# kubeconfig files require a context. Provide one for the API Server.
+current-context: webhook
+contexts:
+- context:
+    cluster: name-of-remote-authz-service
+    user: name-of-api-sever
+  name: webhook
 ```
 
 ### Request Payloads


### PR DESCRIPTION
This was brought up on the #sig-auth kubernetes slack channel. The current config example is missing a current-context which causes the webhook plugin to choose a default value.