### PR TITLE
Resized images in the services and horizontal-pod-autoscaling pages.

### DIFF
--- a/docs/user-guide/horizontal-pod-autoscaling/index.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/index.md
@@ -16,7 +16,7 @@ to match the observed average CPU utilization to the target specified by user.
 
 ## How does the Horizontal Pod Autoscaler work?
 
-![Horizontal Pod Autoscaler diagram](/images/docs/horizontal-pod-autoscaler.svg)
+![Horizontal Pod Autoscaler diagram](/images/docs/horizontal-pod-autoscaler.svg){:height="600" width="600"}
 
 The autoscaler is implemented as a control loop.
 It periodically queries CPU utilization for the pods it targets.

--- a/docs/user-guide/services/index.md
+++ b/docs/user-guide/services/index.md
@@ -175,7 +175,7 @@ By default, the choice of backend is round robin.  Client-IP based session affin
 can be selected by setting `service.spec.sessionAffinity` to `"ClientIP"` (the
 default is `"None"`).
 
-![Services overview diagram for userspace proxy](/images/docs/services-userspace-overview.svg)
+![Services overview diagram for userspace proxy](/images/docs/services-userspace-overview.svg){:height="500" width="500"}
 
 ### Proxy-mode: iptables
 
@@ -198,7 +198,7 @@ userspace proxier, the iptables proxier cannot automatically retry another
 `Pod` if the one it initially selects does not respond, so it depends on
 having working [readiness probes](/docs/user-guide/production-pods/#liveness-and-readiness-probes-aka-health-checks).
 
-![Services overview diagram for iptables proxy](/images/docs/services-iptables-overview.svg)
+![Services overview diagram for iptables proxy](/images/docs/services-iptables-overview.svg){:height="500" width="500"}
 
 ## Multi-Port Services
 


### PR DESCRIPTION
The images rendered full-size previously and occupied way too much space on a page.

See: 
- http://kubernetes.io/docs/user-guide/services/#proxy-mode-userspace
- http://kubernetes.io/docs/user-guide/horizontal-pod-autoscaling/