### PR TITLE
Update hellonode.md to address Connection refused

### DIFF
--- a/docs/hellonode.md
+++ b/docs/hellonode.md
@@ -103,6 +103,7 @@ Visit your app in the browser, or use `curl` or `wget` if you’d like :
 $ curl http://localhost:8080
 Hello World!
 ```
+
 **If you get a `Connection refused` message, your `DOCKER_HOST` address may be the address of your Docker VM, not the localhost address.** Use the `docker-machine ip default` command to find the Docker VM address.
 
 ```shell

--- a/docs/hellonode.md
+++ b/docs/hellonode.md
@@ -104,14 +104,7 @@ $ curl http://localhost:8080
 Hello World!
 ```
 
-**If you get a `Connection refused` message, your `DOCKER_HOST` address may be the address of your Docker VM, not the localhost address.** Use the `docker-machine ip default` command to find the Docker VM address.
-
-```shell
-$ docker-machine ip default
-192.168.1.100
-$ curl 192.168.1.100:8080
-Hello World!
-```
+**If you recieve a `Connection refused` message from Docker for Mac, ensure you are using the latest version of Docker (1.12 or later).** 
 
 Let’s now stop the container. In this example, our app was running as Docker process `2c66d0efcbd4`, which we looked up with `docker ps`:
 

--- a/docs/hellonode.md
+++ b/docs/hellonode.md
@@ -103,6 +103,14 @@ Visit your app in the browser, or use `curl` or `wget` if you’d like :
 $ curl http://localhost:8080
 Hello World!
 ```
+**If you get a `Connection refused` message, your `DOCKER_HOST` address may be the address of your Docker VM, not the localhost address.** Use the `docker-machine ip default` command to find the Docker VM address.
+
+```shell
+$ docker-machine ip default
+192.168.1.100
+$ curl 192.168.1.100:8080
+Hello World!
+```
 
 Let’s now stop the container. In this example, our app was running as Docker process `2c66d0efcbd4`, which we looked up with `docker ps`:
 


### PR DESCRIPTION
Issue #404 Connection refused due to localhost address not being docker vm address
Lines 106-114 briefly describes reason for the Connection refused error and resolution as seen in issue #404.