### PR TITLE
Remove typo'd '=' from AWS ELB SSL documentation

### DIFF
--- a/docs/user-guide/services/index.md
+++ b/docs/user-guide/services/index.md
@@ -460,7 +460,7 @@ within AWS Certificate Manager.
     "metadata": {
         "name": "my-service",
         "annotations": {
-            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol=": "(https|http|ssl|tcp)"
+            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "(https|http|ssl|tcp)"
         }
     },
 ```


### PR DESCRIPTION
It looks like there was a typo in the `service.beta.kubernetes.io/aws-load-balancer-backend-protocol` AWS SSL annotation key, that causes a syntax error in kubectl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1185)
<!-- Reviewable:end -->
