### PR TITLE
Add missing raw tags 

### DIFF
--- a/docs/getting-started-guides/cloudstack.md
+++ b/docs/getting-started-guides/cloudstack.md
@@ -68,7 +68,7 @@ Check the tasks and templates in `roles/k8s` if you want to modify anything.
 
 Once the playbook as finished, it will print out the IP of the Kubernetes master:
 
-    TASK: [k8s | debug msg='k8s master IP is {{ k8s_master.default_ip }}'] ********
+    TASK: [k8s | debug msg='k8s master IP is {% raw %}{{ k8s_master.default_ip }}{% endraw %}'] ********
 
 SSH to it using the key that was created and using the _core_ user and you can list the machines in your cluster:
 

--- a/docs/getting-started-guides/mesos/index.md
+++ b/docs/getting-started-guides/mesos/index.md
@@ -229,23 +229,23 @@ Note that we have passed these two values already as parameter to the apiserver 
 
 A template for an replication controller spinning up the pod with the 3 containers can be found at [cluster/addons/dns/skydns-rc.yaml.in][11] in the repository. The following steps are necessary in order to get a valid replication controller yaml file:
 
-- replace `{{ pillar['dns_replicas'] }}`  with `1`
-- replace `{{ pillar['dns_domain'] }}` with `cluster.local.`
+- replace `{% raw %}{{ pillar['dns_replicas'] }}{% endraw %}`  with `1`
+- replace `{% raw %}{{ pillar['dns_domain'] }}{% endraw %}` with `cluster.local.`
 - add `--kube_master_url=${KUBERNETES_MASTER}` parameter to the kube2sky container command.
 
 In addition the service template at [cluster/addons/dns/skydns-svc.yaml.in][12] needs the following replacement:
 
-- `{{ pillar['dns_server'] }}` with `10.10.10.10`.
+- `{% raw %}{{ pillar['dns_server'] }}{% endraw %}` with `10.10.10.10`.
 
 To do this automatically:
 
-```shell
+```shell{% raw %}
 sed -e "s/{{ pillar\['dns_replicas'\] }}/1/g;"\
 "s,\(command = \"/kube2sky\"\),\\1\\"$'\n'"        - --kube_master_url=${KUBERNETES_MASTER},;"\
 "s/{{ pillar\['dns_domain'\] }}/cluster.local/g" \
   cluster/addons/dns/skydns-rc.yaml.in > skydns-rc.yaml
 sed -e "s/{{ pillar\['dns_server'\] }}/10.10.10.10/g" \
-  cluster/addons/dns/skydns-svc.yaml.in > skydns-svc.yaml
+  cluster/addons/dns/skydns-svc.yaml.in > skydns-svc.yaml{% endraw %}
 ```
 
 Now the kube-dns pod and service are ready to be launched:

--- a/docs/user-guide/compute-resources.md
+++ b/docs/user-guide/compute-resources.md
@@ -222,10 +222,10 @@ The `Restart Count:  5` indicates that the `simmemleak` container in this pod wa
 
 You can call `get pod` with the `-o go-template=...` option to fetch the status of previously terminated containers:
 
-```shell
+```shell{% raw %}
 [13:59:01] $ ./cluster/kubectl.sh  get pod -o go-template='{{range.status.containerStatuses}}{{"Container Name: "}}{{.name}}{{"\r\nLastState: "}}{{.lastState}}{{end}}'  simmemleak-60xbc
 Container Name: simmemleak
-LastState: map[terminated:map[exitCode:137 reason:OOM Killed startedAt:2015-07-07T20:58:43Z finishedAt:2015-07-07T20:58:43Z containerID:docker://0e4095bba1feccdfe7ef9fb6ebffe972b4b14285d5acdec6f0d3ae8a22fad8b2]]
+LastState: map[terminated:map[exitCode:137 reason:OOM Killed startedAt:2015-07-07T20:58:43Z finishedAt:2015-07-07T20:58:43Z containerID:docker://0e4095bba1feccdfe7ef9fb6ebffe972b4b14285d5acdec6f0d3ae8a22fad8b2]]{% endraw %}
 ```
 
 We can see that this container was terminated because `reason:OOM Killed`, where *OOM* stands for Out Of Memory.

--- a/docs/user-guide/connecting-to-applications-port-forward.md
+++ b/docs/user-guide/connecting-to-applications-port-forward.md
@@ -22,9 +22,9 @@ redis-master   2/2       Running   0          41s
 
 The Redis master is listening on port 6397, to verify this,
 
-```shell
+```shell{% raw %}
 $ kubectl get pods redis-master -t='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
-6379
+6379{% endraw %}
 ```
 
 then we forward the port 6379 on the local workstation to the port 6379 of pod redis-master,

--- a/docs/user-guide/deploying-applications.md
+++ b/docs/user-guide/deploying-applications.md
@@ -84,9 +84,9 @@ my-nginx   2         2         2            2           2m        my-nginx
 
 More importantly, the pod template's labels are used to create a [`selector`](/docs/user-guide/labels/#label-selectors) that will match pods carrying those labels. You can see this field by requesting it using the [Go template output format of `kubectl get`](/docs/user-guide/kubectl/kubectl_get):
 
-```shell
+```shell{% raw %}
 $ kubectl get deployment/my-nginx -o template --template="{{.spec.selector}}"
-map[matchLabels:map[run:my-nginx]]
+map[matchLabels:map[run:my-nginx]]{% endraw %}
 ```
 
 You could also specify the `selector` explicitly, such as if you wanted to specify labels in the pod template that you didn't want to select on, but you should ensure that the selector will match the labels of the pods created from the pod template, and that it won't match pods created by other Deployments. The most straightforward way to ensure the latter is to create a unique label value for the Deployment, and to specify it in both the pod template's labels and in the selector's

--- a/docs/user-guide/walkthrough/index.md
+++ b/docs/user-guide/walkthrough/index.md
@@ -67,7 +67,7 @@ On most providers, the pod IPs are not externally accessible. The easiest way to
 Provided the pod IP is accessible, you should be able to access its http endpoint with curl on port 80:
 
 ```shell
-$ curl http://$(kubectl get pod nginx -o go-template={{.status.podIP}})
+$ curl http://$(kubectl get pod nginx -o go-template={% raw %}{{.status.podIP}}{% endraw %})
 ```
 
 Delete the pod by name:

--- a/docs/user-guide/walkthrough/k8s201.md
+++ b/docs/user-guide/walkthrough/k8s201.md
@@ -106,8 +106,8 @@ On most providers, the service IPs are not externally accessible. The easiest wa
 Provided the service IP is accessible, you should be able to access its http endpoint with curl on port 80:
 
 ```shell
-$ export SERVICE_IP=$(kubectl get service nginx-service -o go-template={{.spec.clusterIP}})
-$ export SERVICE_PORT=$(kubectl get service nginx-service -o go-template'={{(index .spec.ports 0).port}}')
+$ export SERVICE_IP=$(kubectl get service nginx-service -o go-template={% raw %}{{.spec.clusterIP}}{% endraw %})
+$ export SERVICE_PORT=$(kubectl get service nginx-service -o go-template={% raw %}{{(index .spec.ports 0).port}}{% endraw %})
 $ curl http://${SERVICE_IP}:${SERVICE_PORT}
 ```
 


### PR DESCRIPTION
addresses issue #81 and issue: https://github.com/kubernetes/kubernetes/issues/23026

Summary:  html generated by jekyll was missing text in double curly braces `{{ }}` due to jekyll presuming these are liquid tags. 


Signed-off-by: mikebrow <brownwm@us.ibm.com>