### PR TITLE
Fix downward api docs to have default limits via node allocatables not node capacities

### DIFF
--- a/docs/user-guide/downward-api/index.md
+++ b/docs/user-guide/downward-api/index.md
@@ -132,4 +132,4 @@ Some more thorough examples:
 
 ## Default values for container resource limits
 
-If cpu and memory limits are not specified for a container, the downward API will default to node's cpu and memory capacities.
+If cpu and memory limits are not specified for a container, the downward API will default to the node allocatable value for cpu and memory.


### PR DESCRIPTION
In the PR https://github.com/kubernetes/kubernetes/pull/29639, the default limits have been changed to node allocatables from node capacities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1107)
<!-- Reviewable:end -->
