### PR TITLE
Remove guide that doesn't exist from the index.

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -122,8 +122,6 @@ toc:
     path: /docs/getting-started-guides/logging/
   - title: Logging with Elasticsearch and Kibana
     path: /docs/getting-started-guides/logging-elasticsearch/
-  - title: Elasticsearch/Kibana Logging Demo
-    path: /docs/user-guide/logging-demo
   - title: Running Commands in a Container with kubectl exec
     path: /docs/user-guide/getting-into-containers/
   - title: Connect with Proxies


### PR DESCRIPTION
It's currently just a 404 and we don't really have any useful content that would belong in such a demo yet:
http://kubernetes.io/docs/user-guide/logging-demo/

@johndmulhausen 