### PR TITLE
user-guides: services: cross-link to dns admin guide

### DIFF
--- a/docs/user-guide/services/index.md
+++ b/docs/user-guide/services/index.md
@@ -317,6 +317,10 @@ Kubernetes also supports DNS SRV (service) records for named ports.  If the
 can do a DNS SRV query for `"_http._tcp.my-service.my-ns"` to discover the port
 number for `"http"`.
 
+The [DNS Admin guide](dns-admin) has further details.
+
+[dns-admin]: http://kubernetes.io/docs/admin/dns/
+
 ## Headless services
 
 Sometimes you don't need or want load-balancing and a single service IP.  In


### PR DESCRIPTION
We need to expand the DNS admin guide further. But, link to it for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1250)

<!-- Reviewable:end -->
