### PR TITLE
Replace "rc" with "deployment" in expose command in Quick Start

### DIFF
--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -25,7 +25,7 @@ deployment "my-nginx" created
 To expose your service to the public internet, run:
 
 ```shell
-$ kubectl expose rc my-nginx --target-port=80 --type=LoadBalancer
+$ kubectl expose deployment my-nginx --target-port=80 --type=LoadBalancer
 service "my-nginx" exposed
 ```
 


### PR DESCRIPTION
According to http://kubernetes.io/docs/user-guide/docker-cli-to-kubectl/, since version 1.2, `run` creates a deployment rather than a replication controller