### PR TITLE
Fix broken labels -> node-selection link

### DIFF
--- a/docs/user-guide/labels.md
+++ b/docs/user-guide/labels.md
@@ -165,4 +165,4 @@ selector:
 #### Selecting sets of nodes
 
 One use case for selecting over labels is to constrain the set of nodes onto which a pod can schedule.
-See the documentation on [node selection](node-selection/README.md) for more information.
+See the documentation on [node selection](/docs/user-guide/node-selection) for more information.


### PR DESCRIPTION
http://kubernetes.io/docs/user-guide/labels/node-selection// doesn't exist;
http://kubernetes.io/docs/user-guide/node-selection/ does.