### PR TITLE
Add alternative way to install kubectl

### DIFF
--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -40,6 +40,12 @@ export PATH=<path/to/kubernetes-directory>/platforms/darwin/amd64:$PATH
 export PATH=<path/to/kubernetes-directory>/platforms/linux/amd64:$PATH
 ```
 
+If you are on a mac, you also can use homebrew to install kubectl:
+
+```shell
+$ brew install kubectl
+```
+
 ## Configuring kubectl
 
 In order for kubectl to find and access the Kubernetes cluster, it needs a [kubeconfig file](/docs/user-guide/kubeconfig-file), which is created automatically when creating a cluster using kube-up.sh (see the [getting started guides](/docs/getting-started-guides/) for more about creating clusters). If you need access to a cluster you didn't create, see the [Sharing Cluster Access document](/docs/user-guide/sharing-clusters).


### PR DESCRIPTION
Hi,

I've added an alternative way to install kubectl for homebrew users. With homebrew it's a little bit easier to install and keep kubectl up to date.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1399)

<!-- Reviewable:end -->
