### PR TITLE
Fix dead link from reference to "nodes"

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,7 +20,7 @@ In the reference section, you can find reference documentation for Kubernetes AP
 
 ## Glossary
 
-Explore the glossary of essential Kubernetes concepts. Some good starting points are the entries for [Pods](/docs/user-guide/pods/), [Nodes](/docs/admin/nodes/), [Services](/docs/user-guide/services/), and [Replication Controllers](/docs/user-guide/replication-controller/).
+Explore the glossary of essential Kubernetes concepts. Some good starting points are the entries for [Pods](/docs/user-guide/pods/), [Nodes](/docs/admin/node.md), [Services](/docs/user-guide/services/), and [Replication Controllers](/docs/user-guide/replication-controller/).
 
 ## Design Docs
 


### PR DESCRIPTION
Fixes #561.

(The proposed change will work both on GitHub directly and on the rendered page where http://kubernetes.io/docs/admin/node.md will redirect to http://kubernetes.io/docs/admin/node/. Omitting the .md will spare the redirect, but does not work on GitHub directly anymore).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1031)
<!-- Reviewable:end -->
