### PR TITLE
Remove 'generic' copy/paste error

### DIFF
--- a/docs/user-guide/kubectl/kubectl_create_configmap.md
+++ b/docs/user-guide/kubectl/kubectl_create_configmap.md
@@ -28,13 +28,13 @@ kubectl create configmap NAME [--type=string] [--from-file=[key=]source] [--from
 
 ```
   # Create a new configmap named my-config with keys for each file in folder bar
-  kubectl create configmap generic my-config --from-file=path/to/bar
+  kubectl create configmap my-config --from-file=path/to/bar
 
   # Create a new configmap named my-config with specified keys instead of names on disk
-  kubectl create configmap generic my-config --from-file=ssh-privatekey=~/.ssh/id_rsa --from-file=ssh-publickey=~/.ssh/id_rsa.pub
+  kubectl create configmap my-config --from-file=ssh-privatekey=~/.ssh/id_rsa --from-file=ssh-publickey=~/.ssh/id_rsa.pub
 
   # Create a new configMap named my-config with key1=config1 and key2=config2
-  kubectl create configmap generic my-config --from-literal=key1=config1 --from-literal=key2=config2
+  kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
 ```
 
 ### Options


### PR DESCRIPTION
Looks like this doc was created from copying the kubectl create secret command, which is similar, but not the same as configmap.  There is no type parameter like kubectl create secret.