### PR TITLE
Use `echo -n` for less ambiguous base64 secret example

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -94,10 +94,10 @@ in json or yaml format, and then create that object.
 Each item must be base64 encoded:
 
 ```shell
-$ echo "admin" | base64
-YWRtaW4K
-$ echo "1f2d1e2e67df" | base64
-MWYyZDFlMmU2N2RmCg==
+$ echo -n "admin" | base64
+YWRtaW4=
+$ echo -n "1f2d1e2e67df" | base64
+MWYyZDFlMmU2N2Rm
 ```
 
 Now write a secret object that looks like this:
@@ -109,8 +109,8 @@ metadata:
   name: mysecret
 type: Opaque
 data:
-  password: MWYyZDFlMmU2N2RmCg==
-  username: YWRtaW4K
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=
 ```
 
 The data field is a map.  Its keys must match
@@ -138,8 +138,8 @@ Get back the secret created in the previous section:
 $ kubectl get secret mysecret -o yaml
 apiVersion: v1
 data:
-  password: MWYyZDFlMmU2N2RmCg==
-  username: YWRtaW4K
+  password: MWYyZDFlMmU2N2Rm
+  username: YWRtaW4=
 kind: Secret
 metadata:
   creationTimestamp: 2016-01-22T18:41:56Z
@@ -154,7 +154,7 @@ type: Opaque
 Decode the password field:
 
 ```shell
-$ echo "MWYyZDFlMmU2N2RmCg==" | base64 -D
+$ echo "MWYyZDFlMmU2N2Rm" | base64 -D
 1f2d1e2e67df
 ```
 


### PR DESCRIPTION
One could be bitten by having unexpected newline characters in base64 encoded secrets (reference: https://github.com/kubernetes/kubernetes/issues/23404).
Calling `echo -n` will omit the trailing newline character.

`
     The echo utility writes any specified operands, separated by single blank (` ') characters and followed by
     a newline (`\n') character, to the standard output.

     The following option is available:

     -n    Do not print the trailing newline character.  This may also be achieved by appending `\c' to the end
           of the string, as is done by iBCS2 compatible systems.  Note that this option as well as the effect
           of `\c' are implementation-defined in IEEE Std 1003.1-2001 (``POSIX.1'') as amended by Cor. 1-2002.
           Applications aiming for maximum portability are strongly encouraged to use printf(1) to suppress the
           newline character.
`