### PR TITLE
Change the title of rkt page to say rkt, not rat.

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -81,7 +81,7 @@ toc:
         path: /docs/getting-started-guides/fedora/fedora-calico/
       - title: rkt
         section:
-        - title: Running Kubernetes on rat
+        - title: Running Kubernetes on rkt
           path: /docs/getting-started-guides/rkt/
         - title: Notes on Different UX with rkt Container Runtime
           path: /docs/getting-started-guides/rkt/notes/


### PR DESCRIPTION
Pretty sure there is no such thing as `rat` yet.

cc @dchen1107 @vishh 