### PR TITLE
Storage class 1.4 docs

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -238,7 +238,7 @@ equal to `""` is always interpreted to be requesting a PV with no class, so it
 can only be bound to PVs with no class (no annotation or one set equal to
 `""`). A PVC with no annotation is not quite the same and is treated differently
 by the cluster depending on whether the
-[`DefaultStorageClass` admission plugin](docs/admin/admission-controllers/#defaultstorageclass)
+[`DefaultStorageClass` admission plugin](/docs/admin/admission-controllers/#defaultstorageclass)
 is turned on.
 
 * If the admission plugin is turned on, the administrator may specify a
@@ -256,7 +256,8 @@ same way as PVCs that have their annotation set to `""`.
 
 When a PVC specifies a `selector` in addition to requesting a `StorageClass`,
 the requirements are ANDed together: only a PV of the requested class and with
-the requested labels may be bound to the PVC.
+the requested labels may be bound to the PVC. Note that currently, a PVC with a
+non-empty `selector` can't have a PV dynamically provisioned for it.
 
 In the future after beta, the `volume.beta.kubernetes.io/storage-class`
 annotation will become an attribute.
@@ -295,13 +296,12 @@ dynamically provisioned.
 
 The name of a `StorageClass` object is significant, and is how users can
 request a particular class. Administrators set the name and other parameters
-of a class, all of which are opaque to users, when first creating
-`StorageClass` objects, and the objects cannot be updated once they are
-created.
+of a class when first creating `StorageClass` objects, and the objects cannot
+be updated once they are created.
 
 Administrators can specify a default `StorageClass` just for PVCs that don't
 request any particular class to bind to: see the
-[`PersistentVolumeClaim` section](docs/user-guide/persistent-volumes/#class-1)
+[`PersistentVolumeClaim` section](#persistentvolumeclaims)
 for details.
 
 ```yaml
@@ -373,16 +373,14 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
   restuserkey: "password"
 ```
 
 * `endpoint`: `glusterfs-cluster` is the endpoint/service name which includes GlusterFS trusted pool IP addresses and this parameter is mandatory.
-* `resturl` : Gluster REST service url which provision gluster volumes on demand. The format should be `IPaddress:Port` and this is a mandatory parameter for GlusterFS dynamic provisioner.
-* `restauthenabled` : Gluster REST service authentication boolean is required if the authentication is enabled on the REST server. If this value is 'true', 'restuser' and 'restuserkey' have to be filled.
-* `restuser` : Gluster REST service user who has access to create volumes in the Gluster Trusted Pool.
-* `restuserkey` : Gluster REST service user's password which will be used for authentication to the REST server.
+* `resturl` : Gluster REST service url which provision gluster volumes on demand. The format should be a valid URL and this is a mandatory parameter for GlusterFS dynamic provisioner.
+* `restuser` : Gluster REST service user who has access to create volumes in the Gluster Trusted Pool. This parameter is optional, empty string will be used when omitted.
+* `restuserkey` : Gluster REST service user's password which will be used for authentication to the REST server. This parameter is optional, empty string will be used when omitted.
 
 #### OpenStack Cinder
 

--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -20,6 +20,21 @@ A `PersistentVolume` (PV) is a piece of networked storage in the cluster that ha
 
 A `PersistentVolumeClaim` (PVC) is a request for storage by a user.  It is similar to a pod.  Pods consume node resources and PVCs consume PV resources.  Pods can request specific levels of resources (CPU and Memory).  Claims can request specific size and access modes (e.g, can be mounted once read/write or many times read-only).
 
+While `PersistentVolumeClaims` allow a user to consume abstract storage
+resources, it is common that users need `PersistentVolumes` with varying
+properties, such as performance, for different problems. Cluster administrators
+need to be able to offer a variety of `PersistentVolumes` that differ in more
+ways than just size and access modes, without exposing users to the details of
+how those volumes are implemented. For these needs there is the `StorageClass`
+resource.
+
+A `StorageClass` provides a way for administrators to describe the "classes" of
+storage they offer. Different classes might map to quality-of-service levels,
+or to backup policies, or to arbitrary policies determined by the cluster
+administrators. Kubernetes itself is unopinionated about what classes
+represent. This concept is sometimes called "profiles" in other storage
+systems.
+
 Please see the [detailed walkthrough with working examples](/docs/user-guide/persistent-volumes/walkthrough/).
 
 
@@ -29,11 +44,17 @@ PVs are resources in the cluster.  PVCs are requests for those resources and als
 
 ### Provisioning
 
-A cluster administrator will create a number of PVs. They carry the details of the real storage which is available for use by cluster users.  They exist in the Kubernetes API and are available for consumption.
+There are two ways PVs may be provisioned: statically or dynamically.
+
+#### Static
+A cluster administrator creates a number of PVs. They carry the details of the real storage which is available for use by cluster users.  They exist in the Kubernetes API and are available for consumption.
+
+#### Dynamic
+When none of the static PVs the administrator created matches a user's `PersistentVolumeClaim`, the cluster may try to dynamically provision a volume specially for the PVC. This provisioning is based on `StorageClasses`: the PVC must request a class and the administrator must have created and configured that class in order for dynamic provisioning to occur. Claims that request the class `""` effectively disable dynamic provisioning for themselves.
 
 ### Binding
 
-A user creates a `PersistentVolumeClaim` with a specific amount of storage requested and with certain access modes.  A control loop in the master watches for new PVCs, finds a matching PV (if possible), and binds them together.  The user will always get at least what they asked for, but the volume may be in excess of what was requested.  Once bound, `PersistentVolumeClaim` binds are exclusive, regardless of the mode used to bind them.
+A user creates, or has already created in the case of dynamic provisioning, a `PersistentVolumeClaim` with a specific amount of storage requested and with certain access modes.  A control loop in the master watches for new PVCs, finds a matching PV (if possible), and binds them together.  If a PV was dynamically provisioned for a new PVC, the loop will always bind that PV to the PVC. Otherwise, the user will always get at least what they asked for, but the volume may be in excess of what was requested.  Once bound, `PersistentVolumeClaim` binds are exclusive, regardless of the mode used to bind them.
 
 Claims will remain unbound indefinitely if a matching volume does not exist.  Claims will be bound as matching volumes become available.  For example, a cluster provisioned with many 50Gi PVs would not match a PVC requesting 100Gi.  The PVC can be bound when a 100Gi PV is added to the cluster.
 
@@ -49,7 +70,7 @@ When a user is done with their volume, they can delete the PVC objects from the 
 
 ### Reclaiming
 
-The reclaim policy for a `PersistentVolume` tells the cluster what to do with the volume after it has been released of its claim.  Currently, volumes can either be Retained, Recycled or Deleted.  Retention allows for manual reclamation of the resource.  For those volume plugins that support it, deletion removes both the `PersistentVolume` object from Kubernetes as well as deletes associated storage asset in external infrastructure such as AWS EBS, GCE PD or Cinder volume. If supported by appropriate volume plugin, recycling performs a basic scrub (`rm -rf /thevolume/*`) on the volume and makes it available again for a new claim.
+The reclaim policy for a `PersistentVolume` tells the cluster what to do with the volume after it has been released of its claim.  Currently, volumes can either be Retained, Recycled or Deleted.  Retention allows for manual reclamation of the resource.  For those volume plugins that support it, deletion removes both the `PersistentVolume` object from Kubernetes as well as deletes associated storage asset in external infrastructure such as AWS EBS, GCE PD or Cinder volume.  Volumes that were dynamically provisioned are always deleted.  If supported by appropriate volume plugin, recycling performs a basic scrub (`rm -rf /thevolume/*`) on the volume and makes it available again for a new claim.
 
 ## Types of Persistent Volumes
 
@@ -78,6 +99,8 @@ Each PV contains a spec and status, which is the specification and status of the
   kind: PersistentVolume
   metadata:
     name: pv0003
+    annotations:
+      volume.beta.kubernetes.io/storage-class: "slow"
   spec:
     capacity:
       storage: 5Gi
@@ -130,6 +153,16 @@ In the CLI, the access modes are abbreviated to:
 | RDB                  | x            | x           | -            |
 | VsphereVolume        | x            | -           | -            |
 
+### Class
+
+A PV can have a class, which is specified by setting the
+`volume.beta.kubernetes.io/storage-class` annotation to the name of a
+`StorageClass`. A PV of a particular class can only be bound to PVCs requesting
+that class. A PV with no annotation or its class annotation set to `""` has no
+class and can only be bound to PVCs that request no particular class.
+
+In the future after beta, the `volume.beta.kubernetes.io/storage-class`
+annotation will become an attribute.
 
 ### Recycling Policy
 
@@ -161,6 +194,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: myclaim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "slow"
 spec:
   accessModes:
     - ReadWriteOnce
@@ -191,6 +226,41 @@ Claims can specify a [label selector](/docs/user-guide/labels/#label-selectors) 
 
 All of the requirements, from both `matchLabels` and `matchExpressions` are ANDed together – they must all be satisfied in order to match.
 
+### Class
+
+A claim can request a particular class by specifying the name of a
+`StorageClass`using the annotation `volume.beta.kubernetes.io/storage-class`.
+Only PVs of the requested class, ones with the same annotation as the PVC, can
+be bound to the PVC.
+
+PVCs don't necessarily have to request a class. A PVC with its annotation set
+equal to `""` is always interpreted to be requesting a PV with no class, so it
+can only be bound to PVs with no class (no annotation or one set equal to
+`""`). A PVC with no annotation is not quite the same and is treated differently
+by the cluster depending on whether the
+[`DefaultStorageClass` admission plugin](docs/admin/admission-controllers/#defaultstorageclass)
+is turned on.
+
+* If the admission plugin is turned on, the administrator may specify a
+default `StorageClass`. All PVCs that have no annotation can be bound only to
+PVs of that default. Specifying a default `StorageClass` is done by setting the
+annotation `storageclass.beta.kubernetes.io/is-default-class` equal to "true" in
+a `StorageClass` object. If the administrator does not specify a default, the
+cluster responds to PVC creation as if the admission plugin were turned off. If
+more than one default is specified, the admission plugin forbids the creation of
+all PVCs.
+* If the admission plugin is turned off, there is no notion of a default
+`StorageClass`. All PVCs that have no annotation can be bound only to PVs that
+have no class. In this case the PVCs that have no annotation are treated the
+same way as PVCs that have their annotation set to `""`.
+
+When a PVC specifies a `selector` in addition to requesting a `StorageClass`,
+the requirements are ANDed together: only a PV of the requested class and with
+the requested labels may be bound to the PVC.
+
+In the future after beta, the `volume.beta.kubernetes.io/storage-class`
+annotation will become an attribute.
+
 ## Claims As Volumes
 
 Pods access storage by using the claim as a volume.  Claims must exist in the same namespace as the pod using the claim.  The cluster finds the claim in the pod's namespace and uses it to get the `PersistentVolume` backing the claim.  The volume is then mounted to the host and into the pod.
@@ -216,3 +286,116 @@ spec:
 ### A Note on Namespaces
 
 `PersistentVolumes` binds are exclusive, and since `PersistentVolumeClaims` are namespaced objects, mounting claims with "Many" modes (`ROX`, `RWX`) is only possible within one namespace.
+
+## StorageClasses
+
+Each `StorageClass` contains the fields `provisioner` and `parameters`, which
+are used when a `PersistentVolume` belonging to the class needs to be
+dynamically provisioned.
+
+The name of a `StorageClass` object is significant, and is how users can
+request a particular class. Administrators set the name and other parameters
+of a class, all of which are opaque to users, when first creating
+`StorageClass` objects, and the objects cannot be updated once they are
+created.
+
+Administrators can specify a default `StorageClass` just for PVCs that don't
+request any particular class to bind to: see the
+[`PersistentVolumeClaim` section](docs/user-guide/persistent-volumes/#class-1)
+for details.
+
+```yaml
+kind: StorageClass
+apiVersion: extensions/v1beta1
+metadata:
+  name: standard
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+```
+
+### Provisioner
+Storage classes have a provisioner that determines what volume plugin is used
+for provisioning PVs. This field must be specified. During beta, the available
+provisioner types are `kubernetes.io/aws-ebs` and `kubernetes.io/gce-pd`.
+
+### Parameters
+Storage classes have parameters that describe volumes belonging to the storage
+class. Different parameters may be accepted depending on the `provisioner`. For
+ example, the value `io1`, for the parameter `type`, and the parameter
+`iopsPerGB` are specific to EBS. When a parameter is omitted, some default is
+used.
+
+#### AWS
+
+```yaml
+kind: StorageClass
+apiVersion: extensions/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: io1
+  zone: us-east-1d
+  iopsPerGB: "10"
+```
+
+* `type`: `io1`, `gp2`, `sc1`, `st1`. See [AWS docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) for details. Default: `gp2`.
+* `zone`: AWS zone. If not specified, a random zone from those where Kubernetes cluster has a node is chosen.
+* `iopsPerGB`: only for `io1` volumes. I/O operations per second per GiB. AWS volume plugin multiplies this with size of requested volume to compute IOPS of the volume and caps it at 20 000 IOPS (maximum supported by AWS, see [AWS docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html). A string is expected here, i.e. `"10"`, not `10`.
+* `encrypted`: denotes whether the EBS volume should be encrypted or not. Valid values are `"true"` or `"false"`. A string is expected here, i.e. `"true"`, not `true`.
+* `kmsKeyId`: optional. The full Amazon Resource Name of the key to use when encrypting the volume. If none is supplied but `encrypted` is true, a key is generated by AWS. See AWS docs for valid ARN value.
+
+#### GCE
+
+```yaml
+kind: StorageClass
+apiVersion: extensions/v1beta1
+metadata:
+  name: slow
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+  zone: us-central1-a
+```
+
+* `type`: `pd-standard` or `pd-ssd`. Default: `pd-ssd`
+* `zone`: GCE zone. If not specified, a random zone in the same region as controller-manager will be chosen.
+
+#### GLUSTERFS
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: StorageClass
+metadata:
+  name: slow
+provisioner: kubernetes.io/glusterfs
+parameters:
+  endpoint: "glusterfs-cluster"
+  resturl: "http://127.0.0.1:8081"
+  restauthenabled: "true"
+  restuser: "admin"
+  restuserkey: "password"
+```
+
+* `endpoint`: `glusterfs-cluster` is the endpoint/service name which includes GlusterFS trusted pool IP addresses and this parameter is mandatory.
+* `resturl` : Gluster REST service url which provision gluster volumes on demand. The format should be `IPaddress:Port` and this is a mandatory parameter for GlusterFS dynamic provisioner.
+* `restauthenabled` : Gluster REST service authentication boolean is required if the authentication is enabled on the REST server. If this value is 'true', 'restuser' and 'restuserkey' have to be filled.
+* `restuser` : Gluster REST service user who has access to create volumes in the Gluster Trusted Pool.
+* `restuserkey` : Gluster REST service user's password which will be used for authentication to the REST server.
+
+#### OpenStack Cinder
+
+```yaml
+kind: StorageClass
+apiVersion: extensions/v1beta1
+metadata:
+  name: gold
+provisioner: kubernetes.io/cinder
+parameters:
+  type: fast
+  availability: nova
+```
+
+* `type`: [VolumeType](http://docs.openstack.org/admin-guide/dashboard-manage-volumes.html) created in Cinder. Default is empty.
+* `availability`: Availability Zone. Default is empty.


### PR DESCRIPTION
Ideally this should not need a review because it is simply reverting a revert in the release-1.4 branch. Bear with me... The first commit is https://github.com/kubernetes/kubernetes.github.io/pull/1064 and the second commit is https://github.com/kubernetes/kubernetes.github.io/pull/1121. Only, this time I am targeting them at the correct branch, 1.4.

1. StorageClass docs intended for 1.4 got merged into master (my bad)
2. I reverted the docs in master yesterday
3. Latest changes in master got merged into release-1.4
4. Now I am putting the StorageClass docs back into release-1.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1243)
<!-- Reviewable:end -->
