### PR TITLE
fix rendering issue of docker.md

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -21,80 +21,86 @@ Here's a diagram of what the final result will look like:
 
 **Note: These steps have not been tested with the [Docker For Mac or Docker For Windows beta programs](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/).**
 
-1. You need to have Docker version >= "1.10" installed on the machine.
-2. Enable mount propagation. Hyperkube is running in a container which has to mount volumes for other containers, for example in case of persistent storage. The required steps depend on the init system.
+1) You need to have Docker version >= "1.10" installed on the machine.
+
+2) Enable mount propagation. Hyperkube is running in a container which has to mount volumes for other containers, for example in case of persistent storage. The required steps depend on the init system.
 
 
-  In case of **systemd**, change MountFlags in the Docker unit file to shared.
-  ```shell
-    DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
-    sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-    systemctl daemon-reload
-    systemctl restart docker
-  ```
+In case of **systemd**, change MountFlags in the Docker unit file to shared.
 
-  **Otherwise**, manually set the mount point used by Hyperkube to be shared:
-  ```shell
-    mkdir -p /var/lib/kubelet
-    mount --bind /var/lib/kubelet /var/lib/kubelet
-    mount --make-shared /var/lib/kubelet
-  ```
+```shell
+  DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
+  sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+  systemctl daemon-reload
+  systemctl restart docker
+```
+
+**Otherwise**, manually set the mount point used by Hyperkube to be shared:
+
+```shell
+  mkdir -p /var/lib/kubelet
+  mount --bind /var/lib/kubelet /var/lib/kubelet
+  mount --make-shared /var/lib/kubelet
+```
 
 
 ### Run it
 
-1. Decide which Kubernetes version to use. Set the `${K8S_VERSION}` variable to a version of Kubernetes >= "v1.2.0".
+#### Step 1: Decide which Kubernetes version to use
+
+Set the `${K8S_VERSION}` variable to a version of Kubernetes >= "v1.2.0".
 
 
-  If you'd like to use the current **stable** version of Kubernetes, run the following:
+If you'd like to use the current **stable** version of Kubernetes, run the following:
 
-  ```sh
-  export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-  ```
+```sh
+export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+```
 
-  and for the **latest** available version (including unstable releases):
+and for the **latest** available version (including unstable releases):
 
-  ```sh
-  export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/latest.txt)
-  ```
+```sh
+export K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/latest.txt)
+```
 
-2. Start Hyperkube
+#### Step 2: Start Hyperkube
 
-  ```shell
-  export ARCH=amd64
-  docker run -d \
-      --volume=/sys:/sys:rw \
-      --volume=/var/lib/docker/:/var/lib/docker:rw \
-      --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
-      --volume=/var/run:/var/run:rw \
-      --net=host \
-      --pid=host \
-      --privileged \
-	  --name=kubelet \
-      gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
-      /hyperkube kubelet \
-          --hostname-override=127.0.0.1 \
-          --api-servers=http://localhost:8080 \
-          --config=/etc/kubernetes/manifests \
-          --cluster-dns=10.0.0.10 \
-          --cluster-domain=cluster.local \
-          --allow-privileged --v=2
-  ```
+```shell
+export ARCH=amd64
+docker run -d \
+    --volume=/sys:/sys:rw \
+    --volume=/var/lib/docker/:/var/lib/docker:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+    --volume=/var/run:/var/run:rw \
+    --net=host \
+    --pid=host \
+    --privileged \
+  --name=kubelet \
+    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    /hyperkube kubelet \
+        --hostname-override=127.0.0.1 \
+        --api-servers=http://localhost:8080 \
+        --config=/etc/kubernetes/manifests \
+        --cluster-dns=10.0.0.10 \
+        --cluster-domain=cluster.local \
+        --allow-privileged --v=2
+```
 
-  > Note that `--cluster-dns` and `--cluster-domain` is used to deploy dns, feel free to discard them if dns is not needed.
+> Note that `--cluster-dns` and `--cluster-domain` is used to deploy dns, feel free to discard them if dns is not needed.
 
-  > If you would like to mount an external device as a volume, add `--volume=/dev:/dev` to the command above. It may however, cause some problems described in [#18230](https://github.com/kubernetes/kubernetes/issues/18230)
+> If you would like to mount an external device as a volume, add `--volume=/dev:/dev` to the command above. It may however, cause some problems described in [#18230](https://github.com/kubernetes/kubernetes/issues/18230)
 
-  > Architectures other than `amd64` are experimental and sometimes unstable, but feel free to try them out! Valid values: `arm`, `arm64` and `ppc64le`. ARM is available with Kubernetes version `v1.3.0-alpha.2` and higher. ARM 64-bit and PowerPC 64 little-endian are available with `v1.3.0-alpha.3` and higher. Track progress on multi-arch support [here](https://github.com/kubernetes/kubernetes/issues/17981)
+> Architectures other than `amd64` are experimental and sometimes unstable, but feel free to try them out! Valid values: `arm`, `arm64` and `ppc64le`. ARM is available with Kubernetes version `v1.3.0-alpha.2` and higher. ARM 64-bit and PowerPC 64 little-endian are available with `v1.3.0-alpha.3` and higher. Track progress on multi-arch support [here](https://github.com/kubernetes/kubernetes/issues/17981)
 
-  > If you are behind a proxy, you need to pass the proxy setup to curl in the containers to pull the certificates. Create a .curlrc under /root folder (because the containers are running as root) with the following line:
-  ```
-  proxy = <your_proxy_server>:<port>
-  ```
+> If you are behind a proxy, you need to pass the proxy setup to curl in the containers to pull the certificates. Create a .curlrc under /root folder (because the containers are running as root) with the following line:
+```
+proxy = <your_proxy_server>:<port>
+```
 
-  This actually runs the kubelet, which in turn runs a [pod](/docs/user-guide/pods/) that contains the other master components.
+This actually runs the kubelet, which in turn runs a [pod](/docs/user-guide/pods/) that contains the other master components.
 
-  ** **SECURITY WARNING** ** services exposed via Kubernetes using Hyperkube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
+**SECURITY WARNING**: Services exposed via Kubernetes using Hyperkube are available on the host node's public network interface / IP address.  Because of this, this guide is not suitable for any host node/server that is directly internet accessible.  Refer to [#21735](https://github.com/kubernetes/kubernetes/issues/21735) for addtional info.
+
 
 ### Download `kubectl`
 


### PR DESCRIPTION
The docker getting started guide seemed to be correct when rending it in github. However, page layout was broken on kubernetes.io (line breaks missing, numbering not correct)

I changed the page structure a bit to work-around the layout problems