### PR TITLE
Add link to IBM SoftLayer instructions

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -161,6 +161,8 @@ toc:
       path: /docs/getting-started-guides/azure/
     - title: Running Kubernetes on CenturyLink Cloud
       path: /docs/getting-started-guides/clc/
+    - title: Running Kubernetes on IBM SoftLayer
+      path: https://github.com/patrocinio/kubernetes-softlayer
   - title: Running Kubernetes on Custom Solutions
     section:
     - title: Creating a Custom Cluster from Scratch

--- a/docs/getting-started-guides/index.md
+++ b/docs/getting-started-guides/index.md
@@ -49,6 +49,7 @@ few commands, and have active community support.
 - [Azure](/docs/getting-started-guides/coreos/azure/) (Weave-based, contributed by WeaveWorks employees)
 - [Azure](/docs/getting-started-guides/azure/) (Flannel-based, contributed by Microsoft employee)
 - [CenturyLink Cloud](/docs/getting-started-guides/clc)
+- [IBM SoftLayer](https://github.com/patrocinio/kubernetes-softlayer)
 
 ### Custom Solutions
 


### PR DESCRIPTION
This is a continuation of PR 1183 (https://github.com/kubernetes/kubernetes.github.io/pull/1183), which I messed up when I rebased.

--- Original comments:

Originally, I created a page describing the turn-key solution to deploy Kubernetes in IBM SoftLayer, but the reviewer on the following PR #313 asked me to host the information in another repository.

So this PR is to create a link to the external repository containing the instructions.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1198)
<!-- Reviewable:end -->
