### PR TITLE
libvirt daemon error on arch

### DIFF
--- a/docs/getting-started-guides/libvirt-coreos.md
+++ b/docs/getting-started-guides/libvirt-coreos.md
@@ -280,8 +280,10 @@ Start the libvirt daemon
 On Arch:
 
 ```shell
-systemctl start libvirtd
+systemctl start libvirtd virtlogd.socket
 ```
+
+The `virtlogd.socket` is not started with the libvirtd daemon. If you enable the `libvirtd.service` it is linked and started automatically on the next boot.
 
 On Ubuntu 14.04:
 


### PR DESCRIPTION
the virtlogd.socket is not started with the libvirtd daemon. if you enable the libvirtd.service it is linked and started on the next reboot.

See: https://bbs.archlinux.org/viewtopic.php?id=206206
