### PR TITLE
Clarified remark about authorizers determining groups

### DIFF
--- a/docs/admin/accessing-the-api.md
+++ b/docs/admin/accessing-the-api.md
@@ -52,8 +52,8 @@ On GCE, Client Certificates, Password, Plain Tokens, and JWT Tokens are all enab
 If the request cannot be authenticated, it is rejected with HTTP status code 401.
 Otherwise, the user is authenticated as a specific `username`, and the user name
 is available to subsequent steps to use in their decisions.  Some authenticators
-may also provide the group memberships of the user, while other authenticators
-do not (and expect the authorizer to determine these).
+also provide the group memberships of the user, while other authenticators
+do not.
 
 While Kubernetes uses "usernames" for access control decisions and in request logging,
 it does not have a `user` object nor does it store usernames or other information about


### PR DESCRIPTION
The old text said that this is expected, which does not match
my understanding.  The new text says that it is allowed,
and none of the standard authorizers does so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1303)
<!-- Reviewable:end -->
