### PR TITLE
Avoid rendering "shell" in OS X nginx curl command

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -145,6 +145,7 @@ kubectl get svc nginx --template={{.spec.clusterIP}}
 {% endraw %}```
 
 On OS X, since docker is running inside a VM, run the following command instead:
+
 ```shell
 docker-machine ssh `docker-machine active` curl $ip
 ```


### PR DESCRIPTION
Haven't tested this on a local setup, but other examples hint that this will work.