### PR TITLE
Corrected references to version of the default k8s

### DIFF
--- a/docs/getting-started-guides/ubuntu.md
+++ b/docs/getting-started-guides/ubuntu.md
@@ -35,7 +35,7 @@ Ubuntu 15 which uses systemd instead of upstart.
 Clone the kubernetes github repo locally
 
 ```shell
-$ git clone https://github.com/kubernetes/kubernetes.git
+$ git clone --depth 1 https://github.com/kubernetes/kubernetes.git
 ```
 
 #### Configure and start the Kubernetes cluster

--- a/docs/getting-started-guides/ubuntu.md
+++ b/docs/getting-started-guides/ubuntu.md
@@ -24,7 +24,7 @@ use a CNI plugin instead.
 Internet to download the necessary files, while worker nodes do not.
 3. These guide is tested OK on Ubuntu 14.04 LTS 64bit server, but it can not work with
 Ubuntu 15 which uses systemd instead of upstart.
-4. Dependencies of this guide: etcd-2.2.1, flannel-0.5.5, k8s-1.1.8, may work with higher versions.
+4. Dependencies of this guide: etcd-2.2.1, flannel-0.5.5, k8s-1.2.0, may work with higher versions.
 5. All the remote servers can be ssh logged in without a password by using key authentication.
 
 
@@ -41,12 +41,12 @@ $ git clone https://github.com/kubernetes/kubernetes.git
 #### Configure and start the Kubernetes cluster
 
 The startup process will first download all the required binaries automatically.
-By default etcd version is 2.2.1, flannel version is 0.5.5 and k8s version is 1.1.8.
+By default etcd version is 2.2.1, flannel version is 0.5.5 and k8s version is 1.2.0.
 You can customize your etcd version, flannel version, k8s version by changing corresponding variables
 `ETCD_VERSION` , `FLANNEL_VERSION` and `KUBE_VERSION` like following.
 
 ```shell
-$ export KUBE_VERSION=1.1.8
+$ export KUBE_VERSION=1.2.0
 $ export FLANNEL_VERSION=0.5.0
 $ export ETCD_VERSION=2.2.0
 ```


### PR DESCRIPTION
Noticed while working through the Ubuntu-based installation.