### PR TITLE
Fix decode flag

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -154,7 +154,7 @@ type: Opaque
 Decode the password field:
 
 ```shell
-$ echo "MWYyZDFlMmU2N2Rm" | base64 -D
+$ echo "MWYyZDFlMmU2N2Rm" | base64 -d
 1f2d1e2e67df
 ```
 


### PR DESCRIPTION
I'm on Ubuntu 14.04 and `-D` is invalid. 
`-d` gets the required output.