### PR TITLE
latest kubernetes requires golang 1.4+

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -23,7 +23,7 @@ You need an [etcd](https://github.com/coreos/etcd/releases) in your path, please
 
 #### go
 
-You need [go](https://golang.org/doc/install) at least 1.3+ in your path, please make sure it is installed and in your ``$PATH``.
+You need [go](https://golang.org/doc/install) at least 1.4+ in your path, please make sure it is installed and in your ``$PATH``.
 
 ### Starting the cluster
 


### PR DESCRIPTION
Latest kubernetes requires golang 1.4+ as shown below : 

```mykub:~/kubernetes hack/local-up-cluster.sh
Detected go version: go version go1.3.3 linux/amd64.Kubernetes requires go version 1.4 or greater.Please install Go version 1.4 or later.
```