### PR TITLE
Clarified the apiGroup identified by empty string

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -53,7 +53,7 @@ A request has the following attributes that can be considered for authorization:
   - what resource is being accessed (for resource requests only)
   - what subresource is being accessed (for resource requests only)
   - the namespace of the object being accessed (for namespaced resource requests only)
-  - the API group being accessed (for resource requests only)
+  - the API group being accessed (for resource requests only); an empty string designates the [core API group](../api.md#api-groups)
 
 The request verb for a resource API endpoint can be determined by the HTTP verb used and whether or not the request acts on an individual resource or a collection of resources:
 
@@ -231,7 +231,7 @@ metadata:
   namespace: default
   name: pod-reader
 rules:
-  - apiGroups: [""] # The API group "" indicates the default API Group.
+  - apiGroups: [""] # The API group "" indicates the core API Group.
     resources: ["pods"]
     verbs: ["get", "watch", "list"]
     nonResourceURLs: []


### PR DESCRIPTION
Noted this where the relevance of api group is introduced, and
corrected the reference to what the empty string means ("core" api
group, which is the terminology used in the page that introduces api
group, rather than the old text "default").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1304)
<!-- Reviewable:end -->
