### PR TITLE
Addition to openssl certificate creation process

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -470,4 +470,8 @@ Finally, add the following parameters into API server start parameters:
 
           openssl x509  -noout -text -in ./server.crt
 
-Finally, do not forget to fill out and add the same parameters into the API server start parameters.
+1.  Fill in and add the following parameters into the API server start parameters:
+
+          --client-ca-file=/yourdirectory/ca.crt
+          --tls-cert-file=/yourdirectory/server.crt
+          --tls-private-key-file=/yourdirectory/server.key


### PR DESCRIPTION
Added an additional step to the openssl certificate generation process to show the required API server start parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1443)
<!-- Reviewable:end -->
