### PR TITLE
Ingress TLS docs

### DIFF
--- a/docs/user-guide/ingress.md
+++ b/docs/user-guide/ingress.md
@@ -28,7 +28,7 @@ Typically, services and pods have IPs only routable by the cluster network. All 
 An Ingress is a collection of rules that allow inbound connections to reach the cluster services.
 
 ```
-internet
+    internet
         |
    [ Ingress ]
    --|-----|--


### PR DESCRIPTION
Don't checking till https://github.com/kubernetes/contrib/pull/579 goes in because I want to link to the BETA_LIMITATIONS doc there