### PR TITLE
Add instructions for overriding autodetected network interface.

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -42,16 +42,6 @@ You will install the following packages on all the machines:
 
 For each host in turn:
 
-<!--
-    # curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-    # cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-    deb http://packages.cloud.google.com/apt kubernetes-xenial main
-    EOF
-    # apt-get update
-    # apt-get install -y kubeadm docker.io§
--->
-
-
 * SSH into the machine and become `root` if you are not already (for example, run `sudo su -`).
 * If the machine is running Ubuntu 16.04, run:
 
@@ -91,6 +81,9 @@ All of these components run in pods started by `kubelet`.
 To initialize the master, pick one of the machines you previously installed `kubelet` and `kubeadm` on, and run:
 
      # kubeadm init
+
+**Note:** this will autodetect the network interface to advertise the master on as the interface with the default gateway.
+If you want to use a different interface, specify `--api-advertise-addresses=<ip-address>` argument to `kubeadm init`.
 
 This will download and install the cluster database and "control plane" components.
 This may take several minutes.


### PR DESCRIPTION
Fixes `kubeadm` issues https://github.com/kubernetes/kubernetes/issues/33618 and https://github.com/kubernetes/kubernetes/issues/33562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1334)
<!-- Reviewable:end -->
