### PR TITLE
Correct case used in CoreOS hyperlink in getting-started-guides

### DIFF
--- a/docs/getting-started-guides/index.md
+++ b/docs/getting-started-guides/index.md
@@ -70,7 +70,7 @@ writing a new solution](https://github.com/kubernetes/kubernetes/tree/{{page.git
 
 These solutions are combinations of cloud provider and OS not covered by the above solutions.
 
-- [AWS + coreos](/docs/getting-started-guides/coreos)
+- [AWS + CoreOS](/docs/getting-started-guides/coreos)
 - [GCE + CoreOS](/docs/getting-started-guides/coreos)
 - [AWS + Ubuntu](/docs/getting-started-guides/juju)
 - [Joyent + Ubuntu](/docs/getting-started-guides/juju)


### PR DESCRIPTION
Minor typo fix to ensure 'CoreOS' case is correct and consistent throughout getting-started-guides.

Great job on these K8s docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1376)
<!-- Reviewable:end -->
