### PR TITLE
Remove deprecated namespace admission plug-ins

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -117,21 +117,6 @@ When the plug-in sets a compute resource request, it annotates the pod with info
 
 See the [InitialResouces proposal](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/proposals/initial-resources.md) for more details.
 
-### NamespaceExists (deprecated)
-
-This plug-in will observe all incoming requests that attempt to create a resource in a Kubernetes `Namespace`
-and reject the request if the `Namespace` was not previously created.  We strongly recommend running
-this plug-in to ensure integrity of your data.
-
-The functionality of this admission controller has been merged into `NamespaceLifecycle`
-
-### NamespaceAutoProvision (deprecated)
-
-This plug-in will observe all incoming requests that attempt to create a resource in a Kubernetes `Namespace`
-and create a new `Namespace` if one did not already exist previously.
-
-We strongly recommend `NamespaceLifecycle` over `NamespaceAutoProvision`.
-
 ### NamespaceLifecycle
 
 This plug-in enforces that a `Namespace` that is undergoing termination cannot have new objects created in it,

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -91,7 +91,7 @@ coreos:
         ExecStart=/opt/bin/kube-apiserver \
         --service-account-key-file=/opt/bin/kube-serviceaccount.key \
         --service-account-lookup=false \
-        --admission-control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
+        --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
         --runtime-config=api/v1 \
         --allow-privileged=true \
         --insecure-bind-address=0.0.0.0 \

--- a/docs/getting-started-guides/fedora/fedora-calico.md
+++ b/docs/getting-started-guides/fedora/fedora-calico.md
@@ -97,7 +97,7 @@ KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0"
 KUBE_ETCD_SERVERS="--etcd-servers=http://kube-master:4001"
 
 # Remove ServiceAccount from this line to run without API Tokens
-KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ResourceQuota"
+KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ResourceQuota"
 ```
 
 * Create /var/run/kubernetes on master:


### PR DESCRIPTION
The plug-ins are being removed from the source tree.

/cc @kubernetes/rh-cluster-infra

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1079)
<!-- Reviewable:end -->
