### PR TITLE
Fix docker options setting in CentOS

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -176,7 +176,7 @@ start_k8s(){
             ;;
         centos)
             DOCKER_CONF="/etc/sysconfig/docker"
-            echo "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | tee -a ${DOCKER_CONF}
+            sed -i "/^OPTIONS=/ s|\( --mtu=.*\)\?'$| --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}'|" ${DOCKER_CONF}
             if ! command_exists ifconfig; then
                 yum -y -q install net-tools
             fi

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -149,7 +149,7 @@ start_k8s() {
     case "${lsb_dist}" in
         centos)
             DOCKER_CONF="/etc/sysconfig/docker"
-            echo "OPTIONS=\"\$OPTIONS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | tee -a ${DOCKER_CONF}
+            sed -i "/^OPTIONS=/ s|\( --mtu=.*\)\?'$| --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}'|" ${DOCKER_CONF}
             if ! command_exists ifconfig; then
                 yum -y -q install net-tools
             fi


### PR DESCRIPTION
This PR replaces kubernetes/kubernetes#23857 .

This is related to kubernetes/kubernetes#22718

systemctl does not expand environment variables.

You can confirm it in man page.
http://manpages.org/systemdexec/5


> Environment=
> ...
> Variable expansion is not performed inside the strings, and $ has no special meaning.
> ...

EnvironmentFile may behave the same.