### PR TITLE
Fix sample for Ingress TLS

### DIFF
--- a/docs/user-guide/ingress.md
+++ b/docs/user-guide/ingress.md
@@ -218,7 +218,7 @@ metadata:
   name: no-rules-map
 spec:
   tls:
-    secretName: testsecret
+    - secretName: testsecret
   backend:
     serviceName: s1
     servicePort: 80


### PR DESCRIPTION
[v1beta1.IngressSpec](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_ingressspec) expects an v1beta1.IngressTLS **array**.

Without this change executing the code in the example will return this error:

> error validating "ingress.yml": error validating data: expected type array, for field spec.tls, got map; if you choose to ignore these errors, turn validation off with --validate=false