### PR TITLE
Clarify secrets file mode might be read in decimal notation

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -344,6 +344,9 @@ In this case, the file resulting in `/etc/foo/my-group/my-username` will have
 permission value of `0777`. Owing to JSON limitations, you must specify the mode
 in decimal notation.
 
+Note that this permission value might be displayed in decimal notation if you
+read it later.
+
 **Consuming Secret Values from Volumes**
 
 Inside the container that mounts a secret volume, the secret keys appear as


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/33475

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1447)
<!-- Reviewable:end -->
