### PR TITLE
Updated addons section for cluster-components

### DIFF
--- a/docs/admin/cluster-components.md
+++ b/docs/admin/cluster-components.md
@@ -61,12 +61,12 @@ selects a node for them to run on.
 
 ### addons
 
-Addons are pods and services that implement cluster features. They don't run on
-the master VM, but currently the default setup scripts that make the API calls
-to create these pods and services does run on the master VM. See:
-[kube-master-addons](http://releases.k8s.io/HEAD/cluster/saltbase/salt/kube-master-addons/kube-master-addons.sh)
+Addons are pods and services that implement cluster features. The pods may be managed
+by Deployments, ReplicationContollers, etc. Namespaced addon objects are created in
+the "kube-system" namespace.
 
-Addon objects are created in the "kube-system" namespace.
+Addon manager takes the responsibility for creating and maintaining addon resources.
+See [here](http://releases.k8s.io/HEAD/cluster/addons) for more details.
 
 #### DNS
 


### PR DESCRIPTION
Fixed #1462.

Updates the description and link on http://kubernetes.io/docs/admin/cluster-components/ for the addons section. Content pasted below.

@lavalamp 

---
### addons

Addons are resources like ReplicationContoller and Services that implement cluster features. They don't run on the master VM, but currently the program that makes the API calls to manage these addon resources does run on the master VM. See: [addon manager](http://releases.k8s.io/HEAD/cluster/addons/addon-manager)

Addon objects are created in the "kube-system" namespace except `PersistentVolumes`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1463)

<!-- Reviewable:end -->
