### PR TITLE
fix broken file reference in PSP guide

### DIFF
--- a/docs/user-guide/pod-security-policy/index.md
+++ b/docs/user-guide/pod-security-policy/index.md
@@ -130,7 +130,7 @@ A pod must validate every field against the PSP.
 Here is an example Pod Security Policy. It has permissive settings for
 all fields
 
-{% include code.html language="yaml" file="sj.yaml" ghlink="/docs/user-guide/pod-security-policy/psp.yaml" %}
+{% include code.html language="yaml" file="psp.yaml" ghlink="/docs/user-guide/pod-security-policy/psp.yaml" %}
 
 Create the policy by downloading the example file and then running this command:
 


### PR DESCRIPTION
Fixes the included file reference in the psp guide which was breaking deploy/netlify

https://github.com/kubernetes/kubernetes.github.io/pull/1206#issuecomment-248447241

@nikhiljindal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1277)
<!-- Reviewable:end -->
