### PR TITLE
docs: Clarify use of the base64 utility

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -124,9 +124,11 @@ $ kubectl create -f ./secret.yaml
 secret "mysecret" created
 ```
 
-**Encoding Note:** The serialized JSON and YAML values of secret data are encoded as
-base64 strings.  Newlines are not valid within these strings and must be
-omitted (i.e. do not use `-b` option of `base64` which breaks long lines.)
+**Encoding Note:** The serialized JSON and YAML values of secret data are
+encoded as base64 strings.  Newlines are not valid within these strings and must
+be omitted.  When using the `base64` utility on Darwin/OS X users should avoid
+using the `-b` option to split long lines.  Conversely Linux users *should* add
+the option `-w 0` to `base64` commands.
 
 #### Decoding a Secret
 


### PR DESCRIPTION
The base64 utility has different options on both Darwin and Linux.
Adding clarification as to how the use of these utilities differ
on platforms.