### PR TITLE
Now that kubectl run creates a deployment by default, expose here should expose the deployment previously created.

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -113,7 +113,7 @@ Now run `docker ps` you should see nginx running.  You may need to wait a few mi
 ### Expose it as a service
 
 ```shell
-kubectl expose rc nginx --port=80
+kubectl expose deployment nginx --port=80
 ```
 
 Run the following command to obtain the IP of this service we just created. There are two IPs, the first one is internal (CLUSTER_IP), and the second one is the external load-balanced IP (if a LoadBalancer is configured)


### PR DESCRIPTION
cc @bgrant0607 @janetkuo 