### PR TITLE
34613 404 Not Found on links referring to /docs/user-guide/kubectl/ku…

### DIFF
--- a/docs/admin/static-pods.md
+++ b/docs/admin/static-pods.md
@@ -88,7 +88,7 @@ static-web-my-node1     172.17.0.3                              my-node1/192.168
 
 Labels from the static pod are propagated into the mirror-pod and can be used as usual for filtering.
 
-Notice we cannot delete the pod with the API server (e.g. via [`kubectl`](/docs/user-guide/kubectl/kubectl/) command), kubelet simply won't remove it.
+Notice we cannot delete the pod with the API server (e.g. via [`kubectl`](/docs/user-guide/kubectl/) command), kubelet simply won't remove it.
 
 ```shell
 [joe@my-master ~] $ kubectl delete pod static-web-my-node1

--- a/docs/user-guide/federation/replicasets.md
+++ b/docs/user-guide/federation/replicasets.md
@@ -35,7 +35,7 @@ The API for Federated Replica Set is 100% compatible with the
 API for traditional Kubernetes Replica Set. You can create a replica set by sending
 a request to the federation apiserver.
 
-You can do that using [kubectl](/docs/user-guide/kubectl/kubectl/) by running:
+You can do that using [kubectl](/docs/user-guide/kubectl/) by running:
 
 ``` shell
 kubectl --context=federation-cluster create -f myrs.yaml

--- a/docs/user-guide/federation/secrets.md
+++ b/docs/user-guide/federation/secrets.md
@@ -35,7 +35,7 @@ The API for Federated Secret is 100% compatible with the
 API for traditional Kubernetes Secret. You can create a secret by sending
 a request to the federation apiserver.
 
-You can do that using [kubectl](/docs/user-guide/kubectl/kubectl/) by running:
+You can do that using [kubectl](/docs/user-guide/kubectl/) by running:
 
 ``` shell
 kubectl --context=federation-cluster create -f mysecret.yaml

--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -5,7 +5,7 @@ assignees:
 
 ---
 
-To deploy and manage applications on Kubernetes, you’ll use the Kubernetes command-line tool, [kubectl](/docs/user-guide/kubectl/kubectl/). It lets you inspect your cluster resources, create, delete, and update components, and much more. You will use it to look at your new cluster and bring up example apps.
+To deploy and manage applications on Kubernetes, you’ll use the Kubernetes command-line tool, [kubectl](/docs/user-guide/kubectl/). It lets you inspect your cluster resources, create, delete, and update components, and much more. You will use it to look at your new cluster and bring up example apps.
 
 ## Installing kubectl
 

--- a/docs/user-guide/replicasets.md
+++ b/docs/user-guide/replicasets.md
@@ -18,7 +18,7 @@ the selector support. Replica Set supports the new set-based selector requiremen
 as described in the [labels user guide](/docs/user-guide/labels/#label-selectors)
 whereas a Replication Controller only supports equality-based selector requirements.
 
-Most [`kubectl`](/docs/user-guide/kubectl/kubectl/) commands that support
+Most [`kubectl`](/docs/user-guide/kubectl/) commands that support
 Replication Controllers also support Replica Sets. One exception is the
 [`rolling-update`](/docs/user-guide/kubectl/kubectl_rolling-update/) command. If
 you want the rolling update functionality please consider using Deployments


### PR DESCRIPTION
Changed all links referring to kubectl from /docs/user-guide/kubectl/kubectl/ to /docs/user-guide/kubectl/

fixes #1441 34613
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1441)
<!-- Reviewable:end -->
