### PR TITLE
Update scratch.md - Broken link in the docs

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -368,7 +368,7 @@ Then you need to configure your kubelet with flag:
 
 ### kubelet
 
-All nodes should run kubelet.  See [Selecting Binaries](#selecting-binaries).
+All nodes should run kubelet.  See [Software Binaries](#software-binaries).
 
 Arguments to consider:
 


### PR DESCRIPTION
There is a broken anchor link in the docs. I think instead this link may refer to the "Software Binaries" section.