### PR TITLE
Update Node.JS examples to LTS 4.4 base image

### DIFF
--- a/docs/getting-started-guides/meanstack.md
+++ b/docs/getting-started-guides/meanstack.md
@@ -53,7 +53,7 @@ First, you need a `Dockerfile`. This is basically the list of instructions Docke
 Here is the `Dockerfile` for the web server:
 
 ```shell
-FROM node:0.10.40
+FROM node:4.4
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -65,7 +65,7 @@ CMD ["node", "app.js"]
 
 A `Dockerfile` is pretty self explanatory, and this one is dead simple.
 
-First, it uses the official Node.js image as the base image.
+First, it uses the official Node.js LTS image as the base image.
 
 Then, it creates a folder to store the code, `cd`s into that directory, copies the code in, and installs the dependencies with npm.
 
@@ -441,4 +441,3 @@ By using Container Engine and Kubernetes, we have a very robust, container based
 Hopefully I can do some more posts about advanced Kubernetes topics such as changing the cluster size and number of Node.js web server replicas, using different environments (dev, staging, prod) on the same cluster, and doing rolling updates.
 
 Thanks to [Mark Mandel](https://medium.com/@markmandel), [Aja Hammerly](https://medium.com/@thagomizer), and [Jack Wilber](https://medium.com/@jack.g.wilber). [Some rights reserved](http://creativecommons.org/licenses/by/4.0/) by the author.
-

--- a/docs/hellonode.md
+++ b/docs/hellonode.md
@@ -75,13 +75,13 @@ Next, create a file, also within `hellonode/` named `Dockerfile`. A Dockerfile d
 #### Dockerfile
 
 ```conf
-FROM node:0.12
+FROM node:4.4
 EXPOSE 8080
 COPY server.js .
 CMD node server.js
 ```
 
-This "recipe" for the Docker image will start from the Node 0.12 image found on the Docker registry, expose port 8080, copy our `server.js` file to the image and start the Node server.
+This "recipe" for the Docker image will start from the official Node.js LTS image found on the Docker registry, expose port 8080, copy our `server.js` file to the image and start the Node server.
 
 Now build an image of your container by running `docker build`, tagging the image with the Google  Container Registry repo for your `PROJECT_ID`:
 


### PR DESCRIPTION
As mentioned in #297, the current hellonode and MEAN stack examples are using a version that is in Maintenance mode and will no longer be supported by October 2016.  The current LTS version is 4.4.X, which is available on Dockerhub under node:4.4.

I have updated the hellonode and MEAN stack examples to use the node:4.4 LTS docker image.

For more information about the Node.JS release cycle, visit [the project website](https://github.com/nodejs/LTS#lts_schedule)