### PR TITLE
Minor changes to volume.md

### DIFF
--- a/docs/user-guide/volumes.md
+++ b/docs/user-guide/volumes.md
@@ -117,6 +117,30 @@ Watch out when using this type of volume, because:
   behave differently on different nodes due to different files on the nodes
 * when Kubernetes adds resource-aware scheduling, as is planned, it will not be
   able to account for resources used by a `hostPath`
+* the directories created on the underlying hosts are only writable by root, you either need
+  to run your process as root in a priveleged container or modify the file permissions on
+  the host to be able to write to a `hostPath` volume
+
+#### Example pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  containers:
+  - image: gcr.io/google_containers/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /test-pd
+      name: test-volume
+  volumes:
+  - name: test-volume
+    hostPath:
+      # directory location on host
+      path: /data
+```
 
 ### gcePersistentDisk
 


### PR DESCRIPTION
This patch adds additional content
to the description of the hostPath
volume type based on things that I
did not find to be clear from the
documentation.

1. included an example pod definition
in the hostPath description to demonstrate
that `path` is the name of the key to use to
specify the local directory location.

2. documented that any directories created
based on hostPath definitions will not be
writable in the container unless priveleged
is set to true.