### PR TITLE
Add one-line installation for kubectl in minikube guide

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -51,37 +51,35 @@ Minikube requires one of the following:
 * The latest [Virtualbox](https://www.virtualbox.org/wiki/Downloads).
 * The latest version of [VMWare Fusion](https://www.vmware.com/products/fusion).
 
-### Installation
+### Install `minikube`
 
 See the [latest Minikube release](https://github.com/kubernetes/minikube/releases) for installation instructions.
 
-### Download `kubectl`
+### Install `kubectl`
 
-You will need to download the kubectl client binary for `${K8S_VERSION}` (in this example: `{{page.version}}.0`)
+You will need to download and install the kubectl client binary for `${K8S_VERSION}` (in this example: `{{page.version}}.0`)
 to run commands against the cluster.
 
-Downloads:
-
- - `linux/amd64`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl
- - `linux/386`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/386/kubectl
- - `linux/arm`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/arm/kubectl
- - `linux/arm64`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/arm64/kubectl
- - `linux/ppc64le`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/ppc64le/kubectl
- - `OS X/amd64`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/amd64/kubectl
- - `OS X/386`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/386/kubectl
- - `windows/amd64`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/windows/amd64/kubectl.exe
- - `windows/386`: http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/windows/386/kubectl.exe
+```shell
+# linux/amd64
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# linux/386
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/386/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# linux/arm
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/arm/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# linux/arm64
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/arm64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+#linux/ppc64le
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/ppc64le/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# OS X/amd64 
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# OS X/386 
+curl -Lo kubectl http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/darwin/386/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+```
 
 The generic download path is:
 ```
 http://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${GOOS}/${GOARCH}/${K8S_BINARY}
-```
-
-An example install with `linux/amd64`:
-
-```
-curl -sSL "http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl" > /usr/bin/kubectl
-chmod +x /usr/bin/kubectl
 ```
 
 ### Starting the cluster


### PR DESCRIPTION
Addressed several things:

1. Fix that `curl -sSL "http://storage.googleapis.com/kubernetes-release/release/{{page.version}}.0/bin/linux/amd64/kubectl" > /usr/bin/kubectl` requires root permission (and adding `sudo` doesn't work)
2. Fix that can't just copy & paste commands to download & install kubectl 
3. Change path from /usr/bin/kubectl to /usr/local/bin/kubectl 
4. Removed kubectl installation on Windows since it's not supported by minikube 

Preview: http://janetkuo.github.io/docs/getting-started-guides/minikube/

@jlowdermilk @dlorenc @kubernetes/docs 