### PR TITLE
Use correct API group name for RBAC.

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -175,7 +175,7 @@ As of 1.3 RBAC mode is in alpha and considered experimental.
 To use RBAC, you must both enable the authorization module with `--authorization-mode=RBAC`,
 and [enable the API version](
 docs/admin/cluster-management.md/#Turn-on-or-off-an-api-version-for-your-cluster),
-with a `--runtime-config=` that includes `rbac.authorization/v1alpha1`.
+with a `--runtime-config=` that includes `rbac.authorization.k8s.io/v1alpha1`.
 
 ### Roles, RolesBindings, ClusterRoles, and ClusterRoleBindings
 


### PR DESCRIPTION
The API group name for RBAC, as passed to the apiserver's `--runtime-config` option, is currently incorrect and will cause the apiserver to fail to boot.