### PR TITLE
rev version in _config.yaml to fix various docs links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ defaults:
     scope:
       path: ""
     values:
-      version: "v1.2"
-      githubbranch: "release-1.2"
+      version: "v1.3"
+      githubbranch: "release-1.3"
       docsbranch: "master"
   -
     scope:


### PR DESCRIPTION
There are a number of docs that are broken on the docs site at the moment. 

Most notably for me, the links to the configs on http://kubernetes.io/docs/getting-started-guides/openstack-heat/.

```
config-default.sh Sets all parameters needed for heat template.
config-image.sh Sets parameters needed to download and create new OpenStack image via glance.
openrc-default.sh Sets environment variables for communicating to OpenStack. These are consumed by the cli tools (heat, glance, swift, nova).
openrc-swift.sh Some OpenStack setups require the use of seperate swift credentials. Put those credentials in this file.
```

After updating the config and running the docs site locally, the links worked as expected.