### PR TITLE
correct misspelling

### DIFF
--- a/docs/getting-started-guides/meanstack.md
+++ b/docs/getting-started-guides/meanstack.md
@@ -3,7 +3,7 @@
 
 **By: Sandeep Dinesh** - _July 29, 2015_
 
-![image](/images/docs/meanstack/image_0.png) 
+![image](/images/docs/meanstack/image_0.png)
 
 In [a recent post](http://blog.sandeepdinesh.com/2015/07/running-mean-web-application-in-docker.html), I talked about running a MEAN stack with [Docker Containers.](http://docker.com/)
 
@@ -14,7 +14,7 @@ Thankfully, there is a system we can use to manage our containers in a cluster e
 * TOC
 {:toc}
 
-## The Basics of Using Kubernetes 
+## The Basics of Using Kubernetes
 
 Before we jump in and start kube’ing it up, it’s important to understand some of the fundamentals of Kubernetes.
 
@@ -34,7 +34,7 @@ Instead, you have to build a custom container that has the code already inside i
 
 To do this, you need to use more Docker. Make sure you have the latest version installed for the rest of this tutorial.
 
-Getting the code: 
+Getting the code:
 
 Before starting, let’s get some code to run. You can follow along on your personal machine or a Linux VM in the cloud. I recommend using Linux or a Linux VM; running Docker on Mac and Windows is outside the scope of this tutorial.
 
@@ -72,7 +72,7 @@ Then, it creates a folder to store the code, `cd`s into that directory, copies t
 Finally, it specifies the command Docker should run when the container starts, which is to start the app.
 
 
-## Step 2: Building our Container 
+## Step 2: Building our Container
 
 Right now, the directory should look like this:
 
@@ -410,11 +410,11 @@ web-controller-xxxx    1/1       Running   0          1m
 
 ## Step 9: Accessing the App
 
-At this point, everything is up and running. The architecture looks something like this: 
+At this point, everything is up and running. The architecture looks something like this:
 
-![image](/images/docs/meanstack/MEANstack_architecture.svg){: style="max-width:25%"} 
+![image](/images/docs/meanstack/MEANstack_architecture.svg){: style="max-width:25%"}
 
-By default, port 80 should be open on the load balancer. In order to find the IP address of our app, run this command: 
+By default, port 80 should be open on the load balancer. In order to find the IP address of our app, run this command:
 
 ```shell
 $ gcloud compute forwarding-rules list
@@ -436,7 +436,7 @@ And the Database works!
 
 By using Container Engine and Kubernetes, we have a very robust, container based MEAN stack running in production.
 
-[In anoter post](https://medium.com/google-cloud/mongodb-replica-sets-with-kubernetes-d96606bd9474#.e93x7kuq5), I cover how to setup a MongoDB replica set. This is very important for running in production.
+[In another post](https://medium.com/google-cloud/mongodb-replica-sets-with-kubernetes-d96606bd9474#.e93x7kuq5), I cover how to setup a MongoDB replica set. This is very important for running in production.
 
 Hopefully I can do some more posts about advanced Kubernetes topics such as changing the cluster size and number of Node.js web server replicas, using different environments (dev, staging, prod) on the same cluster, and doing rolling updates.
 


### PR DESCRIPTION
At the bottom of the [MEAN stack on Google Cloud Platform](http://kubernetes.io/docs/getting-started-guides/meanstack/#final-thoughts) guide, there is a sentence:

> In anoter post, I cover how to setup a MongoDB replica set. This is very important for running in production.

The misspelling of "another" has been corrected to:

> In another post, I cover how to setup a MongoDB replica set. This is very important for running in production.

Also, a few spots of extra white space were also cleaned up.