### PR TITLE
Update local instructions

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -4,7 +4,21 @@
 * TOC
 {:toc}
 
+### Introduction
+
+This tutorial is designed to start a local cluster, consisting of a master and single node
+on the local machine.
+
+To interact with the cluster you then can use kubectl to do so.
+
 ### Requirements
+
+This tutorial is intended to run on Linux and needs Docker. It was tested on Ubuntu 16.04
+but other Linuxes should be similar.
+
+**Warning**
+This tutorial exposes the Kubernetes installation on a public IP address, be sure you
+understand the risks involved.
 
 #### Linux
 
@@ -17,44 +31,163 @@ At least [Docker](https://docs.docker.com/installation/#installation)
 ps`).  Some of the Kubernetes components need to run as root, which normally
 works fine with docker.
 
-#### etcd
-
-You need an [etcd](https://github.com/coreos/etcd/releases) in your path, please make sure it is installed and in your ``$PATH``.
-
-#### go
-
-You need [go](https://golang.org/doc/install) at least 1.3+ in your path, please make sure it is installed and in your ``$PATH``.
-
 ### Starting the cluster
 
-First, you need to [download Kubernetes](/docs/getting-started-guides/binary_release/). Then open a separate tab of your terminal 
-and run the following (since one needs sudo access to start/stop Kubernetes daemons, it is easier to run the entire script as root):
+First you will need to open up your terminal.
 
+Then you need to configure the directory where to place the binaries and their dependencies:
 ```shell
-cd kubernetes
-hack/local-up-cluster.sh
+export KUBE_BIN=~/kube-bin
+export PATH=${PATH}:${KUBE_BIN}
 ```
 
-This will build and start a lightweight local cluster, consisting of a master
-and a single node. Type Control-C to shut it down.
+Then, you need to configure the IP and port on which the API will be exposed. Make sure that
+this IP matches one assigned to your computer.
+```shell
+export KUBE_API_ADDR=192.168.1.111
+export KUBE_API_PORT=8080
+```
 
-You can use the cluster/kubectl.sh script to interact with the local cluster. hack/local-up-cluster.sh will
-print the commands to run to point kubectl at the local cluster.
+The next step is to configure versions for the dependencies, these will be used later:
+```shell
+export FLANNEL_VERSION="0.5.5"
+export ETCD_VERSION=2.3.3
+export KUBE_VERSION="1.2.3"
+export KUBERNETES_PROVIDER=local
+export NUM_NODES=1
+```
 
+**Note** During this tutorial we'll launch many commands as background running commands.
+If you want to launch them in separate tabs, please remember to always run the above
+commands so that everything is configured correctly.
+
+Now, lets downloaded Kubernetes and extract it:
+```shell
+curl -L https://github.com/kubernetes/kubernetes/releases/download/v${KUBE_VERSION}/kubernetes.tar.gz \
+    -o /tmp/kubernetes.tar.gz
+cd /tmp
+tar -zxvf kubernetes.tar.gz
+rm kubernetes.tar.gz
+cd kubernetes/server
+tar -zxvf kubernetes-server-linux-amd64.tar.gz
+
+mv kubernetes/server/bin ~/${KUBE_BIN}
+```
+
+From now one, the commands will need to be executed in the directory where you've placed
+Kubernetes so lets make sure where are there:
+```shell
+cd ${KUBE_BIN}
+```
+
+Our first dependency that needs to run is [etdc](https://coreos.com/etcd/):
+```shell
+curl -L  https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz \
+    -o etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
+tar zxvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
+cp etcd-v${ETCD_VERSION}-linux-amd64/etcd .
+cp etcd-v${ETCD_VERSION}-linux-amd64/etcdctl .
+rm -r etcd-v${ETCD_VERSION}-linux-amd64.tar.gz etcd-v${ETCD_VERSION}-linux-amd64
+```
+
+This will launch it in the background but you could launch it as well in a separate terminal:
+```shell
+ETCD_VERSION=false ./etcd &
+```
+
+After etcd has loaded successfully, we need to add an entry for the flannel network configuration:
+```shell
+./etcdctl mk /coreos.com/network/config '{"Network":"172.17.0.0/16"}'
+```
+
+Now, download [flannel](https://coreos.com/flannel/) in order to create the networking
+layer to be used by Kubernetes:
+```shell
+curl -L https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz \
+    -o flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz
+tar zxvf flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz
+cp flannel-${FLANNEL_VERSION}/flanneld .
+rm -r flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz flannel-${FLANNEL_VERSION}
+```
+
+Flannel needs to be launched as root, and again it will be launched in background:
+```shell
+sudo ./flanneld &
+```
+
+Finally, before we are able to launch Kubernetes, we should create the default directory
+where it expects to store the security certificates being used
+```shell
+sudo mkdir -p /var/run/kubernetes
+```
+
+Now lets launch the Kubernetes. First we need to launch the API server. This needs to
+run as root:
+```shell
+sudo ./kube-apiserver --service-cluster-ip-range=127.0.0.1/28 \
+    --etcd-servers='http://localhost:2379,http://localhost:4001' \
+    --insecure-bind-address=${KUBE_API_ADDR} --insecure-port=${KUBE_API_PORT} &
+```
+
+Next, we need to launch Kubelet:
+```shell
+sudo ./kubelet --api-servers=${KUBE_API_ADDR}:${KUBE_API_PORT} &
+```
+
+Launch the Controller manager:
+```shell
+sudo ./kube-controller-manager --master=${KUBE_API_ADDR}:${KUBE_API_PORT} \
+    --root-ca-file=/var/run/kubernetes/apiserver.crt &
+```
+
+Launch the proxy:
+```shell
+sudo ./kube-proxy --master=${KUBE_API_ADDR}:${KUBE_API_PORT} &
+```
+
+Launch the scheduler
+```shell
+sudo ./kube-scheduler --master=${KUBE_API_ADDR}:${KUBE_API_PORT} &
+```
+
+And that's it. Your Kubernetes cluster should now be up and running.
+
+
+#### Get the Dashboard and run it
+
+To get the [Kubernetes Dashboard](http://kubernetes.io/docs/user-guide/ui/) up and
+running you'll need to do is to:
+
+- download and schedule (run) the dashboard board:
+```shell
+kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
+```
+- expose it to the world:
+```shell
+kubectl proxy --port=9090 &
+```
+
+To see if this works, you can do this
+```shell
+./kubectl -s=${KUBE_API_ADDR}:${KUBE_API_PORT} describe pods --namespace=kube-system
+```
+
+Note that ` --namespace=kube-system ` is needed as the pod is launched in that namespace.
 
 ### Running a container
 
 Your cluster is running, and you want to start running containers!
 
-You can now use any of the cluster/kubectl.sh commands to interact with your local setup.
+You can now use any of the kubectl commands to interact with your local setup.
 
 ```shell
-cluster/kubectl.sh get pods
-cluster/kubectl.sh get services
-cluster/kubectl.sh get deployments
-cluster/kubectl.sh run my-nginx --image=nginx --replicas=2 --port=80
+cd ~/kube-bin
+./kubectl get pods
+./kubectl get services
+./kubectl get deployments
+./kubectl run my-nginx --image=nginx --replicas=2 --port=80
 
-## begin wait for provision to complete, you can monitor the docker pull by opening a new terminal
+## Begin wait for provision to complete, you can monitor the docker pull by opening a new terminal
   sudo docker images
   ## you should see it pulling the nginx image, once the above command returns it
   sudo docker ps
@@ -62,10 +195,10 @@ cluster/kubectl.sh run my-nginx --image=nginx --replicas=2 --port=80
   exit
 ## end wait
 
-## introspect Kubernetes!
-cluster/kubectl.sh get pods
-cluster/kubectl.sh get services
-cluster/kubectl.sh get deployments
+## Introspect Kubernetes
+./kubectl get pods
+./kubectl get services
+./kubectl get deployments
 ```
 
 ### Running a user defined pod
@@ -77,7 +210,7 @@ However you cannot view the nginx start page on localhost. To verify that nginx 
 You can control the specifications of a pod via a user defined manifest, and reach nginx through your browser on the port specified therein:
 
 ```shell
-cluster/kubectl.sh create -f docs/user-guide/pod.yaml
+./kubectl create -f docs/user-guide/pod.yaml
 ```
 
 Congratulations!
@@ -95,14 +228,6 @@ By default the IP range for service cluster IPs is 10.0.*.* - depending on your
 docker installation, this may conflict with IPs for containers.  If you find
 containers running with IPs in this range, edit hack/local-cluster-up.sh and
 change the service-cluster-ip-range flag to something else.
-
-#### I changed Kubernetes code, how do I run it?
-
-```shell
-cd kubernetes
-hack/build-go.sh
-hack/local-up-cluster.sh
-```
 
 #### kubectl claims to start a container but `get pods` and `docker ps` don't show it.
 


### PR DESCRIPTION
This attempts to improve the instructions to launch Kubernetes on a local machine.

I'm sure this can be improved and hopefully not expose the installation to a public IP of the machine but at the moment I don't know how to do that so help would be appreciated.

If I've missed something from the bootstrapping process, please let me know, things appear to work on my machine so far.

This has the advantage it can easily be copy-pasted into a bash script and have it up and running for the user quite easily.