### PR TITLE
Fix typo in ConfigMap doc

### DIFF
--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -267,7 +267,7 @@ spec:
         - name: SPECIAL_LEVEL_KEY
           valueFrom:
             configMapKeyRef:
-              name: special-configmap
+              name: special-config
               key: special.how
         - name: SPECIAL_TYPE_KEY
           valueFrom:
@@ -318,7 +318,7 @@ spec:
         - name: SPECIAL_LEVEL_KEY
           valueFrom:
             configMapKeyRef:
-              name: special-configmap
+              name: special-config
               key: special.how
         - name: SPECIAL_TYPE_KEY
           valueFrom:


### PR DESCRIPTION
@kelseyhightower I realized while writing OpenShift docs that there are a couple errors in the descriptors in the doc, PTAL