### PR TITLE
Fix link to docker reference on runtime privilege

### DIFF
--- a/docs/user-guide/containers.md
+++ b/docs/user-guide/containers.md
@@ -51,7 +51,7 @@ Here are examples for these rules in table format
 
 ## Capabilities
 
-By default, Docker containers are "unprivileged" and cannot, for example, run a Docker daemon inside a Docker container. We can have fine grain control over the capabilities using cap-add and cap-drop.More details [here](https://docs.docker.com/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration).
+By default, Docker containers are "unprivileged" and cannot, for example, run a Docker daemon inside a Docker container. We can have fine grain control over the capabilities using cap-add and cap-drop. More details [here](https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities).
 
 The relationship between Docker's capabilities and [Linux capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html)
 


### PR DESCRIPTION
Fixes the link to point to the right anchor. Also adds white space after period.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1068)
<!-- Reviewable:end -->
