### PR TITLE
Fix update documentation reference to doc location

### DIFF
--- a/docs/user-guide/update-demo/index.md
+++ b/docs/user-guide/update-demo/index.md
@@ -13,11 +13,11 @@ here](https://github.com/kubernetes/kubernetes.github.io/tree/{{page.docsbranch}
 
 ### Step Zero: Prerequisites
 
-This example assumes that you have forked the repository and [turned up a Kubernetes cluster](/docs/getting-started-guides/):
+This example assumes that you have forked the docs repository and [turned up a Kubernetes cluster](/docs/getting-started-guides/):
 
 ```shell
-$ cd kubernetes
-$ ./cluster/kube-up.sh
+$ git clone -b {{page.docsbranch}} https://github.com/kubernetes/kubernetes.github.io
+$ cd kubernetes.github.io
 ```
 
 ### Step One: Turn up the UX for the demo
@@ -81,14 +81,7 @@ This first stops the replication controller by turning the target number of repl
 
 ### Step Six: Cleanup
 
-To turn down a Kubernetes cluster:
-
-```shell
-$ ./cluster/kube-down.sh
-```
-
-Kill the proxy running in the background:
-After you are done running this demo make sure to kill it:
+After you are done running this demo make sure to kill the proxy running in the background:
 
 ```shell
 $ jobs


### PR DESCRIPTION
It seems docs were moved from kubernetes repo and now
live in the website repo. I've updated the prequisite to
reflect this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1247)
<!-- Reviewable:end -->
