### PR TITLE
Clarify titles under "Running Kubernetes"

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -156,15 +156,15 @@ toc:
       path: /docs/getting-started-guides/scratch/
     - title: Custom Cloud Solutions
       section:
-      - title: AWS or GCE on CoreOS
+      - title: CoreOS on AWS or GCE
         path: /docs/getting-started-guides/coreos/
-      - title: AWS or Joyent on Ubuntu
+      - title: Ubuntu on AWS or Joyent
         path: /docs/getting-started-guides/juju/
-      - title: Rackspace on CoreOS
+      - title: CoreOS on Rackspace
         path: /docs/getting-started-guides/rackspace/
     - title: On-Premise VMs
       section:
-      - title: Vagrant or VMware
+      - title: CoreOS on Vagrant
         path: /docs/getting-started-guides/coreos/
       - title: Cloudstack
         path: /docs/getting-started-guides/cloudstack/
@@ -174,15 +174,13 @@ toc:
         path: /docs/getting-started-guides/juju/
       - title: DCOS
         path: /docs/getting-started-guides/dcos/
-      - title: libvirt on CoreOS
+      - title: CoreOS on libvirt
         path: /docs/getting-started-guides/libvirt-coreos/
       - title: oVirt
         path: /docs/getting-started-guides/ovirt/
       - title: OpenStack Heat
         path: /docs/getting-started-guides/openstack-heat/
-      - title: libvirt or KVM
-        path: /docs/getting-started-guides/fedora/flannel_multi_node_cluster/
-      - title: Multinode Cluster on CoreOS
+      - title: CoreOS on Multinode Cluster
         path: /docs/getting-started-guides/coreos/coreos_multinode_cluster/
       - title: Fedora With Calico Networking
         path: /docs/getting-started-guides/fedora/fedora-calico/


### PR DESCRIPTION
Of course AWS does not "run on CoreOS", so under "Running Kubernetes" the title should not be "AWS on CoreOS".
This is highly irritating when browsing the docs the first time.
The title should either be: "Kubernetes with AWS provider on CoreOS", or "CoreOS on AWS".
I picked the latter form, and fixed a couple of non-optimal titles in this fashion.

I also changed "Vagrant or VMware" to "CoreOS on Vagrant", because the article is mostly about CoreOS, including other platforms (btw. VMWare is just a Vagrant provider in this context).
Also note that there is a little navigation bug because the article "/docs/getting-started-guides/coreos/" is linked twice: when clicked, the other link is selected too in the navigation (under certain circumstances). It may make sense to split the article in 2 files: one about Vagrant only, one about AWS and GCE.

I removed the "libvirt or KVM" link, because the article is already linked under "On Bare Metal", where it fits better. It has nothing special to do with libvirt and KVM and doesn't mention any of both.