### PR TITLE
Download links should use https & v1.2.0 (not http & alpha.7)

### DIFF
--- a/docs/getting-started-guides/docker-multinode.md
+++ b/docs/getting-started-guides/docker-multinode.md
@@ -35,7 +35,7 @@ it is still useful to use containers for deployment and management, so we create
 You can specify the version on every node before install:
 
 ```shell
-export K8S_VERSION=<your_k8s_version (e.g. 1.2.0-alpha.7)>
+export K8S_VERSION=<your_k8s_version (e.g. 1.2.0)>
 export ETCD_VERSION=<your_etcd_version (e.g. 2.2.1)>
 export FLANNEL_VERSION=<your_flannel_version (e.g. 0.5.5)>
 export FLANNEL_IFACE=<flannel_interface (defaults to eth0)>

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -9,7 +9,7 @@ Enviroinment variables used:
 
 ```shell
 export MASTER_IP=<the_master_ip_here>
-export K8S_VERSION=<your_k8s_version (e.g. 1.2.0-alpha.7)>
+export K8S_VERSION=<your_k8s_version (e.g. 1.2.0)>
 export ETCD_VERSION=<your_etcd_version (e.g. 2.2.1)>
 export FLANNEL_VERSION=<your_flannel_version (e.g. 0.5.5)>
 export FLANNEL_IFACE=<flannel_interface (defaults to eth0)>
@@ -199,11 +199,11 @@ sudo docker run \
 At this point, you should have a functioning 1-node cluster.  Let's test it out!
 
 Download the kubectl binary for `${K8S_VERSION}` ({{page.version}}) and make it available by editing your PATH environment variable.
-([OS X/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/amd64/kubectl))
-([OS X/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/386/kubectl))
-([linux/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/amd64/kubectl))
-([linux/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/386/kubectl))
-([linux/arm](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/arm/kubectl))
+([OS X/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/amd64/kubectl))
+([OS X/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/386/kubectl))
+([linux/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl))
+([linux/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/386/kubectl))
+([linux/arm](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/arm/kubectl))
 
 For example, OS X:
 

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -199,16 +199,16 @@ sudo docker run \
 At this point, you should have a functioning 1-node cluster.  Let's test it out!
 
 Download the kubectl binary for `${K8S_VERSION}` ({{page.version}}) and make it available by editing your PATH environment variable.
-([OS X/amd64](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/amd64/kubectl))
-([OS X/386](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/386/kubectl))
-([linux/amd64](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/amd64/kubectl))
-([linux/386](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/386/kubectl))
-([linux/arm](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/arm/kubectl))
+([OS X/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/amd64/kubectl))
+([OS X/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/386/kubectl))
+([linux/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/amd64/kubectl))
+([linux/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/386/kubectl))
+([linux/arm](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/arm/kubectl))
 
 For example, OS X:
 
 ```shell
-$ wget http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/darwin/amd64/kubectl
+$ wget https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/darwin/amd64/kubectl
 $ chmod 755 kubectl
 $ PATH=$PATH:`pwd`
 ```
@@ -216,7 +216,7 @@ $ PATH=$PATH:`pwd`
 Linux:
 
 ```shell
-$ wget http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
+$ wget https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
 $ chmod 755 kubectl
 $ PATH=$PATH:`pwd`
 ```

--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -26,7 +26,7 @@ if ( ! ps -ef | grep "/usr/bin/docker" | grep -v 'grep' &> /dev/null ); then
 fi
 
 # Make sure k8s version env is properly set
-K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.7"}
+K8S_VERSION=${K8S_VERSION:-"1.2.0"}
 ETCD_VERSION=${ETCD_VERSION:-"2.2.1"}
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -26,7 +26,7 @@ if ( ! ps -ef | grep "/usr/bin/docker" | grep -v 'grep' &> /dev/null  ); then
 fi
 
 # Make sure k8s version env is properly set
-K8S_VERSION=${K8S_VERSION:-"1.2.0-alpha.7"}
+K8S_VERSION=${K8S_VERSION:-"1.2.0"}
 FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.5"}
 FLANNEL_IFACE=${FLANNEL_IFACE:-"eth0"}
 FLANNEL_IPMASQ=${FLANNEL_IPMASQ:-"true"}

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -53,16 +53,16 @@ At this point you should have a running Kubernetes cluster.  You can test this
 by downloading the kubectl binary for `${K8S_VERSION}` (look at the URL in the
 following links) and make it available by editing your PATH environment
 variable.
-([OS X/amd64](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/amd64/kubectl))
-([OS X/386](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/386/kubectl))
-([linux/amd64](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/amd64/kubectl))
-([linux/386](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/386/kubectl))
-([linux/arm](http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/arm/kubectl))
+([OS X/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/amd64/kubectl))
+([OS X/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/386/kubectl))
+([linux/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/amd64/kubectl))
+([linux/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/386/kubectl))
+([linux/arm](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/arm/kubectl))
 
 For example, OS X:
 
 ```shell
-$ wget http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/darwin/amd64/kubectl
+$ wget https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/darwin/amd64/kubectl
 $ chmod 755 kubectl
 $ PATH=$PATH:`pwd`
 ```
@@ -70,7 +70,7 @@ $ PATH=$PATH:`pwd`
 Linux:
 
 ```shell
-$ wget http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
+$ wget https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
 $ chmod 755 kubectl
 $ PATH=$PATH:`pwd`
 ```

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -14,7 +14,7 @@ Here's a diagram of what the final result will look like:
 
 1. You need to have docker installed on one machine.
 2. Decide what Kubernetes version to use.  Set the `${K8S_VERSION}` variable to
-   a released version of Kubernetes >= "1.2.0-alpha.7"
+   a released version of Kubernetes >= "1.2.0"
 
 ### Run it
 
@@ -53,11 +53,11 @@ At this point you should have a running Kubernetes cluster.  You can test this
 by downloading the kubectl binary for `${K8S_VERSION}` (look at the URL in the
 following links) and make it available by editing your PATH environment
 variable.
-([OS X/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/amd64/kubectl))
-([OS X/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/darwin/386/kubectl))
-([linux/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/amd64/kubectl))
-([linux/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/386/kubectl))
-([linux/arm](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0-alpha.7/bin/linux/arm/kubectl))
+([OS X/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/amd64/kubectl))
+([OS X/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/386/kubectl))
+([linux/amd64](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl))
+([linux/386](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/386/kubectl))
+([linux/arm](https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/arm/kubectl))
 
 For example, OS X:
 

--- a/docs/getting-started-guides/ubuntu-calico.md
+++ b/docs/getting-started-guides/ubuntu-calico.md
@@ -77,8 +77,8 @@ We'll use the `kubelet` to bootstrap the Kubernetes master.
 1.  Download and install the `kubelet` and `kubectl` binaries:
 
     ```shell
-    sudo wget -N -P /usr/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubectl
-    sudo wget -N -P /usr/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubelet
+    sudo wget -N -P /usr/bin https://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubectl
+    sudo wget -N -P /usr/bin https://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubelet
     sudo chmod +x /usr/bin/kubelet /usr/bin/kubectl
     ```
 
@@ -354,7 +354,7 @@ On your compute nodes, it is important that you install Calico before Kubernetes
 1.  Download and Install the kubelet binary:
 
     ```shell
-    sudo wget -N -P /usr/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubelet
+    sudo wget -N -P /usr/bin https://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubelet
     sudo chmod +x /usr/bin/kubelet
     ```
 
@@ -389,7 +389,7 @@ To administer your cluster from a separate host (e.g your laptop), you will need
 1. Download the kubectl binary.
 
    ```shell
-   sudo wget -N -P /usr/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubectl
+   sudo wget -N -P /usr/bin https://storage.googleapis.com/kubernetes-release/release/v1.1.4/bin/linux/amd64/kubectl
    sudo chmod +x /usr/bin/kubectl
    ```
 


### PR DESCRIPTION
A user pointed out that downloading binaries over http is not the best
idea.

Also replace 1.2.0-alpha.7 with 1.2.0, now that 1.2.0 is released