### PR TITLE
Corrected `INSTANCE_PREFIX` usage

### DIFF
--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -50,7 +50,7 @@ export MASTER_SIZE=m3.medium
 export NODE_SIZE=m3.medium
 export AWS_S3_REGION=eu-west-1
 export AWS_S3_BUCKET=mycompany-kubernetes-artifacts
-export INSTANCE_PREFIX=k8s
+export KUBE_AWS_INSTANCE_PREFIX=k8s
 ...
 ```
 


### PR DESCRIPTION
`INSTANCE_PREFIX` environment variable is being overwritten by `KUBE_AWS_INSTANCE_PREFIX` environment variable or defaulting to `kubernetes`, see https://github.com/kubernetes/kubernetes/blob/59628744141bb6debd4ac042882ffa6855d846ce/cluster/aws/config-default.sh#L66

```bash
INSTANCE_PREFIX="${KUBE_AWS_INSTANCE_PREFIX:-kubernetes}"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1045)
<!-- Reviewable:end -->
