### PR TITLE
fixit-575: typo in link to k8petstore

### DIFF
--- a/_data/samples.yml
+++ b/_data/samples.yml
@@ -76,4 +76,4 @@ toc:
   - title: Nodejs + Mongo
     path: https://github.com/kubernetes/kubernetes/tree/release-1.2/examples/nodesjs-mongodb
   - title: Petstore
-    path: https://github.com/kubernetes/kubernetes/tree/release-1.2/examples/k8spetstore/
+    path: https://github.com/kubernetes/kubernetes/tree/release-1.2/examples/k8petstore/


### PR DESCRIPTION
Small typo.

fixes #575 and some other dupes that I will mark later.

The "mistake" is actually upstream imho, but we need working docs.