### PR TITLE
missing "etcd" package in yum command

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -39,7 +39,7 @@ gpgcheck=0
 * Install Kubernetes on all hosts - centos-{master,minion}.  This will also pull in etcd, docker, and cadvisor.
 
 ```shell
-yum -y install --enablerepo=virt7-docker-common-release kubernetes
+yum -y install --enablerepo=virt7-docker-common-release kubernetes etcd
 ```
 
 * Add master and node to /etc/hosts on all machines (not needed if hostnames already in DNS)


### PR DESCRIPTION
If there is no "etcd" package in yum command, it won't be installed automatically.