### PR TITLE
Fix a row in the job patterns table

### DIFF
--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -214,7 +214,7 @@ The pattern names are also links to examples and more detailed description.
 | -------------------------------------------------------------------------- |:-----------------:|:---------------------------:|:-------------------:|:-------------------:|
 | [Job Template Expansion](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/job/expansions/README.md)          |                   |                             |          ✓          |          ✓          |
 | [Queue with Pod Per Work Item](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/job/work-queue-1/README.md)  |         ✓         |                             |      sometimes      |          ✓          |
-| [Queue with Variable Pod Count](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/job/work-queue-2/README.md) |                   |         ✓         |             ✓               |                     |          ✓          |
+| [Queue with Variable Pod Count](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/job/work-queue-2/README.md) |         ✓         |             ✓               |                     |          ✓          |
 | Single Job with Static Work Assignment                                     |         ✓         |                             |          ✓          |                     |
 
 When you specify completions with `.spec.completions`, each Pod created by the Job controller


### PR DESCRIPTION
In the raw Markdown, the row for the "Queue with Variable Pod Count" pattern has one more column than the other rows. The extra empty cell (in column 2) shifts the checkmarks one column to the right of where they should be. Reading through [the example of how this job pattern works](https://github.com/kubernetes/kubernetes/blob/release-1.2/examples/job/work-queue-2/README.md), it's clear that columns 2, 3, and 5 are the ones that should be checked.