### PR TITLE
Replace HA docs podmaster with --leader-elect flag 

### DIFF
--- a/docs/admin/high-availability.md
+++ b/docs/admin/high-availability.md
@@ -7,7 +7,7 @@ This document describes how to build a high-availability (HA) Kubernetes cluster
 Users who merely want to experiment with Kubernetes are encouraged to use configurations that are simpler to set up such as
 the simple [Docker based single node cluster instructions](/docs/getting-started-guides/docker),
 or try [Google Container Engine](https://cloud.google.com/container-engine/) for hosted Kubernetes.
-
+le
 Also, at this time high availability support for Kubernetes is not continuously tested in our end-to-end (e2e) testing.  We will
 be working to add this continuous testing, but for now the single-node master installations are more heavily tested.
 
@@ -182,8 +182,8 @@ them to talk to the external load balancer's IP address.
 
 So far we have set up state storage, and we have set up the API server, but we haven't run anything that actually modifies
 cluster state, such as the controller manager and scheduler.  To achieve this reliably, we only want to have one actor modifying state at a time, but we want replicated
-instances of these actors, in case a machine dies.  To achieve this, we are going to use a lease-lock in etcd to perform
-master election.  We will use the `--leader-elect` flag for each scheduler and controller-manager, using etcd locks this will ensure that only 1 instance of the scheduler and controller-manager are running at once.
+instances of these actors, in case a machine dies.  To achieve this, we are going to use a lease-lock in the API to perform
+master election.  We will use the `--leader-elect` flag for each scheduler and controller-manager, using a lease in the API will ensure that only 1 instance of the scheduler and controller-manager are running at once.
 
 ### Installing configuration files
 

--- a/docs/admin/high-availability.md
+++ b/docs/admin/high-availability.md
@@ -7,7 +7,7 @@ This document describes how to build a high-availability (HA) Kubernetes cluster
 Users who merely want to experiment with Kubernetes are encouraged to use configurations that are simpler to set up such as
 the simple [Docker based single node cluster instructions](/docs/getting-started-guides/docker),
 or try [Google Container Engine](https://cloud.google.com/container-engine/) for hosted Kubernetes.
-le
+
 Also, at this time high availability support for Kubernetes is not continuously tested in our end-to-end (e2e) testing.  We will
 be working to add this continuous testing, but for now the single-node master installations are more heavily tested.
 

--- a/docs/admin/high-availability/kube-controller-manager.yaml
+++ b/docs/admin/high-availability/kube-controller-manager.yaml
@@ -9,7 +9,7 @@ spec:
     - -c
     - /usr/local/bin/kube-controller-manager --master=127.0.0.1:8080 --cluster-name=e2e-test-bburns
       --cluster-cidr=10.245.0.0/16 --allocate-node-cidrs=true --cloud-provider=gce  --service-account-private-key-file=/srv/kubernetes/server.key
-      --v=2 1>>/var/log/kube-controller-manager.log 2>&1
+      --v=2 --leader-elect=true 1>>/var/log/kube-controller-manager.log 2>&1
     image: gcr.io/google_containers/kube-controller-manager:fda24638d51a48baa13c35337fcd4793
     livenessProbe:
       httpGet:

--- a/docs/admin/high-availability/kube-scheduler.yaml
+++ b/docs/admin/high-availability/kube-scheduler.yaml
@@ -10,7 +10,7 @@ spec:
     command:
     - /bin/sh
     - -c
-    - /usr/local/bin/kube-scheduler --master=127.0.0.1:8080 --v=2 1>>/var/log/kube-scheduler.log
+    - /usr/local/bin/kube-scheduler --master=127.0.0.1:8080 --v=2 --leader-elect=true 1>>/var/log/kube-scheduler.log
       2>&1
     livenessProbe:
       httpGet:


### PR DESCRIPTION
The current HA docs still tell you to use a podmaster, they have a reference to the fact that this method is deprecated but they point to https://github.com/kubernetes/kubernetes/pull/16830. 

As I understand it (and from my experience) the new `--leader-elect` flag is the most straight forward to get HA set up. So I think this is what we want.