### PR TITLE
Fix commands in Connect with Port Forwarding guide

### DIFF
--- a/docs/user-guide/connecting-to-applications-port-forward.md
+++ b/docs/user-guide/connecting-to-applications-port-forward.md
@@ -6,7 +6,7 @@ kubectl port-forward forwards connections to a local port to a port on a pod. It
 ## Creating a Redis master
 
 ```shell
-$ kubectl create examples/redis/redis-master.yaml
+$ kubectl create -f examples/redis/redis-master.yaml
 pods/redis-master
 ```
 
@@ -23,7 +23,7 @@ redis-master   2/2       Running   0          41s
 The Redis master is listening on port 6379, to verify this,
 
 ```shell{% raw %}
-$ kubectl get pods redis-master -t='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+$ kubectl get pods redis-master --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
 6379{% endraw %}
 ```
 


### PR DESCRIPTION
fixes:
* added -f flag to command create
* changed not existent flag -t to --template