### PR TITLE
mark node phase as deprecated

### DIFF
--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -31,19 +31,7 @@ The usage of these fields varies depending on your cloud provider or bare metal 
 
 ### Node Phase
 
-Node Phase is the current lifecycle phase of node, one of `Pending`,
-`Running` and `Terminated`.
-
-* Pending: New nodes are created in this state. A node stays in this state until it is configured.
-
-* Running: Node has been configured and the Kubernetes components are running
-
-* Terminated: Node has been removed from the cluster. It will not receive any scheduling requests,
-and any running pods will be removed from the node.
-
-Node with `Running` phase is necessary but not sufficient requirement for
-scheduling Pods. For a node to be considered a scheduling candidate, it
-must have appropriate conditions, see below.
+Deprecated: Node Phase is no longer used
 
 ### Node Condition
 


### PR DESCRIPTION
I'm not sure on what the best wording for this should be, but `Node Phase` is no longer populated, and so the docs should say so.

@random-liu on slack/#sig-node told me that they believed node phase was unused.

cc @dawnchen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/549)
<!-- Reviewable:end -->
