### PR TITLE
CMD syntax is invalid

### DIFF
--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -362,7 +362,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh", "cat", "/etc/config/special.how" ]
+      command: [ "/bin/sh", "cat /etc/config/special.how" ]
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config
@@ -390,7 +390,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh", "cat", "/etc/config/path/to/special-key" ]
+      command: [ "/bin/sh", "cat /etc/config/path/to/special-key" ]
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config


### PR DESCRIPTION
Argument to 'cat' command was lost.  Merged 'cat' and args for exec command syntax.