### PR TITLE
Points to documentation about running privileged containers

### DIFF
--- a/docs/user-guide/volumes.md
+++ b/docs/user-guide/volumes.md
@@ -126,9 +126,10 @@ Watch out when using this type of volume, because:
   behave differently on different nodes due to different files on the nodes
 * when Kubernetes adds resource-aware scheduling, as is planned, it will not be
   able to account for resources used by a `hostPath`
-* the directories created on the underlying hosts are only writable by root, you either need
-  to run your process as root in a privileged container or modify the file permissions on
-  the host to be able to write to a `hostPath` volume
+* the directories created on the underlying hosts are only writable by root. You
+  either need to run your process as root in a
+  [privileged container](/docs/user-guide/security-context) or modify the file
+  permissions on the host to be able to write to a `hostPath` volume
 
 #### Example pod
 


### PR DESCRIPTION
Documentation of volume hostpath refers to "privileged containers" but doesn't say (or points to) how to use them

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1409)
<!-- Reviewable:end -->
