### PR TITLE
Use node:latest image

### DIFF
--- a/docs/hellonode.md
+++ b/docs/hellonode.md
@@ -75,7 +75,7 @@ Next, create a file, also within `hellonode/` named `Dockerfile`. A Dockerfile d
 #### Dockerfile
 
 ```conf
-FROM node:0.12
+FROM node:latest
 EXPOSE 8080
 COPY server.js .
 CMD node server.js


### PR DESCRIPTION
Node 6.0.0 was recently released, and development is moving fast. Why not rely on the latest Node, rather than a dated `0.12`?