### PR TITLE
Added livenessprobe example with hidden parameters

### DIFF
--- a/docs/user-guide/pod-states.md
+++ b/docs/user-guide/pod-states.md
@@ -89,6 +89,40 @@ If a node dies or is disconnected from the rest of the cluster, some entity with
 
 ## Examples
 
+### Advanced livenessProbe example
+
+Liveness probes are executed by `kubelet`, so all requests will be made within kubelet network namespace.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness
+  name: liveness-http
+spec:
+  containers:
+  - args:
+    - /server
+    image: gcr.io/google_containers/liveness
+    livenessProbe:
+      httpGet:
+        # when "host" is not defined, "PodIP" will be used
+        # host: my-host
+        # when "scheme" is not defined, "HTTP" scheme will be used. Only "HTTP" and "HTTPS" are allowed
+        # scheme: HTTPS
+        path: /healthz
+        port: 8080
+        httpHeaders:
+          - name: X-Custom-Header
+            value: Awesome
+      initialDelaySeconds: 15
+      timeoutSeconds: 1
+    name: liveness
+```
+
+### Example states
+
    * Pod is `Running`, 1 container, container exits success
      * Log completion event
      * If RestartPolicy is:


### PR DESCRIPTION
Didn't find any mention about the HTTP/HTTPS  scheme or host definition. Fixed.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1496)

<!-- Reviewable:end -->
