### PR TITLE
Add line break between commands

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -66,6 +66,7 @@ You can check that the secret was created like this:
 $ kubectl get secrets
 NAME                  TYPE                                  DATA      AGE
 db-user-pass          Opaque                                2         51s
+
 $ kubectl describe secrets/db-user-pass
 Name:		db-user-pass
 Namespace:	default


### PR DESCRIPTION
Currently the second command seems to "disappear" between the two outputs. This change tries to mitigate it.