### PR TITLE
fix typo, change base24 to base64

### DIFF
--- a/docs/user-guide/ui.md
+++ b/docs/user-guide/ui.md
@@ -100,7 +100,7 @@ track=stable
 
 - **Image Pull Secret**: In case the specified Docker container image is private, it may require [pull secret](/docs/user-guide/secrets/) credentials.
 
-  Dashboard offers all available secrets in a dropdown list, and allows you to create a new secret. The secret name must follow the DNS domain name syntax, e.g. `new.image-pull.secret`. The content of a secret must be base24-encoded and specified in a  [`.dockercfg`](/docs/user-guide/images/#specifying-imagepullsecrets-on-a-pod) file. The secret name may consist of a maximum of 253 characters.
+  Dashboard offers all available secrets in a dropdown list, and allows you to create a new secret. The secret name must follow the DNS domain name syntax, e.g. `new.image-pull.secret`. The content of a secret must be base64-encoded and specified in a  [`.dockercfg`](/docs/user-guide/images/#specifying-imagepullsecrets-on-a-pod) file. The secret name may consist of a maximum of 253 characters.
 
   In case the creation of the image pull secret is successful, it is selected by default. If the creation fails, no secret is applied.
 


### PR DESCRIPTION
The page on Web UI (http://kubernetes.io/docs/user-guide/ui/) mentions 'base24' encoding for secrets. Clearly this is a typo and the intention was to say 'base64'.