### PR TITLE
remove specific Fedora and Kubernetes version when describing configuration

### DIFF
--- a/docs/admin/static-pods.md
+++ b/docs/admin/static-pods.md
@@ -48,7 +48,7 @@ For example, this is how to start a simple web server as a static pod:
     EOF
     ```
 
-2. Configure your kubelet daemon on the node to use this directory by running it with `--config=/etc/kubelet.d/` argument.  On Fedora Fedora 21 with Kubernetes 0.17 edit `/etc/kubernetes/kubelet` to include this line:
+2. Configure your kubelet daemon on the node to use this directory by running it with `--config=/etc/kubelet.d/` argument.  On Fedora edit `/etc/kubernetes/kubelet` to include this line:
 
     ```conf
     KUBELET_ARGS="--cluster-dns=10.254.0.10 --cluster-domain=kube.local --config=/etc/kubelet.d/"
@@ -56,7 +56,7 @@ For example, this is how to start a simple web server as a static pod:
 
     Instructions for other distributions or Kubernetes installations may vary.
 
-3. Restart kubelet. On Fedora 21, this is:
+3. Restart kubelet. On Fedora, this is:
 
     ```shell
     [root@my-node1 ~] $ systemctl restart kubelet


### PR DESCRIPTION
Kubernetes is already well supported on Fedora. No need to mention Fedora version. At the same time, kubernetes-0.17 is quite outdated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1166)
<!-- Reviewable:end -->
