### PR TITLE
Update link to Kompose repository

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -35,6 +35,6 @@ Use Helm to:
 
 ### Kompose 
 
-[`kompose`](https://github.com/skippbox/kompose) is a tool to help users familiar with `docker-compose`
+[Kompose](https://github.com/kubernetes-incubator/kompose) is a tool to help users familiar with `docker-compose`
 move to Kubernetes. It takes a Docker Compose file and translates it into Kubernetes objects. `kompose`
 is a convenient tool to go from local Docker development to managing your application with Kubernetes.


### PR DESCRIPTION
Kompose has been moved to kubernetes-incubator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1499)
<!-- Reviewable:end -->
