### PR TITLE
Fix links to AppArmor policy references

### DIFF
--- a/docs/admin/apparmor/index.md
+++ b/docs/admin/apparmor/index.md
@@ -349,8 +349,8 @@ logs or through `journalctl`. More information is provided in
 
 Additional resources:
 
-- http://wiki.apparmor.net/index.php/QuickProfileLanguage
-- http://wiki.apparmor.net/index.php/ProfileLanguage
+- [Quick guide to the AppArmor profile language](http://wiki.apparmor.net/index.php/QuickProfileLanguage)
+- [AppArmor core policy reference](http://wiki.apparmor.net/index.php/ProfileLanguage)
 
 ## API Reference
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1360)
<!-- Reviewable:end -->
