### PR TITLE
Remove `=true` from gcloud commands

### DIFF
--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -111,11 +111,11 @@ to the corresponding `gcloud` commands.
 Examples:
 
 ```shell
-gcloud container clusters create mytestcluster --zone=us-central1-b --enable-autoscaling=true --min-nodes=3 --max-nodes=10 --num-nodes=5
+gcloud container clusters create mytestcluster --zone=us-central1-b --enable-autoscaling --min-nodes=3 --max-nodes=10 --num-nodes=5
 ```
 
 ```shell
-gcloud container clusters update mytestcluster --enable-autoscaling=true --min-nodes=1 --max-nodes=15
+gcloud container clusters update mytestcluster --enable-autoscaling --min-nodes=1 --max-nodes=15
 ```
 
 **Cluster autoscaler expects that nodes have not been manually modified (e.g. by adding labels via kubectl) as those properties would not be propagated to the new nodes within the same instance group.**


### PR DESCRIPTION
--<flag>=true/false trips up gcloud (from [SO question](http://stackoverflow.com/questions/39454375/enable-autoscaling-on-gke-cluster-creation)):

```
$ gcloud container clusters create mytestcluster --enable-autoscaling=true --min-nodes=3 --max-nodes=10 --num-nodes=5
usage: gcloud container clusters create  NAME [optional flags]
ERROR: (gcloud.container.clusters.create) argument --enable-autoscaling: ignored explicit argument 'true'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1211)
<!-- Reviewable:end -->
