### PR TITLE
fix lack of key command when start flanneld

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -114,6 +114,7 @@ sudo docker -H unix:///var/run/docker-bootstrap.sock run -d \
     --privileged \
     -v /dev/net:/dev/net \
     quay.io/coreos/flannel:${FLANNEL_VERSION} \
+    /opt/bin/flanneld \
         --ip-masq=${FLANNEL_IPMASQ} \
         --iface=${FLANNEL_IFACE}
 ```


### PR DESCRIPTION
Little difference between script [master.sh](https://github.com/kubernetes/kubernetes/blob/master/docs%2Fgetting-started-guides%2Fdocker-multinode%2Fmaster.sh#L158) and [document](http://kubernetes.io/docs/getting-started-guides/docker-multinode/master/#starting-the-kubernetes-master)