### PR TITLE
Fix HPA link and add comment on v1 spec

### DIFF
--- a/docs/user-guide/horizontal-pod-autoscaling/hpa-php-apache-v1.yaml
+++ b/docs/user-guide/horizontal-pod-autoscaling/hpa-php-apache-v1.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: php-apache
+    subresource: scale
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80

--- a/docs/user-guide/horizontal-pod-autoscaling/index.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/index.md
@@ -75,9 +75,29 @@ i.e. you cannot bind a horizontal pod autoscaler to a replication controller and
 The reason this doesn't work is that when rolling update creates a new replication controller,
 the horizontal pod autoscaler will not be bound to the new replication controller.
 
+## Changes in the beta1 and v1 specs
+
+As any Kubernetes object you can declare and create a autoscaler in a yaml file. Take into account that the spec changed a little during the stabilization so now instead of writing:
+
+```yaml
+apiVersion: extensions/v1beta1
+[...]
+spec:
+  scaleRef:
+  [...]
+  cpuUtilization:
+    targetPercentage: 50
+```
+
+You write:
+
+
+{% include code.html language="yaml" file="hpa-php-apache-v1.yaml" 
+   ghlink="/docs/user-guide/horizontal-pod-autoscaling/hpa-php-apache-v1.yaml" %}
+
 
 ## Further reading
 
 * Design documentation: [Horizontal Pod Autoscaling](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/horizontal-pod-autoscaler.md).
 * Manual of autoscale command in kubectl: [kubectl autoscale](/docs/user-guide/kubectl/kubectl_autoscale).
-* Usage example of [Horizontal Pod Autoscaler](/docs/user-guide/horizontal-pod-autoscaling/).
+* Usage example of [Horizontal Pod Autoscaler](/docs/user-guide/horizontal-pod-autoscaling/walkthrough/).


### PR DESCRIPTION
The difference on HPA specs for the beta and v1 can be improved.

Also, fix a broken link in the hpa/index.md .