### PR TITLE
Deleted cluster server pointer

### DIFF
--- a/docs/getting-started-guides/docker-multinode/testing.md
+++ b/docs/getting-started-guides/docker-multinode/testing.md
@@ -20,7 +20,7 @@ If the status of any node is `Unknown` or `NotReady` your cluster is broken, dou
 ### Run an application
 
 ```shell
-kubectl -s http://localhost:8080 run nginx --image=nginx --port=80
+kubectl run nginx --image=nginx --port=80
 ```
 
 now run `docker ps` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.


### PR DESCRIPTION
Deleted cluster server pointer as `kubectl` might be run from any other location, not only from `localhost`.