### PR TITLE
GC gc's unused images, not unreferenced

### DIFF
--- a/docs/admin/garbage-collection.md
+++ b/docs/admin/garbage-collection.md
@@ -4,7 +4,7 @@
 * TOC
 {:toc}
 
-Garbage collection is a helpful function of kubelet that will clean up unreferenced images and unused containers. kubelet will perform garbage collection for containers every minute and garbage collection for images every five minutes.
+Garbage collection is a helpful function of kubelet that will clean up unused images and unused containers. kubelet will perform garbage collection for containers every minute and garbage collection for images every five minutes.
 
 External garbage collection tools are not recommended as these tools can potentially break the behavior of kubelet by removing containers expected to exist.
 


### PR DESCRIPTION
Tags reference images but from what I see the kubelet will delete a tagged image that isn't in *use* by a container. When I first read this I took this to mean that it wouldn't GC tagged images.