### PR TITLE
Fix code fencing for DNS validation example

### DIFF
--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -166,12 +166,15 @@ busybox   1/1       Running   0          <some-time>
 ```
 
 ### Validate DNS works
+
 Once that pod is running, you can exec nslookup in that environment:
+
 ```
 kubectl exec busybox -- nslookup kubernetes.default
 ```
 
 You should see something like:
+
 ```
 Server:    10.0.0.10
 Address 1: 10.0.0.10


### PR DESCRIPTION
Code fences need some breathing room in order to render correctly with some markdown parsers.

![kubernetes_-_using_dns_pods_and_services](https://cloud.githubusercontent.com/assets/521627/19254413/50433dc8-8f21-11e6-96cb-7838c1043b52.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1425)
<!-- Reviewable:end -->
