### PR TITLE
Escape curly braces for go-template

### DIFF
--- a/docs/user-guide/walkthrough/index.md
+++ b/docs/user-guide/walkthrough/index.md
@@ -67,7 +67,9 @@ On most providers, the pod IPs are not externally accessible. The easiest way to
 Provided the pod IP is accessible, you should be able to access its http endpoint with curl on port 80:
 
 ```shell
+{% raw %}
 $ curl http://$(kubectl get pod nginx -o go-template={{.status.podIP}})
+{% endraw %}
 ```
 
 Delete the pod by name:

--- a/docs/user-guide/walkthrough/k8s201.md
+++ b/docs/user-guide/walkthrough/k8s201.md
@@ -106,9 +106,11 @@ On most providers, the service IPs are not externally accessible. The easiest wa
 Provided the service IP is accessible, you should be able to access its http endpoint with curl on port 80:
 
 ```shell
+{% raw %}
 $ export SERVICE_IP=$(kubectl get service nginx-service -o go-template={{.spec.clusterIP}})
 $ export SERVICE_PORT=$(kubectl get service nginx-service -o go-template'={{(index .spec.ports 0).port}}')
 $ curl http://${SERVICE_IP}:${SERVICE_PORT}
+{% endraw %}
 ```
 
 To delete the service by name:


### PR DESCRIPTION
```shell
$ curl http://$(kubectl get pod nginx -o go-template=
```

should be

```shell
$ curl http://$(kubectl get pod nginx -o go-template={{.status.podIP}})
```