### PR TITLE
Added named port to liveness example

### DIFF
--- a/docs/user-guide/liveness/http-liveness-named-port.yaml
+++ b/docs/user-guide/liveness/http-liveness-named-port.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness
+  name: liveness-http
+spec:
+  containers:
+  - args:
+    - /server
+    image: gcr.io/google_containers/liveness
+    ports:
+     - name: liveness-port
+       containerPort: 8080
+       hostPort: 8080
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: liveness-port
+        httpHeaders:
+          - name: X-Custom-Header
+            value: Awesome
+      initialDelaySeconds: 15
+      timeoutSeconds: 1
+    name: liveness

--- a/docs/user-guide/liveness/index.md
+++ b/docs/user-guide/liveness/index.md
@@ -24,6 +24,13 @@ The [http-liveness.yaml](/docs/user-guide/liveness/http-liveness.yaml) demonstra
 
 The Kubelet sends an HTTP request to the specified path and port to perform the health check. If you take a look at image/server.go, you will see the server starts to respond with an error code 500 after 10 seconds, so the check fails. The Kubelet sends probes to the container's IP address, unless overridden by the optional `host` field in httpGet. If the container listens on `127.0.0.1` and `hostNetwork` is `true` (i.e., it does not use the pod-specific network), then `host` should be specified as `127.0.0.1`. Be warned that, outside of less common cases like that, `host` does probably not result in what you would expect. If you set it to a non-existing hostname (or your competitor's!), probes will never reach the pod, defeating the whole point of health checks. If your pod relies on e.g. virtual hosts, which is probably the more common case, you should not use `host`, but rather set the `Host` header in `httpHeaders`.
 
+### Using a named port for liveness probes
+
+You can also use a named `ContainerPort` for HTTP liveness checks. 
+
+The [http-liveness-named-port.yaml](/docs/user-guide/liveness/http-liveness-named-port.yaml) demonstrates the named-port HTTP check.
+{% include code.html language="yaml" file="http-liveness-named-port.yaml" ghlink="/docs/user-guide/liveness/http-liveness-named-port.yaml" %}
+
 This [guide](/docs/user-guide/walkthrough/k8s201/#health-checking) has more information on health checks.
 
 ## Get your hands dirty


### PR DESCRIPTION
The docs only showed an integer port example. This docs addition shows how a named `ContainerPort` can also be used.

@justinsb Thanks for your help earlier. PTAL?