### PR TITLE
Document revisionHistoryLimit in Deployment spec

### DIFF
--- a/docs/user-guide/deployments.md
+++ b/docs/user-guide/deployments.md
@@ -468,7 +468,15 @@ To learn more about when a pod is considered ready, see [Container Probes](/docs
 
 ### Revision History Limit
 
-`.spec.revisionHistoryLimit` is an optional field that specifies the number of old replica sets to retain to allow rollback. All old replica sets will be kept by default, if this field is not set. The configuration of each Deployment revision is stored in its replica sets; therefore, once an old replica set is deleted, you lose the ability to rollback to that revision of Deployment. 
+`.spec.revisionHistoryLimit` is an optional field that specifies the number of
+old replica sets to retain to allow rollback. Its ideal value depends on the
+frequency and stability of new deployments. All old replica sets will be kept by
+default, consuming resources in `etcd` and crowding the output of `kubectl get
+rs`, if this field is not set. The configuration of each Deployment revision is
+stored in its replica sets; therefore, once an old replica set is deleted, you
+lose the ability to roll back to that revision of Deployment. More specifically,
+setting this field to zero means that a new deployment revision can be undone
+only while still in progress.
 
 ### Paused
 


### PR DESCRIPTION
I'm not sure the field should be optional, but that ship has already sailed. It should definitely be a lot more prominent than hidden in the API docs, though.