### PR TITLE
docs: convert curl downloads from HTTP to HTTPS

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -90,7 +90,7 @@ http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${GO
 An example install with `linux/amd64`:
 
 ```
-curl -sSL "http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl" > /usr/bin/kubectl
+curl -sSL "https://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl" > /usr/bin/kubectl
 chmod +x /usr/bin/kubectl
 ```
 

--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -79,7 +79,7 @@ curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page
 
 The generic download path is:
 ```
-http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${GOOS}/${GOARCH}/${K8S_BINARY}
+https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${GOOS}/${GOARCH}/${K8S_BINARY}
 ```
 
 ### Starting the cluster


### PR DESCRIPTION
Several command literals in the installation documents for downloading
used `curl` with non-HTTPS protocol.  They have been converted to HTTPS
for both man-in-the-middle risk reduction and consistency with the rest
of the documentation corpus.