### PR TITLE
Add ScheduledJob to validation

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apis/batch"
+	batch_validation "k8s.io/kubernetes/pkg/apis/batch/validation"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	expvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -126,6 +127,11 @@ func validateObject(obj runtime.Object) (errors field.ErrorList) {
 			t.Namespace = api.NamespaceDefault
 		}
 		errors = expvalidation.ValidateDaemonSet(t)
+	case *batch.ScheduledJob:
+		if t.Namespace == "" {
+			t.Namespace = api.NamespaceDefault
+		}
+		errors = batch_validation.ValidateScheduledJob(t)
 	default:
 		errors = field.ErrorList{}
 		errors = append(errors, field.InternalError(field.NewPath(""), fmt.Errorf("no validation defined for %#v", obj)))
@@ -236,6 +242,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"redis-resource-deployment":  &extensions.Deployment{},
 			"redis-secret-deployment":    &extensions.Deployment{},
 			"run-my-nginx":               &extensions.Deployment{},
+			"sj":                         &batch.ScheduledJob{},
 		},
 		"../docs/admin": {
 			"daemon": &extensions.DaemonSet{},


### PR DESCRIPTION
Fix the tests for release-1.4 in https://github.com/kubernetes/kubernetes.github.io/pull/1123 @janetkuo added a file for a `ScheduledJob` this results in a fail:

````
=== RUN   TestExampleObjectSchemas
--- FAIL: TestExampleObjectSchemas (0.02s)
	examples_test.go:293: ../docs/user-guide/sj.yaml: sj does not have a test case defined
```


See https://github.com/kubernetes/kubernetes.github.io/pull/1067 for example. I added the file and a validation for the `ScheduledJob`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1159)
<!-- Reviewable:end -->
