### PR TITLE
Inconsistent secret name in db credentials example

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -425,10 +425,10 @@ credentials.
 Make the secrets:
 
 ```shell
-$ kubectl create secret generic prod-db-password --from-literal=user=produser --from-literal=password=Y4nys7f11
-secret "prod-db-password" created
-$ kubectl create secret generic test-db-password --from-literal=user=testuser --from-literal=password=iluvtests
-secret "test-db-password" created
+$ kubectl create secret generic prod-db-secret --from-literal=user=produser --from-literal=password=Y4nys7f11
+secret "prod-db-secret" created
+$ kubectl create secret generic test-db-secret --from-literal=user=testuser --from-literal=password=iluvtests
+secret "test-db-secret" created
 ```
 
 Now make the pods:


### PR DESCRIPTION
The creation of the secret uses prod/test-db-password, but the remainder of the example uses prod/test-db-secret.