### PR TITLE
Update persistent volume docs to mention dynamic provisioning

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -13,14 +13,11 @@ See [Persistent Storage design document](https://github.com/kubernetes/kubernete
 
 ## Provisioning
 
-A Persistent Volume (PV) in Kubernetes represents a real piece of underlying storage capacity in the infrastructure.  Cluster administrators
-must first create storage (create their Google Compute Engine (GCE) disks, export their NFS shares, etc.) in order for Kubernetes to mount it.
+A Persistent Volume (PV) in Kubernetes represents a real piece of underlying storage capacity in the infrastructure.  Cluster administrators must first create storage (create their Google Compute Engine (GCE) disks, export their NFS shares, etc.) in order for Kubernetes to mount it.
 
-PVs are intended for "network volumes" like GCE Persistent Disks, NFS shares, and AWS ElasticBlockStore volumes.  `HostPath` was included
-for ease of development and testing.  You'll create a local `HostPath` for this example.
+PVs are intended for "network volumes" like GCE Persistent Disks, NFS shares, and AWS ElasticBlockStore volumes.  `HostPath` was included for ease of development and testing.  In this guide, you'll create a local `HostPath` for this example.
 
-> IMPORTANT! For `HostPath` to work, you will need to run a single node cluster.  Kubernetes does not
-support local storage on the host at this time.  There is no guarantee your pod ends up on the correct node where the `HostPath` resides.
+> IMPORTANT! For `HostPath` to work, you will need to run a single node cluster.  With more than one node, there is no guarantee your pod ends up on the correct node where the `HostPath` resides.
 
 ```shell
 # This will be nginx's webroot


### PR DESCRIPTION
This PR updates update persistent volume docs to:
* Mention dynamic provisioning
* Fix broken links
* Change some wording to be slightly clearer.
* Move `Types of Persistent Volumes` to a be sub-section of `PersistentVolume`

CC @kubernetes/goog-cluster @kubernetes/sig-storage 