### PR TITLE
Fix self-referencing link in Horizontal Pod Autoscaling doc

### DIFF
--- a/docs/user-guide/horizontal-pod-autoscaling/index.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/index.md
@@ -80,4 +80,4 @@ the horizontal pod autoscaler will not be bound to the new replication controlle
 
 * Design documentation: [Horizontal Pod Autoscaling](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/horizontal-pod-autoscaler.md).
 * Manual of autoscale command in kubectl: [kubectl autoscale](/docs/user-guide/kubectl/kubectl_autoscale).
-* Usage example of [Horizontal Pod Autoscaler](/docs/user-guide/horizontal-pod-autoscaling/).
+* Usage example of [Horizontal Pod Autoscaler](/docs/user-guide/horizontal-pod-autoscaling/walkthrough/).


### PR DESCRIPTION
The link was self-referencing. Linking the walkthrough that has actual example.