### PR TITLE
Docs/ingress: new(?) healthcheck range

### DIFF
--- a/docs/user-guide/ingress.md
+++ b/docs/user-guide/ingress.md
@@ -54,8 +54,8 @@ Make sure you review the [beta limitations](https://github.com/kubernetes/contri
 ```shell
 $ export TAG=$(basename `gcloud container clusters describe ${CLUSTER_NAME} --zone ${ZONE} | grep gke | awk '{print $2}'` | sed -e s/group/node/)
 $ export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services echoheaders)
-$ gcloud compute firewall-rules create allow-130-211-0-0-22 \
-  --source-ranges 130.211.0.0/22 \
+$ gcloud compute firewall-rules create allow-130-211-0-0-21 \
+  --source-ranges 130.211.0.0/21 \
   --target-tags $TAG \
   --allow tcp:$NODE_PORT
 ```


### PR DESCRIPTION
Whilst setting up a k8s cluster in GKE, we noticed the Ingress object creating an HTTP load balancer with ip address 130.211.7.x
Said firewall rule (`--source-ranges 130.211.0.0/22`) does not cover this ip address (max of 130.211.0.0/22 is 130.211.3.255)
The /21 covers our scenario, however, I do not know the full range.
Please verify the range before accepting this change