### PR TITLE
Update volume specification for vSphere in volumes.md

### DIFF
--- a/docs/user-guide/volumes.md
+++ b/docs/user-guide/volumes.md
@@ -478,7 +478,7 @@ spec:
   volumes:
   - name: test-volume
     # This VMDK volume must already exist.
-    vsphereVirtualDisk:
+    vsphereVolume:
       volumePath: myDisk
       fsType: ext4
 ```


### PR DESCRIPTION
Fixes ```error validating data: found invalid field vsphereVirtualDisk for v1.Volume; if you choose to ignore these errors, turn validation off with --validate=false```