### PR TITLE
Fix kubectl get documentation

### DIFF
--- a/docs/user-guide/kubectl/kubectl_get.md
+++ b/docs/user-guide/kubectl/kubectl_get.md
@@ -12,6 +12,7 @@ Display one or many resources
 Display one or many resources.
 
 Valid resource types include:
+
    * clusters (valid only for federation apiservers)
    * componentstatuses (aka 'cs')
    * configmaps (aka 'cm')
@@ -68,7 +69,9 @@ kubectl get -o json pod web-pod-13je7
 kubectl get -f pod.yaml -o json
 
 # Return only the phase value of the specified pod.
+{% raw %}
 kubectl get -o template pod/web-pod-13je7 --template={{.status.phase}}
+{% endraw %}
 
 # List all replication controllers and services together in ps output format.
 kubectl get rc,services


### PR DESCRIPTION
- fix list of valid resource types
- fix showing template  
  It was fainling with following error message:  
  `Liquid Warning: Liquid syntax error (line 68): [:dot, "."] is not a valid expression in "{{.status.phase}}" in docs/user-guide/kubectl/kubectl_get.md`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1396)
<!-- Reviewable:end -->
