### PR TITLE
Fix deployDNS.md.

### DIFF
--- a/docs/getting-started-guides/docker-multinode/deployDNS.md
+++ b/docs/getting-started-guides/docker-multinode/deployDNS.md
@@ -26,7 +26,7 @@ $ sed -e "s/{{ pillar\['dns_replicas'\] }}/${DNS_REPLICAS}/g;s/{{ pillar\['dns_d
 
 # If the kube-system namespace isn't already created, create it
 $ kubectl get ns
-$ kubectl create -f ./kube-system.yaml
+$ kubectl create namespace kube-system
 
 $ kubectl create -f ./skydns.yaml{% endraw %}
 ```


### PR DESCRIPTION
There is no mention of where to find kube-system.yaml, and it's not
necessary with kubectl 1.2. You can just create the namespace
directly.