### PR TITLE
I fixed typo on command line

### DIFF
--- a/docs/user-guide/working-with-resources.md
+++ b/docs/user-guide/working-with-resources.md
@@ -28,7 +28,7 @@ spec:
 EOF
 $ kubectl create -f /tmp/original.yaml
 pods/original
-$ kubectl get pods/original -o yaml > /tmp/current.yaml
+$ kubectl get pods/foo -o yaml > /tmp/current.yaml
 pods/original
 $ wc -l /tmp/original.yaml /tmp/current.yaml
       51 /tmp/current.yaml


### PR DESCRIPTION
If you actually issue these commands you will see the error I am fixing

old :    kubectl get pods/original -o yaml > /tmp/current.yaml
           Error from server: pods "original" not found

new :  kubectl get pods/foo -o yaml > /tmp/current.yaml

previously the pod name was wrong