### PR TITLE
Update managing deployments user guide

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -242,7 +242,7 @@ toc:
     path: /docs/user-guide/managing-deployments/
   - title: Deploying Applications
     path: /docs/user-guide/deploying-applications/
-  - title: Rolling Updating Applications with kubectl
+  - title: Rolling Update
     path: /docs/user-guide/rolling-updates/
   - title: Launching, Exposing, and Killing Applications
     path: /docs/user-guide/quick-start/

--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -238,11 +238,11 @@ toc:
   section:
   - title: "Managing Applications: Prerequisites"
     path: /docs/user-guide/prereqs/
-  - title: Managing Deployments
+  - title: Managing Resources
     path: /docs/user-guide/managing-deployments/
   - title: Deploying Applications
     path: /docs/user-guide/deploying-applications/
-  - title: Updating Applications with Rolling Updates
+  - title: Rolling Updating Applications with kubectl
     path: /docs/user-guide/rolling-updates/
   - title: Launching, Exposing, and Killing Applications
     path: /docs/user-guide/quick-start/

--- a/docs/user-guide/managing-deployments.md
+++ b/docs/user-guide/managing-deployments.md
@@ -2,65 +2,38 @@
 ---
 You've deployed your application and exposed it via a service. Now what? Kubernetes provides a number of tools to help you manage your application deployment, including scaling and updating. Among the features we'll discuss in more depth are [configuration files](/docs/user-guide/configuring-containers/#configuration-in-kubernetes) and [labels](/docs/user-guide/deploying-applications/#labels).
 
+You can find all the files for this example [in our docs
+repo here](https://github.com/kubernetes/kubernetes.github.io/tree/{{page.docsbranch}}/docs/user-guide/).
+
 * TOC
 {:toc}
 
 ## Organizing resource configurations
 
-Many applications require multiple resources to be created, such as a Replication Controller and a Service. Management of multiple resources can be simplified by grouping them together in the same file (separated by `---` in YAML). For example:
+Many applications require multiple resources to be created, such as a Deployment and a Service. Management of multiple resources can be simplified by grouping them together in the same file (separated by `---` in YAML). For example:
 
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: my-nginx-svc
-  labels:
-    app: nginx
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 80
-  selector:
-    app: nginx
----
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: my-nginx
-spec:
-  replicas: 2
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx
-        ports:
-        - containerPort: 80
-```
+{% include code.html language="yaml" file="nginx-app.yaml" ghlink="/docs/user-guide/nginx-app.yaml" %}
 
 Multiple resources can be created the same way as a single resource:
 
 ```shell
-$ kubectl create -f ./nginx-app.yaml
-services/my-nginx-svc
-replicationcontrollers/my-nginx
+$ kubectl create -f docs/user-guide/nginx-app.yaml
+service "my-nginx-svc" created
+deployment "my-nginx" created
 ```
 
-The resources will be created in the order they appear in the file. Therefore, it's best to specify the service first, since that will ensure the scheduler can spread the pods associated with the service as they are created by the replication controller(s).
+The resources will be created in the order they appear in the file. Therefore, it's best to specify the service first, since that will ensure the scheduler can spread the pods associated with the service as they are created by the controller(s), such as Deployment.
 
 `kubectl create` also accepts multiple `-f` arguments:
 
 ```shell
-$ kubectl create -f ./nginx-svc.yaml -f ./nginx-rc.yaml
+$ kubectl create -f docs/user-guide/nginx/nginx-svc.yaml -f docs/user-guide/nginx/nginx-deployment.yaml
 ```
 
 And a directory can be specified rather than or in addition to individual files:
 
 ```shell
-$ kubectl create -f ./nginx/
+$ kubectl create -f docs/user-guide/nginx/
 ```
 
 `kubectl` will read any files with suffixes `.yaml`, `.yml`, or `.json`.
@@ -70,8 +43,8 @@ It is a recommended practice to put resources related to the same microservice o
 A URL can also be specified as a configuration source, which is handy for deploying directly from configuration files checked into github:
 
 ```shell
-$ kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/docs/user-guide/pod.yaml
-pods/nginx
+$ kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/docs/user-guide/nginx-deployment.yaml
+deployment "nginx-deployment" created
 ```
 
 ## Bulk operations in kubectl
@@ -79,34 +52,37 @@ pods/nginx
 Resource creation isn't the only operation that `kubectl` can perform in bulk. It can also extract resource names from configuration files in order to perform other operations, in particular to delete the same resources you created:
 
 ```shell
-$ kubectl delete -f ./nginx/
-replicationcontrollers "my-nginx" deleted
-services "my-nginx-svc" deleted
+$ kubectl delete -f docs/user-guide/nginx/
+deployment "my-nginx" deleted
+service "my-nginx-svc" deleted
 ```
 
 In the case of just two resources, it's also easy to specify both on the command line using the resource/name syntax:
 
 ```shell
-$ kubectl delete replicationcontrollers/my-nginx services/my-nginx-svc
+$ kubectl delete deployments/my-nginx services/my-nginx-svc
 ```
 
-For larger numbers of resources, one can use labels to filter resources. The selector is specified using `-l`:
+For larger numbers of resources, you'll find it easier to specify the selector (label query) specified using `-l` or `--selector`, to filter resources by their labels:
 
 ```shell
-$ kubectl delete all -lapp=nginx
-replicationcontrollers "my-nginx" deleted
-services "my-nginx-svc" deleted
+$ kubectl delete deployment,services -l app=nginx
+deployment "my-nginx" deleted
+service "my-nginx-svc" deleted
 ```
 
 Because `kubectl` outputs resource names in the same syntax it accepts, it's easy to chain operations using `$()` or `xargs`:
 
 ```shell
-$ kubectl get $(kubectl create -f ./nginx/ -o name | grep my-nginx)
-CONTROLLER   CONTAINER(S)   IMAGE(S)   SELECTOR    REPLICAS
-my-nginx     nginx          nginx      app=nginx   2
-NAME           LABELS      SELECTOR    IP(S)          PORT(S)
-my-nginx-svc   app=nginx   app=nginx   10.0.152.174   80/TCP
+$ kubectl get $(k create -f docs/user-guide/nginx/ -o name | grep service)
+NAME           CLUSTER-IP   EXTERNAL-IP   PORT(S)      AGE
+my-nginx-svc   10.0.0.208                 80/TCP       0s
 ```
+
+With the above commands, we first create resources under docs/user-guide/nginx/ and print the resources created with `-o name` output format 
+(print each resource as resource/name). Then we `grep` only the "service", and then print it with `kubectl get`. 
+
+If you're interested in learning more about `kubectl`, go ahead and read [kubectl Overview](/docs/user-guide/kubectl-overview). 
 
 ## Using labels effectively
 
@@ -191,29 +167,34 @@ The frontend service would span both sets of replicas by selecting the common su
 
 ## Updating labels
 
-Sometimes existing pods and other resources need to be relabeled before creating new resources. This can be done with `kubectl label`. For example:
+Sometimes existing pods and other resources need to be relabeled before creating new resources. This can be done with `kubectl label`. 
+For example, if you want to label all your nginx pods as frontend tier, simply run:
 
 ```shell
-$ kubectl label pods -lapp=nginx tier=fe
-pod "my-nginx-v4-9gw19" labeled
-pod "my-nginx-v4-hayza" labeled
-pod "my-nginx-v4-mde6m" labeled
-pod "my-nginx-v4-sh6m8" labeled
-pod "my-nginx-v4-wfof4" labeled
-$ kubectl get pods -lapp=nginx -Ltier
-NAME                READY     STATUS    RESTARTS   AGE       TIER
-my-nginx-v4-9gw19   1/1       Running   0          15m       fe
-my-nginx-v4-hayza   1/1       Running   0          14m       fe
-my-nginx-v4-mde6m   1/1       Running   0          18m       fe
-my-nginx-v4-sh6m8   1/1       Running   0          19m       fe
-my-nginx-v4-wfof4   1/1       Running   0          16m       fe
+$ kubectl label pods -l app=nginx tier=fe
+pod "my-nginx-2035384211-j5fhi" labeled
+pod "my-nginx-2035384211-u2c7e" labeled
+pod "my-nginx-2035384211-u3t6x" labeled
 ```
+
+This first filters all pods with the label "app=nginx", and then labels them with the "tier=fe". 
+To see the pods you just labeled, run: 
+
+```shell
+$ kubectl get pods -l app=nginx -L tier
+NAME                        READY     STATUS    RESTARTS   AGE       TIER
+my-nginx-2035384211-j5fhi   1/1       Running   0          23m       fe
+my-nginx-2035384211-u2c7e   1/1       Running   0          23m       fe
+my-nginx-2035384211-u3t6x   1/1       Running   0          23m       fe
+```
+
+This outputs all "app=nginx" pods, with an additional label column of pods' tier (specified with `-L` or `--label-columns`).
 
 For more information, please see [labels](/docs/user-guide/labels/) and [kubectl label](/docs/user-guide/kubectl/kubectl_label/) document.
 
 ## Updating annotations
 
-Sometimes you want to attach annotations to resources. Annotations are arbitrary non-identifying metadata for retrieval by API clients such as tools, libraries, etc. This can be done with `kubectl annotate`. For example:
+Sometimes you would want to attach annotations to resources. Annotations are arbitrary non-identifying metadata for retrieval by API clients such as tools, libraries, etc. This can be done with `kubectl annotate`. For example:
 
 ```shell
 $ kubectl annotate pods my-nginx-v4-9gw19 description='my frontend running nginx'
@@ -230,195 +211,118 @@ For more information, please see [annotations](/docs/user-guide/annotations/) an
 
 ## Scaling your application
 
-When load on your application grows or shrinks, it's easy to scale with `kubectl`. For instance, to increase the number of nginx replicas from 2 to 3, do:
+When load on your application grows or shrinks, it's easy to scale with `kubectl`. For instance, to decrease the number of nginx replicas from 3 to 1, do:
 
 ```shell
-$ kubectl scale rc my-nginx --replicas=3
+$ kubectl scale deployment/my-nginx --replicas=1
 replicationcontroller "my-nginx" scaled
-$ kubectl get pods -lapp=nginx
-NAME             READY     STATUS    RESTARTS   AGE
-my-nginx-1jgkf   1/1       Running   0          3m
-my-nginx-divi2   1/1       Running   0          1h
-my-nginx-o0ef1   1/1       Running   0          1h
 ```
 
-To have the system automatically choose the number of nginx replicas as needed, range from 1 to 3, do:
+Now you only have one pod managed by the deployment. 
+
+```shell
+$ kubectl get pods -l app=nginx
+NAME                        READY     STATUS    RESTARTS   AGE
+my-nginx-2035384211-j5fhi   1/1       Running   0          30m
+```
+
+To have the system automatically choose the number of nginx replicas as needed, ranging from 1 to 3, do:
 
 ```shell 
-$ kubectl autoscale rc my-nginx --min=1 --max=3
-replicationcontroller "my-nginx" autoscaled
-$ kubectl get pods -lapp=nginx
-NAME             READY     STATUS    RESTARTS   AGE
-my-nginx-1jgkf   1/1       Running   0          3m
-my-nginx-divi2   1/1       Running   0          3m
-$ kubectl get horizontalpodautoscaler 
-NAME      REFERENCE                           TARGET    CURRENT     MINPODS   MAXPODS   AGE
-nginx     ReplicationController/nginx/scale   80%       <waiting>   1         3         1m
+$ kubectl autoscale deployment/my-nginx --min=1 --max=3
+deployment "my-nginx" autoscaled
 ```
 
-For more information, please see [kubectl scale](/docs/user-guide/kubectl/kubectl_scale/), [kubectl autoscale](/docs/user-guide/kubectl/kubectl_autoscale/) and [horizontal pod autoscaler](/docs/user-guide/horizontal-pod-autoscaling/) document.
+Now your nginx replicas will be scaled up and down as needed, automatically. 
 
-## Updating your application without a service outage
+For more information, please see [kubectl scale](/docs/user-guide/kubectl/kubectl_scale/), [kubectl autoscale](/docs/user-guide/kubectl/kubectl_autoscale/) and [horizontal pod autoscaler](/docs/user-guide/horizontal-pod-autoscaler/) document.
 
-At some point, you'll eventually need to update your deployed application, typically by specifying a new image or image tag, as in the canary deployment scenario above. `kubectl` supports several update operations, each of which is applicable to different scenarios.
-
-To update a service without an outage, `kubectl` supports what is called ['rolling update'?](/docs/user-guide/kubectl/kubectl_rolling-update), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/simple-rolling-update.md) and the [example of rolling update](/docs/user-guide/update-demo/) for more information.
-
-Let's say you were running version 1.7.9 of nginx:
-
-```yaml
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: my-nginx
-spec:
-  replicas: 5
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.7.9
-        ports:
-        - containerPort: 80
-```
-
-To update to version 1.9.1, you can use [`kubectl rolling-update --image`](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/simple-rolling-update.md):
-
-```shell
-$ kubectl rolling-update my-nginx --image=nginx:1.9.1
-Created my-nginx-ccba8fbd8cc8160970f63f9a2696fc46
-```
-
-In another window, you can see that `kubectl` added a `deployment` label to the pods, whose value is a hash of the configuration, to distinguish the new pods from the old:
-
-```shell
-$ kubectl get pods -lapp=nginx -Ldeployment
-NAME                                              READY     STATUS    RESTARTS   AGE       DEPLOYMENT
-my-nginx-ccba8fbd8cc8160970f63f9a2696fc46-k156z   1/1       Running   0          1m        ccba8fbd8cc8160970f63f9a2696fc46
-my-nginx-ccba8fbd8cc8160970f63f9a2696fc46-v95yh   1/1       Running   0          35s       ccba8fbd8cc8160970f63f9a2696fc46
-my-nginx-divi2                                    1/1       Running   0          2h        2d1d7a8f682934a254002b56404b813e
-my-nginx-o0ef1                                    1/1       Running   0          2h        2d1d7a8f682934a254002b56404b813e
-my-nginx-q6all                                    1/1       Running   0          8m        2d1d7a8f682934a254002b56404b813e
-```
-
-`kubectl rolling-update` reports progress as it progresses:
-
-```shell
-Scaling up my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 from 0 to 3, scaling down my-nginx from 3 to 0 (keep 3 pods available, don't exceed 4 pods)
-Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 up to 1
-Scaling my-nginx down to 2
-Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 up to 2
-Scaling my-nginx down to 1
-Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 up to 3
-Scaling my-nginx down to 0
-Update succeeded. Deleting old controller: my-nginx
-Renaming my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 to my-nginx
-replicationcontroller "my-nginx" rolling updated
-```
-
-If you encounter a problem, you can stop the rolling update midway and revert to the previous version using `--rollback`:
-
-```shell
-$ kubectl rolling-update my-nginx --rollback
-Setting "my-nginx" replicas to 1
-Continuing update with existing controller my-nginx.
-Scaling up nginx from 1 to 1, scaling down my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 from 1 to 0 (keep 1 pods available, don't exceed 2 pods)
-Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 down to 0
-Update succeeded. Deleting my-nginx-ccba8fbd8cc8160970f63f9a2696fc46
-replicationcontroller "my-nginx" rolling updated
-```
-
-This is one example where the immutability of containers is a huge asset.
-
-If you need to update more than just the image (e.g., command arguments, environment variables), you can create a new replication controller, with a new name and distinguishing label value, such as:
-
-```yaml
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: my-nginx-v4
-spec:
-  replicas: 5
-  selector:
-    app: nginx
-    deployment: v4
-  template:
-    metadata:
-      labels:
-        app: nginx
-        deployment: v4
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.9.2
-        args: [“nginx”,”-T”]
-        ports:
-        - containerPort: 80
-```
-
-and roll it out:
-
-```shell
-$ kubectl rolling-update my-nginx -f ./nginx-rc.yaml
-Created my-nginx-v4
-Scaling up my-nginx-v4 from 0 to 5, scaling down my-nginx from 4 to 0 (keep 4 pods available, don't exceed 5 pods)
-Scaling my-nginx-v4 up to 1
-Scaling my-nginx down to 3
-Scaling my-nginx-v4 up to 2
-Scaling my-nginx down to 2
-Scaling my-nginx-v4 up to 3
-Scaling my-nginx down to 1
-Scaling my-nginx-v4 up to 4
-Scaling my-nginx down to 0
-Scaling my-nginx-v4 up to 5
-Update succeeded. Deleting old controller: my-nginx
-replicationcontroller "my-nginx-v4" rolling updated
-```
-
-You can also run the [update demo](/docs/user-guide/update-demo/) to see a visual representation of the rolling update process.
 
 ## In-place updates of resources
 
-Sometimes it's necessary to make narrow, non-disruptive updates to resources you've created. For instance, you might want to update the container's image of your pod.
+Sometimes it's necessary to make narrow, non-disruptive updates to resources you've created. 
+
+### kubectl apply
+
+The most disciplined way to update resources is [`kubectl apply`](/docs/user-guide/kubectl/kubectl_apply/). If you maintain a set of configuration files in source control, 
+where they can be maintained and versioned along with the code for the resources they configure. Then, when you're ready to push 
+configuration changes to the cluster, you can run `kubectl apply`.
+
+This command will compare the version of the configuration that you're pushing with the previous version and apply the changes you've made, without overwriting any automated changes to properties you haven't specified.
+
+```shell
+$ kubectl apply -f docs/user-guide/nginx/nginx-deployment.yaml
+deployment "my-nginx" configured
+```
+
+Note that `kubectl apply` attaches an annotation to the resource in order to determine the changes to the configuration since the previous invocation. When it's invoked, `kubectl apply` does a three-way diff between the previous configuration, the provided input and the current configuration of the resource, in order to determine how to modify the resource.
+
+Currently, resources are created without this annotation, so the first invocation of `kubectl apply` will fall back to a two-way diff between the provided input and the current configuration of the resource. During this first invocation, it cannot detect the deletion of properties set when the resource was created. For this reason, it will not remove them.
+
+All subsequent calls to `kubectl apply`, and other commands that modify the configuration, such as `kubectl replace` and `kubectl edit`, will update the annotation, allowing subsequent calls to `kubectl apply` to detect and perform deletions using a three-way diff.
+
+### kubectl edit
+
+Alternatively, you may also update resources with `kubectl edit`:
+
+```shell
+$ kubectl edit deployment/my-nginx
+```
+
+This is equivalent to first `get` the resource, edit it in text editor, and then `apply` the resource with the updated version:
+
+```shell
+$ kubectl get deployment my-nginx -o yaml > /tmp/nginx.yaml
+$ vi /tmp/nginx.yaml
+# do some edit, and then save the file
+$ kubectl apply -f /tmp/nginx.yaml
+deployment "my-nginx" configured
+$ rm /tmp/nginx.yaml
+```
+
+This allows you to do more significant changes more easily. Note that you can specify the editor with your `EDITOR` or `KUBE_EDITOR` environment variables.
+
+For more information, please see [kubectl edit](/docs/user-guide/kubectl/kubectl_edit/) document.
 
 ### kubectl patch
 
-Suppose you want to fix a typo of the container's image of a pod. One way to do that is with `kubectl patch`:
+Suppose you want to fix a typo of the container's image of a Deployment. One way to do that is with `kubectl patch`:
 
 ```shell
-# Suppose you have a pod with a container named "nginx" and its image "nignx" (typo), 
+# Suppose you have a Deployment with a container named "nginx" and its image "nignx" (typo), 
 # use container name "nginx" as a key to update the image from "nignx" (typo) to "nginx"
-$ kubectl get pod my-nginx-1jgkf -o yaml
+$ kubectl get deployment my-nginx -o yaml
 ```
 
 ```yaml
-apiversion: v1
-kind: pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 ...
 spec:
-  containers:
-  -image: nignx
-   name: nginx
+  template:
+    spec:
+      containers:
+      - image: nignx
+        name: nginx
 ...
 ```
 
 ```shell
-$ kubectl patch pod my-nginx-1jgkf -p '{"spec":{"containers":[{"name":"nginx","image":"nginx"}]}}'
-"my-nginx-1jgkf" patched
+$ kubectl patch deployment my-nginx -p'{"spec":{"template":{"spec":{"containers":[{"name":"nginx","image":"nginx"}]}}}}'
+"my-nginx" patched
 $ kubectl get pod my-nginx-1jgkf -o yaml
 ```
 
 ```yaml
-apiversion: v1
-kind: pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 ...
 spec:
-  containers:
-  -image: nginx
-   name: nginx
+  template:
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
 ...
 ```
 
@@ -428,58 +332,37 @@ The system ensures that you don’t clobber changes made by other users or compo
 
 For more information, please see [kubectl patch](/docs/user-guide/kubectl/kubectl_patch/) document.
 
-### kubectl edit
-
-Alternatively, you may also update resources with `kubectl edit`:
-
-```shell
-$ kubectl edit pod my-nginx-1jgkf
-```
-
-This is equivalent to first `get` the resource, edit it in text editor, and then `replace` the resource with the updated version:
-
-```shell
-$ kubectl get pod my-nginx-1jgkf -o yaml > /tmp/nginx.yaml
-$ vi /tmp/nginx.yaml
-# do some edit, and then save the file
-$ kubectl replace -f /tmp/nginx.yaml
-pod "my-nginx-1jgkf" replaced
-$ rm /tmp/nginx.yaml
-```
-
-This allows you to do more significant changes more easily. Note that you can specify the editor with your `EDITOR` or `KUBE_EDITOR` environment variables.
-
-For more information, please see [kubectl edit](/docs/user-guide/kubectl/kubectl_edit/) document.
-
-## Using configuration files
-
-A more disciplined alternative to patch and edit is `kubectl apply`.
-
-With apply, you can keep a set of configuration files in source control, where they can be maintained and versioned along with the code for the resources they configure. Then, when you're ready to push configuration changes to the cluster, you can run `kubectl apply`.
-
-This command will compare the version of the configuration that you're pushing with the previous version and apply the changes you've made, without overwriting any automated changes to properties you haven't specified.
-
-```shell
-$ kubectl apply -f ./nginx-rc.yaml
-replicationcontroller "my-nginx-v4" configured
-```
-
-As shown in the example above, the configuration used with `kubectl apply` is the same as the one used with `kubectl replace`. However, instead of deleting the existing resource and replacing it with a new one, `kubectl apply` modifies the configuration of the existing resource.
-
-Note that `kubectl apply` attaches an annotation to the resource in order to determine the changes to the configuration since the previous invocation. When it's invoked, `kubectl apply` does a three-way diff between the previous configuration, the provided input and the current configuration of the resource, in order to determine how to modify the resource.
-
-Currently, resources are created without this annotation, so the first invocation of `kubectl apply` will fall back to a two-way diff between the provided input and the current configuration of the resource. During this first invocation, it cannot detect the deletion of properties set when the resource was created. For this reason, it will not remove them.
-
-All subsequent calls to `kubectl apply`, and other commands that modify the configuration, such as `kubectl replace` and `kubectl edit`, will update the annotation, allowing subsequent calls to `kubectl apply` to detect and perform deletions using a three-way diff.
-
 ## Disruptive updates
 
 In some cases, you may need to update resource fields that cannot be updated once initialized, or you may just want to make a recursive change immediately, such as to fix broken pods created by a replication controller. To change such fields, use `replace --force`, which deletes and re-creates the resource. In this case, you can simply modify your original configuration file:
 
 ```shell
-$ kubectl replace -f ./nginx-rc.yaml --force
-replicationcontrollers "my-nginx-v4" replaced
+$ kubectl replace -f docs/user-guide/nginx/nginx-deployment.yaml --force
+deployment "my-nginx" deleted
+deployment "my-nginx" replaced
 ```
+
+## Updating your application without a service outage
+
+At some point, you'll eventually need to update your deployed application, typically by specifying a new image or image tag, as in the canary deployment scenario above. `kubectl` supports several update operations, each of which is applicable to different scenarios.
+
+We'll guide you through how to create and update applications with Deployments. If your deployed application is managed by Replication Controllers, 
+you should read [how to use `kubectl rolling-update`](/docs/user-guide/rolling-updates/) instead. 
+
+Let's say you were running version 1.7.9 of nginx:
+
+```shell
+$ kubectl run my-nginx --image=nginx:1.7.9 --replicas=3
+deployment "my-nginx" created
+```
+
+To update to version 1.9.1, simply change `.spec.template.spec.containers[0].image` from `nginx:1.7.9` to `nginx:1.9.1`, with the kubectl commands we learned above. 
+
+```shell
+$ kubectl edit deployment/my-nginx
+```
+
+That's it! The Deployment will declaratively update the deployed nginx application progressively behind the scene. It ensures that only a certain number of old replicas may be down while they are being updated, and only a certain number of new replicas may be created above the desired number of pods. To learn more details about it, visit [Deployment page](docs/user-guide/deployments/).
 
 ## What's next?
 

--- a/docs/user-guide/nginx-app.yaml
+++ b/docs/user-guide/nginx-app.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx-svc
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/docs/user-guide/nginx/nginx-deployment.yaml
+++ b/docs/user-guide/nginx/nginx-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/docs/user-guide/nginx/nginx-svc.yaml
+++ b/docs/user-guide/nginx/nginx-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx-svc
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: nginx

--- a/docs/user-guide/rolling-updates.md
+++ b/docs/user-guide/rolling-updates.md
@@ -6,6 +6,12 @@
 
 ## Overview
 
+To update a service without an outage, `kubectl` supports what is called ['rolling update'](/docs/user-guide/kubectl/kubectl_rolling-update), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/simple-rolling-update.md) and the [example of rolling update](/docs/user-guide/update-demo/) for more information.
+
+Note that `kubectl rolling-update` only supports Replication Controllers. However, if you deploy applications with Replication Controllers, 
+consider switching them to [Deployments](/docs/user-guide/deployments/). A Deployments is a higher-level controller that automates rolling updates 
+of applications declaratively, and therefore is recommended. If you still want to keep your Replication Controllers and use `kubectl rolling-update`, keep reading:
+
 A rolling update applies changes to the configuration of pods being managed by
 a replication controller. The changes can be passed as a new replication
 controller configuration file; or, if only updating the image, a new container
@@ -114,6 +120,124 @@ Optional fields are:
 
 Additional information about the `kubectl rolling-update` command is available
 from the [`kubectl` reference](/docs/user-guide/kubectl/kubectl_rolling-update/).
+
+## Walkthrough
+
+Let's say you were running version 1.7.9 of nginx:
+
+```yaml
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: my-nginx
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+```
+
+To update to version 1.9.1, you can use [`kubectl rolling-update --image`](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/simple-rolling-update.md) to specify the new image:
+
+```shell
+$ kubectl rolling-update my-nginx --image=nginx:1.9.1
+Created my-nginx-ccba8fbd8cc8160970f63f9a2696fc46
+```
+
+In another window, you can see that `kubectl` added a `deployment` label to the pods, whose value is a hash of the configuration, to distinguish the new pods from the old:
+
+```shell
+$ kubectl get pods -l app=nginx -L deployment
+NAME                                              READY     STATUS    RESTARTS   AGE       DEPLOYMENT
+my-nginx-ccba8fbd8cc8160970f63f9a2696fc46-k156z   1/1       Running   0          1m        ccba8fbd8cc8160970f63f9a2696fc46
+my-nginx-ccba8fbd8cc8160970f63f9a2696fc46-v95yh   1/1       Running   0          35s       ccba8fbd8cc8160970f63f9a2696fc46
+my-nginx-divi2                                    1/1       Running   0          2h        2d1d7a8f682934a254002b56404b813e
+my-nginx-o0ef1                                    1/1       Running   0          2h        2d1d7a8f682934a254002b56404b813e
+my-nginx-q6all                                    1/1       Running   0          8m        2d1d7a8f682934a254002b56404b813e
+```
+
+`kubectl rolling-update` reports progress as it progresses:
+
+```
+Scaling up my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 from 0 to 3, scaling down my-nginx from 3 to 0 (keep 3 pods available, don't exceed 4 pods)
+Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 up to 1
+Scaling my-nginx down to 2
+Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 up to 2
+Scaling my-nginx down to 1
+Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 up to 3
+Scaling my-nginx down to 0
+Update succeeded. Deleting old controller: my-nginx
+Renaming my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 to my-nginx
+replicationcontroller "my-nginx" rolling updated
+```
+
+If you encounter a problem, you can stop the rolling update midway and revert to the previous version using `--rollback`:
+
+```shell
+$ kubectl rolling-update my-nginx --rollback
+Setting "my-nginx" replicas to 1
+Continuing update with existing controller my-nginx.
+Scaling up nginx from 1 to 1, scaling down my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 from 1 to 0 (keep 1 pods available, don't exceed 2 pods)
+Scaling my-nginx-ccba8fbd8cc8160970f63f9a2696fc46 down to 0
+Update succeeded. Deleting my-nginx-ccba8fbd8cc8160970f63f9a2696fc46
+replicationcontroller "my-nginx" rolling updated
+```
+
+This is one example where the immutability of containers is a huge asset.
+
+If you need to update more than just the image (e.g., command arguments, environment variables), you can create a new replication controller, with a new name and distinguishing label value, such as:
+
+```yaml
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: my-nginx-v4
+spec:
+  replicas: 5
+  selector:
+    app: nginx
+    deployment: v4
+  template:
+    metadata:
+      labels:
+        app: nginx
+        deployment: v4
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.9.2
+        args: [“nginx”,”-T”]
+        ports:
+        - containerPort: 80
+```
+
+and roll it out:
+
+```shell
+$ kubectl rolling-update my-nginx -f ./nginx-rc.yaml
+Created my-nginx-v4
+Scaling up my-nginx-v4 from 0 to 5, scaling down my-nginx from 4 to 0 (keep 4 pods available, don't exceed 5 pods)
+Scaling my-nginx-v4 up to 1
+Scaling my-nginx down to 3
+Scaling my-nginx-v4 up to 2
+Scaling my-nginx down to 2
+Scaling my-nginx-v4 up to 3
+Scaling my-nginx down to 1
+Scaling my-nginx-v4 up to 4
+Scaling my-nginx down to 0
+Scaling my-nginx-v4 up to 5
+Update succeeded. Deleting old controller: my-nginx
+replicationcontroller "my-nginx-v4" rolling updated
+```
+
+You can also run the [update demo](/docs/user-guide/update-demo/) to see a visual representation of the rolling update process.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Update "managing deployments" guide (docs/user-guide/managing-deployments.md) by:

1. Replace all references to ReplicationControllers with Deployments. 
2. Move `kubectl rolling-update` section to docs/user-guide/rolling-updates.md. 
3. Re-arrange the order of different flavors of updates (apply -> edit -> patch -> replace)
4. Update kubectl outputs. Fix broken links. 

@kubernetes/docs @kubernetes/examples 