### PR TITLE
Use different anchor for better navigation

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -642,8 +642,6 @@ you must use `ls -la` to see them when listing directory contents.
 
 ### Use-case: Secret visible to one container in a pod
 
-<a name="use-case-two-containers"></a>
-
 Consider a program that needs to handle HTTP requests, do some complex business
 logic, and then sign some messages with an HMAC.  Because it has complex
 application logic, there might be an unnoticed remote file reading exploit in
@@ -688,7 +686,7 @@ Therefore, one Pod does not have access to the secrets of another pod.
 There may be several containers in a pod.  However, each container in a pod has
 to request the secret volume in its `volumeMounts` for it to be visible within
 the container.  This can be used to construct useful [security partitions at the
-Pod level](#use-case-two-containers).
+Pod level](#use-case-secret-visible-to-one-container-in-a-pod).
 
 ### Risks
 


### PR DESCRIPTION
the anchor `#use-case-two-containers` will jump the page where the title is not visible, so it's hard to understand the context. `#use-case-secret-visible-to-one-container-in-a-pod` is a better anchor choice since it jumps straight to the title so the context is clear.

Before (after clicking the link):
http://kubernetes.io/docs/user-guide/secrets/#use-case-two-containers
<img width="1050" alt="screen shot 2016-08-25 at 5 10 53 pm" src="https://cloud.githubusercontent.com/assets/1469579/17990041/f8e1ca58-6ae6-11e6-9da3-8dcb943e4891.png">

After (after clicking the link):
http://kubernetes.io/docs/user-guide/secrets/#use-case-secret-visible-to-one-container-in-a-pod
<img width="1056" alt="screen shot 2016-08-25 at 5 11 09 pm" src="https://cloud.githubusercontent.com/assets/1469579/17990043/fe2c0bea-6ae6-11e6-9ac2-a104d5ae8a5a.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1103)
<!-- Reviewable:end -->
