### PR TITLE
Update DaemonSet docs about node affinity

### DIFF
--- a/docs/admin/daemons.md
+++ b/docs/admin/daemons.md
@@ -71,9 +71,11 @@ a node for testing.
 
 If you specify a `.spec.template.spec.nodeSelector`, then the DaemonSet controller will
 create pods on nodes which match that [node
-selector](https://github.com/kubernetes/kubernetes.github.io/tree/{{page.docsbranch}}/docs/user-guide/node-selection).
+selector](https://github.com/kubernetes/kubernetes.github.io/tree/{{page.docsbranch}}/docs/user-guide/node-selection).  
+If you specify a `scheduler.alpha.kubernetes.io/affinity` annotation in `.spec.template.metadata.annotations`,
+then DaemonSet controller will create pods on nodes which match that [node affinity](../../user-guide/node-selection/#alpha-feature-in-kubernetes-v12-node-affinity).
 
-If you do not specify a `.spec.template.spec.nodeSelector`, then the DaemonSet controller will
+If you do not specify a `.spec.template.spec.nodeSelector` nor `node affinity`, then the DaemonSet controller will
 create pods on all nodes.
 
 ## How Daemon Pods are Scheduled


### PR DESCRIPTION
After merging kubernetes/kubernetes#28803 DaemonSets can also
be scheduled using node affinity.