### PR TITLE
Update vsphere tutorial to reflect non-free requirement

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -11,7 +11,7 @@ convenient).
 
 ### Prerequisites
 
-1. You need administrator credentials to an ESXi machine or vCenter instance.
+1. You need administrator credentials to an ESXi machine or vCenter instance with write mode api access enabled (not available on the free ESXi license).
 2. You must have Go (see [here](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/docs/devel/development.md#go-versions) for supported versions) installed: [www.golang.org](http://www.golang.org).
 3. You must have your `GOPATH` set up and include `$GOPATH/bin` in your `PATH`.
 


### PR DESCRIPTION
The guide updated in this commit does not work for the free version of ESXi due to the fact that any write operation fails with the error message "Current license or ESXi version prohibits execution of the requested operation."  See http://www.doublecloud.org/2011/01/free-esxi-and-apicli-support/ for discussion on the limitations of vSphere's API.