### PR TITLE
Need export KUBERNETES_PROVIDER=local

### DIFF
--- a/docs/getting-started-guides/locally.md
+++ b/docs/getting-started-guides/locally.md
@@ -49,6 +49,7 @@ Your cluster is running, and you want to start running containers!
 You can now use any of the cluster/kubectl.sh commands to interact with your local setup.
 
 ```shell
+export KUBERNETES_PROVIDER=local
 cluster/kubectl.sh get pods
 cluster/kubectl.sh get services
 cluster/kubectl.sh get deployments


### PR DESCRIPTION
Fix #26453

Need to export KUBERNETES_PROVIDER=local before using cluster/kubectl.sh