### PR TITLE
Echo on OS X inserts a newline into its stdout

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -94,9 +94,9 @@ in json or yaml format, and then create that object.
 Each item must be base64 encoded:
 
 ```shell
-$ echo "admin" | base64
+$ printf "admin" | base64
 YWRtaW4K
-$ echo "1f2d1e2e67df" | base64
+$ printf "1f2d1e2e67df" | base64
 MWYyZDFlMmU2N2RmCg==
 ```
 
@@ -152,7 +152,7 @@ type: Opaque
 Decode the password field:
 
 ```shell
-$ echo "MWYyZDFlMmU2N2RmCg==" | base64 -D
+$ printf "MWYyZDFlMmU2N2RmCg==" | base64 -D
 1f2d1e2e67df
 ```
 


### PR DESCRIPTION
if you create a secret file via `kubectl create -f secret.yaml` and used `echo "foo" | base64` the value of the env var is actually "foo\n". `printf(1)` gives us perfect control over `base64(1)`s standard input.