### PR TITLE
Fix hyperkube docs

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -25,7 +25,7 @@ There are two main phases to installing the master:
 ## Setting up flanneld and etcd
 
 _Note_:
-This guide expects **Docker 1.7.1 or higher**.
+This guide expects **Docker 1.10 or higher**.
 
 ### Setup Docker Bootstrap
 
@@ -173,7 +173,7 @@ sudo docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \
     --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
     --volume=/var/run:/var/run:rw \
     --net=host \
     --privileged=true \

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -27,7 +27,7 @@ For each worker node, there are three steps:
 As before, the Flannel daemon is going to provide network connectivity.
 
 _Note_:
-This guide expects **Docker 1.7.1 or higher**.
+This guide expects **Docker 1.10 or higher**.
 
 
 #### Set up a bootstrap docker
@@ -142,7 +142,7 @@ sudo docker run \
     --volume=/sys:/sys:ro \
     --volume=/dev:/dev \
     --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
     --volume=/var/run:/var/run:rw \
     --net=host \
     --privileged=true \

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -14,7 +14,7 @@ Here's a diagram of what the final result will look like:
 
 **Note: These steps have not been tested with the [Docker For Mac or Docker For Windows beta programs](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/).**
 
-1. You need to have docker installed on one machine.
+1. You need to have docker version >= "1.10" installed on the machine.
 2. Decide what Kubernetes version to use. Set the `${K8S_VERSION}` variable to
    a released version of Kubernetes >= "v1.2.0". If you'd like to use the current stable version of Kubernetes, run the following:
 
@@ -36,7 +36,7 @@ docker run -d \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:rw \
     --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
     --volume=/var/run:/var/run:rw \
     --net=host \
     --pid=host \
@@ -178,7 +178,7 @@ docker-machine ssh `docker-machine active`
 ```
 
 ```shell
-sudo umount `cat /proc/mounts | grep /var/lib/kubelet | awk '{print $2}'` 
+sudo umount `cat /proc/mounts | grep /var/lib/kubelet | awk '{print $2}'`
 sudo rm -rf /var/lib/kubelet
 ```
 
@@ -226,4 +226,3 @@ For support level information on all solutions, see the [Table of solutions](/do
 
 Please see the [Kubernetes docs](/docs/) for more details on administering
 and using a Kubernetes cluster.
-


### PR DESCRIPTION
Kubernetes 1.3.0-alpha.5 requires to update the user guide for starting Hyperkube.

Sections:
"Running Kubernetes Locally via Docker"
"Portable Multi-Node Clusters"


Fixes https://github.com/kubernetes/kubernetes/issues/26943