### PR TITLE
Update StorageClass API endpoint

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -306,7 +306,7 @@ for details.
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: standard
 provisioner: kubernetes.io/aws-ebs
@@ -330,7 +330,7 @@ used.
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs
@@ -350,7 +350,7 @@ parameters:
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd
@@ -365,7 +365,7 @@ parameters:
 #### GLUSTERFS
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: slow
@@ -386,7 +386,7 @@ parameters:
 
 ```yaml
 kind: StorageClass
-apiVersion: extensions/v1beta1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: gold
 provisioner: kubernetes.io/cinder


### PR DESCRIPTION
It has been moved from extensions/ to storage.k8s.io/ in 1.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1233)
<!-- Reviewable:end -->
