### PR TITLE
Add John's Dockerfile and promote the docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# A Dockerfile for testing docs changes.
+#
+# Image available on Docker Hub: https://hub.docker.com/r/johndmulhausen/k8sdocs/
+#
+# Run with:
+# docker run -ti --rm -v "$PWD":/k8sdocs -p 4000:4000 johndmulhausen/k8sdocs
+# The site will be automatically updated as you make changes!
+
+FROM starefossen/ruby-node:2-4
+
+RUN gem install github-pages
+
+VOLUME /k8sdocs
+
+EXPOSE 4000
+
+WORKDIR /k8sdocs
+
+CMD jekyll clean && jekyll serve -H 0.0.0.0 -P 4000
+
+# For more instructions, see http://kubernetes.io/editdocs/

--- a/README.md
+++ b/README.md
@@ -11,21 +11,29 @@ change the name of the fork to be:
 
     YOUR_GITHUB_USERNAME.github.io
 
-Then make your changes. 
+Then make your changes.
 
 When you visit [http://YOUR_GITHUB_USERNAME.github.io](http://YOUR_GITHUB_USERNAME.github.io) you should see a special-to-you version of the site that contains the changes you just made.
 
 ## Staging the site locally (using Docker)
 
-Don't like installing stuff? Download and run a local staging server with a single `docker run` command. 
+Download and run a local staging server with a single `docker run` command.
 
-    git clone https://github.com/kubernetes/kubernetes.github.io.git
-    cd kubernetes.github.io
-    docker run -ti --rm -v "$PWD":/k8sdocs -p 4000:4000 johndmulhausen/k8sdocs
+```shell
+git clone https://github.com/kubernetes/kubernetes.github.io.git
+cd kubernetes.github.io
+docker run -ti --rm -v "$PWD":/k8sdocs -p 4000:4000 johndmulhausen/k8sdocs
+```
 
-Then visit [http://localhost:4000](http://localhost:4000) to see our site. Any changes you make on your local machine will be automatically staged.
+Then visit [http://localhost:4000](http://localhost:4000) to see our site. Any
+changes you make on your local machine will be automatically staged.
 
-If you're interested you can view [the Dockerfile for this image](https://gist.github.com/johndmulhausen/f8f0ab8d82d2c755af3a4709729e1859).
+If you'd like the build the image, you can build the `Dockerfile` at the top
+directory with
+
+```shell
+docker build -t k8sdocs
+```
 
 ## Staging the site locally (from scratch setup)
 
@@ -43,7 +51,7 @@ Install Ruby 2.2 or higher. If you're on a Mac, follow [these instructions](http
 
 Install the GitHub Pages package, which includes Jekyll:
 
-	gem install github-pages
+    gem install github-pages
 
 Clone our site:
 
@@ -51,8 +59,8 @@ Clone our site:
 
 Make any changes you want. Then, to see your changes locally:
 
-	cd kubernetes.github.io
-	jekyll serve
+    cd kubernetes.github.io
+    jekyll serve
 
 Your copy of the site will then be viewable at: [http://localhost:4000](http://localhost:4000)
 (or wherever Jekyll tells you).


### PR DESCRIPTION
Using the Dockerfile is the most cross platform way to run the website. For Docs, especially instructions, less is more! Now there is a single cross-platform way of running the docs.