### PR TITLE
add docs for recursive flag usage

### DIFF
--- a/docs/user-guide/managing-deployments.md
+++ b/docs/user-guide/managing-deployments.md
@@ -82,6 +82,49 @@ my-nginx-svc   10.0.0.208                 80/TCP       0s
 With the above commands, we first create resources under docs/user-guide/nginx/ and print the resources created with `-o name` output format 
 (print each resource as resource/name). Then we `grep` only the "service", and then print it with `kubectl get`. 
 
+If you happen to organize your resources across several subdirectories within a particular directory, you can recursively perform the operations on the subdirectories also, by specifying `--recursive` or `-R` alongside the `--filename,-f` flag.
+
+For instance, assume there is a directory `project/k8s/development` that holds all of the manifests needed for the development environment, organized by resource type:
+
+```
+project/k8s/development
+├── configmap
+│   └── my-configmap.yaml
+├── deployment
+│   └── my-deployment.yaml
+└── pvc
+    └── my-pvc.yaml
+```
+
+By default, performing a bulk operation on `project/k8s/development` will stop at the first level of the directory, not processing any subdirectories. If we tried to create the resources in this directory using the following command, we'd encounter an error: 
+
+```shell
+$ kubectl create -f project/k8s/development
+error: you must provide one or more resources by argument or filename (.json|.yaml|.yml|stdin)
+```
+
+Instead, specify the `--recursive` or `-R` flag with the `--filename,-f` flag as such:
+
+```shell
+$ kubectl create -f project/k8s/development --recursive
+configmap "my-config" created
+deployment "my-deployment" created
+persistentvolumeclaim "my-pvc" created
+```
+
+The `--recursive` flag works with any operation that accepts the `--filename,-f` flag such as: `kubectl {create,get,delete,describe,rollout} etc.`
+
+The `--recursive` flag also works when multiple `-f` arguments are provided:
+
+```shell
+$ kubectl create -f project/k8s/namespaces -f project/k8s/development --recursive
+namespace "development" created
+namespace "staging" created
+configmap "my-config" created
+deployment "my-deployment" created
+persistentvolumeclaim "my-pvc" created
+```
+
 If you're interested in learning more about `kubectl`, go ahead and read [kubectl Overview](/docs/user-guide/kubectl-overview). 
 
 ## Using labels effectively


### PR DESCRIPTION
These are the missing usage docs for the `--recursive` flag feature that was added to `kubectl` which will drop in v1.3. The overarching PR's for the `--recursive` feature are:

- https://github.com/kubernetes/kubernetes/pull/23116
- https://github.com/kubernetes/kubernetes/pull/23673
- https://github.com/kubernetes/kubernetes/pull/25110

This should make it in to v1.3