### PR TITLE
Update the kube-proxy arguments for master

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -394,10 +394,10 @@ kubelet.
 Arguments to consider:
 
   - If following the HTTPS security approach:
-    - `--api-servers=https://$MASTER_IP`
+    - `--master=https://$MASTER_IP`
     - `--kubeconfig=/var/lib/kube-proxy/kubeconfig`
   - Otherwise, if taking the firewall-based security approach
-    - `--api-servers=http://$MASTER_IP`
+    - `--master=http://$MASTER_IP`
 
 ### Networking
 


### PR DESCRIPTION
 `kube-proxy` doesn't accept `--api-masters=`, it takes `--master=` instead