### PR TITLE
Expand debugging services tips

### DIFF
--- a/docs/user-guide/debugging-services.md
+++ b/docs/user-guide/debugging-services.md
@@ -78,7 +78,7 @@ $ kubectl run hostnames --image=gcr.io/google_containers/serve_hostname \
 deployment "hostnames" created
 ```
 
-`kubectl` commands will print the type and name of the resource created or mutated, which can then be used in subsequent commands. 
+`kubectl` commands will print the type and name of the resource created or mutated, which can then be used in subsequent commands.
 Note that this is the same as if you had started the `Deployment` with
 the following YAML:
 
@@ -256,6 +256,36 @@ If this fails, you might need to go to the kube-proxy section of this doc, or
 even go back to the top of this document and start over, but instead of
 debugging your own `Service`, debug DNS.
 
+### _Some_ of my images cannot resolve
+
+Check if the container image can resolve DNS via `search`.
+
+For example, Alpine Linux uses `musl-libc` and does not support the `search`
+keyword in `resolv.conf`. If you want to use Alpine as base image you will need
+to get an specially built for Kubernetes.
+
+An example of docker base image with kubernetes compatibility is
+[janeczku/docker-alpine-kubernetes](https://hub.docker.com/r/janeczku/alpine-kubernetes/)
+
+Also, as an example of what happens when we lose the `search` keyword, we can
+simulate and remove it from the `/etc/resolv.conf`.
+
+```bash
+$ kubectl exec -it redis-953548141-70rc8 bash
+
+$ cat /etc/resolv.conf
+search svc.cluster.local cluster.local google.internal.  # and some more
+nameserver 10.75.240.10
+options ndots:5
+
+$ ping redis
+PING redis.palladium.svc.cluster.local (10.75.254.48): 56 data bytes
+
+$ echo "nameserver 10.75.240.10" > /etc/resolv.conf
+$ ping redis
+ping: unknown host
+```
+
 ## Does the Service work by IP?
 
 The next thing to test is whether your `Service` works at all.  From a
@@ -320,11 +350,17 @@ $ kubectl get service hostnames -o json
 }
 ```
 
-Is the port you are trying to access in `spec.ports[]`?  Is the `targetPort`
-correct for your `Pod`s?  If you meant it to be a numeric port, is it a number
-(9376) or a string "9376"?  If you meant it to be a named port, do your `Pod`s
-expose a port with the same name?  Is the port's `protocol` the same as the
-`Pod`'s?
+Also, check:
+
+* Is the port you are trying to access in `spec.ports[]`?
+* Is the `targetPort` correct for your `Pod`s?
+* If you meant it to be a numeric port, is it a number (9376)
+  or a string "9376"?
+* If you meant it to be a named port, do your `Pod`s expose a port
+  with the same name?
+* Is the port's `protocol` the same as the `Pod`'s?
+* Does the service has a `selector` and is correctly written?
+
 
 ## Does the Service have any Endpoints?
 


### PR DESCRIPTION
During my first tests I got a lot of trouble for having non-kubernetes compatible Alpine linux images. Also, one time I incorrectly wrote the service selectors.

This PR is just an expansion for those papercuts.