### PR TITLE
Demo app moves to different namespace

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -182,9 +182,9 @@ To learn more about the sample microservices app, see the [GitHub README](https:
 
 You can then find out the port that the [NodePort feature of services](/docs/user-guide/services/) allocated for the front-end service by running:
 
-    # kubectl describe svc front-end
+    # kubectl describe svc front-end -n sock-shop
     Name:                   front-end
-    Namespace:              default
+    Namespace:              sock-shop
     Labels:                 name=front-end
     Selector:               name=front-end
     Type:                   NodePort
@@ -194,7 +194,7 @@ You can then find out the port that the [NodePort feature of services](/docs/use
     Endpoints:              <none>
     Session Affinity:       None
 
-It takes several minutes to download and start all the containers, watch the output of `kubectl get pods` to see when they're all up and running.
+It takes several minutes to download and start all the containers, watch the output of `kubectl get pods -n sock-shop` to see when they're all up and running.
 
 Then go to the IP address of your cluster's master node in your browser, and specify the given port.
 So for example, `http://<master_ip>:<port>`.


### PR DESCRIPTION
Change `kubeadm` instructions to show use of `sock-shop` namespace rather than `default`.

Background: the demo installs a `DefaultDeny` network policy annotation, which is tripping up some users who go on to create some more pods without removing the annotation.  This change matches https://github.com/microservices-demo/microservices-demo/pull/339 which moves the whole demo out of the `default` namespace.

This change should not be merged until the microservices-demo change is merged.

CC @errordeveloper

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1368)
<!-- Reviewable:end -->
