### PR TITLE
Change RDB typo to RBD

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -150,7 +150,7 @@ In the CLI, the access modes are abbreviated to:
 | HostPath             | x            | -           | -            |
 | iSCSI                | x            | x           | -            |
 | NFS                  | x            | x           | x            |
-| RDB                  | x            | x           | -            |
+| RBD                  | x            | x           | -            |
 | VsphereVolume        | x            | -           | -            |
 
 ### Class


### PR DESCRIPTION
I assume this is referring to `RBD (Ceph Block Device)` and not something else

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1436)
<!-- Reviewable:end -->
