### PR TITLE
Fixed links in cluster-components

### DIFF
--- a/docs/admin/cluster-components.md
+++ b/docs/admin/cluster-components.md
@@ -88,15 +88,15 @@ about containers in a central database, and provides a UI for browsing that data
 
 #### Cluster-level Logging
 
-[Container Logging](/docs/user-guide/monitoring.md) saves container logs
+[Container Logging](/docs/user-guide/monitoring) saves container logs
 to a central log store with search/browsing interface.  There are two
 implementations:
 
 * [Cluster-level logging to Google Cloud Logging](
-docs/user-guide/logging/#cluster-level-logging-to-google-cloud-logging)
+/docs/user-guide/logging/#cluster-level-logging-to-google-cloud-logging)
 
 * [Cluster-level Logging with Elasticsearch and Kibana](
-docs/getting-started-guides/logging-elasticsearch/)
+/docs/getting-started-guides/logging-elasticsearch/)
 
 ## Node components
 
@@ -138,4 +138,3 @@ running.
 ### fluentd
 
 `fluentd` is a daemon which helps provide [cluster-level logging](#cluster-level-logging).
-


### PR DESCRIPTION
Leading slash missing from two links. 
Removed redundant .md for consistency with links below.