### PR TITLE
Fixes bad label reference in "Creating a Service" section of connecting-applications.md

### DIFF
--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -59,7 +59,7 @@ This is equivalent to `kubectl create -f` the following yaml:
 
 {% include code.html language="yaml" file="nginx-svc.yaml" ghlink="/docs/user-guide/nginx-svc.yaml" %}
 
-This specification will create a Service which targets TCP port 80 on any Pod with the `app=nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](/docs/api-reference/v1/definitions/#_v1_service) to see the list of supported fields in service definition.
+This specification will create a Service which targets TCP port 80 on any Pod with the `run: my-nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](/docs/api-reference/v1/definitions/#_v1_service) to see the list of supported fields in service definition.
 Check your Service:
 
 ```shell


### PR DESCRIPTION
My assumption here is that the linked service yaml file (`nginx-svc.yaml`) is correct and the text that refers to the contents of that file is incorrect. 

If that assumption is false, the `nginx-svc.yaml` file should be changed instead. But I suspect it is linked into multiple other docs and that this issue is the result of someone updating the file without updating all docs that reference it.