### PR TITLE
Update hellonode.md

### DIFF
--- a/docs/hellonode.md
+++ b/docs/hellonode.md
@@ -152,6 +152,8 @@ If all goes well, you should be able to see the container image listed in the co
 
 ![image](/images/hellonode/image_10.png)
 
+**Note:** *Docker for Windows, Version 1.12 or 1.12.1, does not yet support this procedure. Instead, it replies with the message 'denied: Unable to access the repository; please check that you have permission to access it'. A bugfix is available at http://stackoverflow.com/questions/39277986/unable-to-push-to-google-container-registry-unable-to-access-the-repository?answertab=votes#tab-top.*
+
 ## Create your Kubernetes Cluster
 
 A cluster consists of a Master API server and a set of worker VMs called Nodes.


### PR DESCRIPTION
Docker for Windows 1.12/1.12.1 does not work as described when pushing images to the google container image registry - it stops with an error message. It takes a long time (6h to several days) to find a solution and since Docker is becoming more popular on windows this seems worth mentioning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1467)
<!-- Reviewable:end -->
