### PR TITLE
Use default release version of kubernetes during `kubeadm init` run

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -82,7 +82,7 @@ All of these components run in pods started by `kubelet`.
 
 To initialize the master, pick one of the machines you previously installed `kubelet` and `kubeadm` on, and run:
 
-     # kubeadm init --use-kubernetes-version v1.4.0-beta.11
+     # kubeadm init
 
 This will download and install the cluster database and "control plane" components.
 This may take several minutes.


### PR DESCRIPTION
Since kubernetes v1.4.0 is released, we should use [default release](https://github.com/kubernetes/kubernetes/blob/7309d34873a4ab355f9a9930d8d51e852ce2badb/cmd/kubeadm/app/api/types.go#L72) version of Kubernetes when user runs `kubeadm init`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kubernetes.github.io/1314)
<!-- Reviewable:end -->
