### PR TITLE
Warn that iptables proxier doesn't handle readiness failures.

### DIFF
--- a/docs/user-guide/services/index.md
+++ b/docs/user-guide/services/index.md
@@ -193,7 +193,10 @@ default is `"None"`).
 As with the userspace proxy, the net result is that any traffic bound for the
 `Service`'s IP:Port is proxied to an appropriate backend without the clients
 knowing anything about Kubernetes or `Services` or `Pods`. This should be
-faster and more reliable than the userspace proxy.
+faster and more reliable than the userspace proxy. However, unlike the
+userspace proxier, the iptables proxier cannot automatically retry another
+`Pod` if the one it initially selects does not respond, so it depends on
+having working [readiness probes](/docs/user-guide/production-pods/#liveness-and-readiness-probes-aka-health-checks).
 
 ![Services overview diagram for iptables proxy](/images/docs/services-iptables-overview.svg)
 


### PR DESCRIPTION
qv https://github.com/kubernetes/kubernetes/issues/24322

Not totally sure about the wording. @thockin?

(The totally-sketchy-looking hardcoded link to readiness probes documentation is stolen from docs/user-guide/ingress.md...)