### PR TITLE
Update networkpolicies.md

### DIFF
--- a/docs/user-guide/networkpolicies.md
+++ b/docs/user-guide/networkpolicies.md
@@ -40,9 +40,7 @@ metadata:
 
 To configure the annotation via `kubectl`:
 
-```shell{% raw %}
-kubectl annotate ns <namespace> "net.beta.kubernetes.io/network-policy={\"ingress\": {\"isolation\": \"DefaultDeny\"}}"
-{% endraw %}```
+`kubectl annotate ns <namespace> "net.beta.kubernetes.io/network-policy={\"ingress\": {\"isolation\": \"DefaultDeny\"}}"`
 
 ## The `NetworkPolicy` Resource
 


### PR DESCRIPTION
For the kubectl command to add an annotation to an existing namespace, the block `shell{% raw %} kubectl annotate ns <namespace> "net.beta.kubernetes.io/network-policy={\"ingress\": {\"isolation\": \"DefaultDeny\"}} {% endraw %}"`  will render to `kubectl annotate ns <namespace> "net.beta.kubernetes.io/networkpolicy={\"ingress\": {\"isolation\": \"DefaultDeny\"}}` NOT `kubectl annotate ns <namespace> "net.beta.kubernetes.io/network-policy={\"ingress\": {\"isolation\": \"DefaultDeny\"}}`.  (Notice the lack of the hyphen between network and policy)