### PR TITLE
Fix typo 'ectdclt'

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -123,7 +123,7 @@ KUBE_API_ARGS=""
 
 ```shell
 $ etcdctl mkdir /kube-centos/network
-$ etcdclt mk /kube-centos/network/config "{ \"Network\": \"172.30.0.0/16\", \"SubnetLen\": 24, \"Backend\": { \"Type\": \"vxlan\" } }"
+$ etcdctl mk /kube-centos/network/config "{ \"Network\": \"172.30.0.0/16\", \"SubnetLen\": 24, \"Backend\": { \"Type\": \"vxlan\" } }"
 ```
 
 * Configure flannel to overlay Docker network in /etc/sysconfig/flanneld on the master (also in the nodes as we'll see):


### PR DESCRIPTION
Fix 'ectdclt' to 'etcdctl'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1542)
<!-- Reviewable:end -->
