### PR TITLE
Fix kubectl 404

### DIFF
--- a/docs/user-guide/accessing-the-cluster.md
+++ b/docs/user-guide/accessing-the-cluster.md
@@ -27,7 +27,7 @@ $ kubectl config view
 ```
 
 Many of the [examples](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/) provide an introduction to using
-kubectl and complete documentation is found in the [kubectl manual](/docs/user-guide/kubectl/kubectl).
+kubectl and complete documentation is found in the [kubectl manual](/docs/user-guide/kubectl/index).
 
 ### Directly accessing the REST API
 


### PR DESCRIPTION
Hello,

This commit fix a typo on page : http://kubernetes.io/docs/user-guide/accessing-the-cluster/

Replace link pointing to 404 (http://kubernetes.io/docs/user-guide/kubectl/kubectl) by http://kubernetes.io/docs/user-guide/kubectl/index

Best regards,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1385)
<!-- Reviewable:end -->
