### PR TITLE
Fix incorrect wording with secrets

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -377,7 +377,7 @@ To use a secret in an environment variable in a pod:
 1. Modify your Pod definition in each container that you wish to consume the value of a secret key to add an environment variable for each secret key you wish to consume.  The environment variable that consumes the secret key should populate the secret's name and key in `env[x].valueFrom.secretKeyRef`.
 1. Modify your image and/or command line so that the program looks for values in the specified environment variables
 
-This is an example of a pod that mounts a secret in a volume:
+This is an example of a pod that uses secrets from environment variables:
 
 ```yaml
 apiVersion: v1
@@ -543,9 +543,9 @@ credentials.
 Make the secrets:
 
 ```shell
-$ kubectl create secret generic prod-db-secret --from-literal=user=produser --from-literal=password=Y4nys7f11
+$ kubectl create secret generic prod-db-secret --from-literal=username=produser --from-literal=password=Y4nys7f11
 secret "prod-db-secret" created
-$ kubectl create secret generic test-db-secret --from-literal=user=testuser --from-literal=password=iluvtests
+$ kubectl create secret generic test-db-secret --from-literal=username=testuser --from-literal=password=iluvtests
 secret "test-db-secret" created
 ```
 


### PR DESCRIPTION
1) The example given in the section "Using Secrets as Environment
Variables" incorrectly stated the secret was using a volume.

2) The commands used to produce secrets in the section "Use-Case: Pods
with prod / test credentials" has been modified such that the literal
used matches the text for what expected files should be on the
filesystem (changed user to username).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1372)
<!-- Reviewable:end -->
