### PR TITLE
Updated etcd repo source

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -57,7 +57,7 @@ Run:
 ```shell
 sudo docker -H unix:///var/run/docker-bootstrap.sock run -d \
     --net=host \
-    gcr.io/google_containers/etcd-amd64:${ETCD_VERSION} \
+    quay.io/coreos/etcd:v${ETCD_VERSION} \
     /usr/local/bin/etcd \
         --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
         --advertise-client-urls=http://${MASTER_IP}:4001 \
@@ -69,7 +69,7 @@ Next, you need to set a CIDR range for flannel.  This CIDR should be chosen to b
 ```shell
 sudo docker -H unix:///var/run/docker-bootstrap.sock run \
     --net=host \
-    gcr.io/google_containers/etcd-amd64:${ETCD_VERSION} \
+    quay.io/coreos/etcd:v${ETCD_VERSION} \
     etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
 ```
 

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -9,8 +9,8 @@ Enviroinment variables used:
 
 ```shell
 export MASTER_IP=<the_master_ip_here>
-export K8S_VERSION=<your_k8s_version (e.g. 1.2.1)>
-export ETCD_VERSION=<your_etcd_version (e.g. 2.2.1)>
+export K8S_VERSION=<your_k8s_version (e.g. 1.2.2)>
+export ETCD_VERSION=<your_etcd_version (e.g. 2.3.1)>
 export FLANNEL_VERSION=<your_flannel_version (e.g. 0.5.5)>
 export FLANNEL_IFACE=<flannel_interface (defaults to eth0)>
 export FLANNEL_IPMASQ=<flannel_ipmasq_flag (defaults to true)>

--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -133,7 +133,7 @@ start_k8s(){
         --restart=on-failure \
         --net=host \
         -d \
-        gcr.io/google_containers/etcd-${ARCH}:${ETCD_VERSION} \
+        quay.io/coreos/etcd:v${ETCD_VERSION} \
         /usr/local/bin/etcd \
             --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
             --advertise-client-urls=http://${MASTER_IP}:4001 \
@@ -142,7 +142,7 @@ start_k8s(){
     sleep 5
     # Set flannel net config
     docker -H unix:///var/run/docker-bootstrap.sock run \
-        --net=host gcr.io/google_containers/etcd:${ETCD_VERSION} \
+        --net=host quay.io/coreos/etcd:v${ETCD_VERSION} \
         etcdctl \
         set /coreos.com/network/config \
             '{ "Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}'


### PR DESCRIPTION
As etcd current releases are available only on quay.io, the actual URL of Docker registry has been updated (from gcr.io to quay.io).