### PR TITLE
Fix kubectl run syntax

### DIFF
--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -30,6 +30,14 @@ my-nginx-3800858182-wqafx           1/1       Running   0          1m
 
 Kubernetes will ensure that your application keeps running, by automatically restarting containers that fail, spreading containers across nodes, and recreating containers on new nodes when nodes fail.
 
+To expose your service to a public IP address, run:
+
+```shell
+$ kubectl expose rc my-nginx --target-port=80 --type=NodePort
+service "my-nginx" exposed
+```
+
+
 To find the public IP address assigned to your application, execute:
 
 ```shell

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -14,7 +14,7 @@ Through integration with some cloud providers (for example Google Compute Engine
 For example, [nginx](http://wiki.nginx.org/Main) is a popular HTTP server, with a [pre-built container on Docker hub](https://registry.hub.docker.com/_/nginx/). The [`kubectl run`](/docs/user-guide/kubectl/kubectl_run) command below will create two nginx replicas, listening on port 80, and a public IP address for your application.
 
 ```shell
-$ kubectl run my-nginx --image=nginx --replicas=2 --port=80 --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }'
+$ kubectl run my-nginx --image=nginx --replicas=2 --port=80 --overrides='{ "spec": { "apiVersion": "v1", "type": "LoadBalancer" } }'
 service "my-nginx" created
 deployment "my-nginx" created
 ```


### PR DESCRIPTION
Removed --expose, changed --service-overrides to --overrides,
and added apiVersion to conform to proper syntax.