### PR TITLE
Broken link fix on dns doc page

### DIFF
--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -41,5 +41,5 @@ details on Cluster Federation and multi-site support.
 
 ## References
 
-- [Docs for the DNS cluster addon](http://releases.k8s.io/{{page.githubbranch}}/cluster/addons/dns/README.md)
+- [Docs for the DNS cluster addon](http://releases.k8s.io/{{page.githubbranch}}/build/kube-dns/README.md)
 


### PR DESCRIPTION
Old link gives 404; the one under build/kube-dns is the most relevant I could find, but please point if it should be resolved to anything else.