### PR TITLE
Use xargs when removing mounts

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -176,7 +176,7 @@ docker-machine ssh `docker-machine active`
 ```
 
 ```shell
-sudo umount `cat /proc/mounts | grep /var/lib/kubelet | awk '{print $2}'` 
+grep /var/lib/kubelet /proc/mounts | awk '{print $2}' | sudo xargs -n1 umount
 sudo rm -rf /var/lib/kubelet
 ```
 


### PR DESCRIPTION
This avoids potential argument list limits when there are many mounts.