### PR TITLE
Fix hyperkube docs-v2

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -16,58 +16,79 @@ Here's a diagram of what the final result will look like:
 
 **Note: These steps have not been tested with the [Docker For Mac or Docker For Windows beta programs](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/).**
 
-1. You need to have docker installed on one machine.
-2. Decide what Kubernetes version to use. Set the `${K8S_VERSION}` variable to
-   a released version of Kubernetes >= "v1.2.0". If you'd like to use the current stable version of Kubernetes, run the following:
+1. You need to have Docker version >= "1.10" installed on the machine.
+2. Enable mount propagation. Hyperkube is running in a container which has to mount volumes for other containers, for example in case of persistent storage. The required steps depend on the init system.
 
-```sh
-export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-```
 
-and for the latest available version (including unstable releases):
+  In case of **systemd**, change MountFlags in the Docker unit file to shared.
+  ```shell
+    DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
+    sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+    systemctl daemon-reload
+    systemctl restart docker
+  ```
 
-```sh
-export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/latest.txt)
-```
+  **Otherwise**, manually set the mount point used by Hyperkube to be shared:
+  ```shell
+    mkdir -p /var/lib/kubelet
+    mount --bind /var/lib/kubelet /var/lib/kubelet
+    mount --make-shared /var/lib/kubelet
+  ```
+
 
 ### Run it
 
-```shell
-export ARCH=amd64
-docker run -d \
-    --volume=/:/rootfs:ro \
-    --volume=/sys:/sys:rw \
-    --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
-    --volume=/var/run:/var/run:rw \
-    --net=host \
-    --pid=host \
-    --privileged \
-    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
-    /hyperkube kubelet \
-        --containerized \
-        --hostname-override=127.0.0.1 \
-        --api-servers=http://localhost:8080 \
-        --config=/etc/kubernetes/manifests \
-        --cluster-dns=10.0.0.10 \
-        --cluster-domain=cluster.local \
-        --allow-privileged --v=2
-```
+1. Decide which Kubernetes version to use. Set the `${K8S_VERSION}` variable to a version of Kubernetes >= "v1.2.0".
 
-> Note that `--cluster-dns` and `--cluster-domain` is used to deploy dns, feel free to discard them if dns is not needed.
 
-> If you would like to mount an external device as a volume, add `--volume=/dev:/dev` to the command above. It may however, cause some problems described in [#18230](https://github.com/kubernetes/kubernetes/issues/18230)
+  If you'd like to use the current **stable** version of Kubernetes, run the following:
 
-> Architectures other than `amd64` are experimental and sometimes unstable, but feel free to try them out! Valid values: `arm`, `arm64` and `ppc64le`. ARM is available with Kubernetes version `v1.3.0-alpha.2` and higher. ARM 64-bit and PowerPC 64 little-endian are available with `v1.3.0-alpha.3` and higher. Track progress on multi-arch support [here](https://github.com/kubernetes/kubernetes/issues/17981)
+  ```sh
+  export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+  ```
 
-> If you are behind a proxy, you need to pass the proxy setup to curl in the containers to pull the certificates. Create a .curlrc under /root folder (because the containers are running as root) with the following line:
-```
-proxy = <your_proxy_server>:<port>
-```
+  and for the **latest** available version (including unstable releases):
 
-This actually runs the kubelet, which in turn runs a [pod](/docs/user-guide/pods/) that contains the other master components.
+  ```sh
+  export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/latest.txt)
+  ```
 
-** **SECURITY WARNING** ** services exposed via Kubernetes using Hyperkube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
+2. Start Hyperkube
+
+  ```shell
+  export ARCH=amd64
+  docker run -d \
+      --volume=/sys:/sys:rw \
+      --volume=/var/lib/docker/:/var/lib/docker:rw \
+      --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+      --volume=/var/run:/var/run:rw \
+      --net=host \
+      --pid=host \
+      --privileged \
+      gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+      /hyperkube kubelet \
+          --hostname-override=127.0.0.1 \
+          --api-servers=http://localhost:8080 \
+          --config=/etc/kubernetes/manifests \
+          --cluster-dns=10.0.0.10 \
+          --cluster-domain=cluster.local \
+          --allow-privileged --v=2
+  ```
+
+  > Note that `--cluster-dns` and `--cluster-domain` is used to deploy dns, feel free to discard them if dns is not needed.
+
+  > If you would like to mount an external device as a volume, add `--volume=/dev:/dev` to the command above. It may however, cause some problems described in [#18230](https://github.com/kubernetes/kubernetes/issues/18230)
+
+  > Architectures other than `amd64` are experimental and sometimes unstable, but feel free to try them out! Valid values: `arm`, `arm64` and `ppc64le`. ARM is available with Kubernetes version `v1.3.0-alpha.2` and higher. ARM 64-bit and PowerPC 64 little-endian are available with `v1.3.0-alpha.3` and higher. Track progress on multi-arch support [here](https://github.com/kubernetes/kubernetes/issues/17981)
+
+  > If you are behind a proxy, you need to pass the proxy setup to curl in the containers to pull the certificates. Create a .curlrc under /root folder (because the containers are running as root) with the following line:
+  ```
+  proxy = <your_proxy_server>:<port>
+  ```
+
+  This actually runs the kubelet, which in turn runs a [pod](/docs/user-guide/pods/) that contains the other master components.
+
+  ** **SECURITY WARNING** ** services exposed via Kubernetes using Hyperkube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
 
 ### Download `kubectl`
 
@@ -229,4 +250,3 @@ For support level information on all solutions, see the [Table of solutions](/do
 
 Please see the [Kubernetes docs](/docs/) for more details on administering
 and using a Kubernetes cluster.
-


### PR DESCRIPTION
I deleted my doc-fork and was not able to recover my old PR. This is the continuation of 

https://github.com/kubernetes/kubernetes.github.io/pull/634

-------------------------------------------
Original description:


Kubernetes 1.3.0-alpha.5 requires to update the user guide for starting Hyperkube.

Sections:
"Running Kubernetes Locally via Docker"
"Portable Multi-Node Clusters"

Fixes kubernetes/kubernetes#26943

--------------------------------------------------
CC @luxas 