### PR TITLE
Fix Calico Install Command

### DIFF
--- a/docs/getting-started-guides/network-policy/calico.md
+++ b/docs/getting-started-guides/network-policy/calico.md
@@ -8,6 +8,7 @@ You can deploy a cluster using Calico for network policy in the default [GCE dep
 
 ```shell
 export NETWORK_POLICY_PROVIDER=calico
+export KUBE_NODE_OS_DISTRIBUTION=debian
 curl -sS https://get.k8s.io | bash
 ```
 


### PR DESCRIPTION
As per https://github.com/kubernetes/kubernetes/issues/32625

Switching nodes to GCI broke the command in this guide, so adding the flag to use debian instead which I've tested to ensure it still works, and it does!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1231)
<!-- Reviewable:end -->
