### PR TITLE
Fix service account syntax authorized.md

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -147,7 +147,7 @@ kube-system full privilege to the API, you would add this line to your policy
 file:
 
 ```json
-{"apiVersion":"abac.authorization.kubernetes.io/v1beta1","kind":"Policy","user":"system:serviceaccount:kube-system:default","namespace":"*","resource":"*","apiGroup":"*"}
+{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user": "system:serviceaccount:kube-system:default", "namespace": "*", "resource": "*", "apiGroup": "*"}}
 ```
 
 The apiserver will need to be restarted to pickup the new policy lines.


### PR DESCRIPTION
The current authorize.md incorrectly specifies the following as the correct syntax for creating a user.
{"apiVersion":"abac.authorization.kubernetes.io/v1beta1","kind":"Policy","user":"system:serviceaccount:kube-system:default","namespace":"*","resource":"*","apiGroup":"*"}

The following is the correct syntax. Tested in v1.2.2
{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user": "system:serviceaccount:kube-system:default", "namespace": "*", "resource": "*", "apiGroup": "*"}}