### PR TITLE
update the gcloud command example since

### DIFF
--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -103,7 +103,7 @@ to the corresponding `gcloud` commands.
 
 Examples:
 ```shell
-gcloud container clusters create mytestcluster --zone=us-central1-b --enable-autoscaling=true --min-nodes=3 --max-nodes=10 --num-nodes=5
+gcloud container clusters create mytestcluster --zone=us-central1-b --enable-autoscaling --min-nodes=3 --max-nodes=10 --num-nodes=5
 ```
 
 ```shell


### PR DESCRIPTION
It doesn't accept assigning a value.

[13:48:57] $ gcloud container clusters create test-single2   --zone=us-central1-b --enable-autoscaling=true --min-nodes=1 --max-nodes=9 --num-nodes=1 
usage: gcloud container clusters create  NAME [optional flags]
ERROR: (gcloud.container.clusters.create) argument --enable-autoscaling: ignored explicit argument 'true'