### PR TITLE
Updated latest Kubernetes version to be set via a variable

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -14,7 +14,11 @@ Here's a diagram of what the final result will look like:
 
 1. You need to have docker installed on one machine.
 2. Decide what Kubernetes version to use.  Set the `${K8S_VERSION}` variable to
-   a released version of Kubernetes >= "1.2.0"
+   a released version of Kubernetes >= "v1.2.0". If you'd like to use the latest released version of Kubernetes, run the following:
+
+```sh
+export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+```
 
 ### Run it
 
@@ -30,7 +34,7 @@ docker run \
     --privileged=true \
     --name=kubelet \
     -d \
-    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} \
     /hyperkube kubelet \
         --containerized \
         --hostname-override="127.0.0.1" \
@@ -63,7 +67,7 @@ variable.
 For example, OS X:
 
 ```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/darwin/amd64/kubectl
+wget http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/darwin/amd64/kubectl
 chmod 755 kubectl
 PATH=$PATH:`pwd`
 ```
@@ -71,7 +75,7 @@ PATH=$PATH:`pwd`
 Linux:
 
 ```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl
+wget http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
 chmod 755 kubectl
 PATH=$PATH:`pwd`
 ```

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -14,10 +14,16 @@ Here's a diagram of what the final result will look like:
 
 1. You need to have docker installed on one machine.
 2. Decide what Kubernetes version to use.  Set the `${K8S_VERSION}` variable to
-   a released version of Kubernetes >= "v1.2.0". If you'd like to use the latest released version of Kubernetes, run the following:
+   a released version of Kubernetes >= "v1.2.0". If you'd like to use the actual stable version of Kubernetes, run the following:
 
 ```sh
 export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+```
+
+   and for the latest available version (including unstable releases):
+
+```sh
+export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/latest.txt)
 ```
 
 ### Run it


### PR DESCRIPTION
Added method to set a Kubernetes variable to the latest actual version.

Updated command with added variable.

Following the https://github.com/kubernetes/kubernetes.github.io/pull/43