### PR TITLE
moving kube-up.sh to legacy for aws install

### DIFF
--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -12,22 +12,18 @@ assignees:
 
 ## Supported Production Grade Tools with High Availability Options
 
-* [Kubernetes Operations](https://github.com/kubernetes/kops) - Production Grade K8s Installation, Upgrades, and Management. Supports running Debian and CentOS in AWS.
+* [Kubernetes Operations](https://github.com/kubernetes/kops) - Production Grade K8s Installation, Upgrades, and Management. Supports running Debian, Ubuntu, CentOS, and RHEL in AWS.
 
 * CoreOS maintains [a CLI tool](https://coreos.com/kubernetes/docs/latest/kubernetes-on-aws.html), `kube-aws` that will create and manage a Kubernetes cluster based on [CoreOS](http://www.coreos.com), using AWS tools: EC2, CloudFormation and Autoscaling.
 
-## Other Options
+---
 
-* Other community projects exist that use tools such that use other configuration management tooling.
+## kube-up bash script
 
-TODO: add more options
+> `kube-up.sh` is a legacy tool that is an easy way to spin up a cluster.  This tool is being deprecated, and does not create a production ready environment.
 
-## Legacy Tooling
 
-`kube-up.sh` is a legacy tool that is an easy way to spin up a cluster.  This tool
-is being deprecated, and does not create a production ready environment.
-
-## Prerequisites
+### Prerequisites
 
 1. You need an AWS account. Visit [http://aws.amazon.com](http://aws.amazon.com) to get started
 2. Install and configure the [AWS Command Line Interface](http://aws.amazon.com/cli)
@@ -40,9 +36,9 @@ You may explicitly set the AWS profile to use using the `AWS_DEFAULT_PROFILE` en
 export AWS_DEFAULT_PROFILE=myawsprofile
 ```
 
-## Cluster turnup
+### Cluster turnup
 
-### Supported procedure: `get-kube`
+#### Supported procedure: `get-kube`
 
 ```shell
 #Using wget

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -2,11 +2,30 @@
 assignees:
 - justinsb
 - lavalamp
+- clove
 
 ---
 
 * TOC
 {:toc}
+
+
+## Supported Production Grade Tools with High Availability Options
+
+* [Kubernetes Operations](https://github.com/kubernetes/kops) - Production Grade K8s Installation, Upgrades, and Management. Supports running Debian and CentOS in AWS.
+
+* CoreOS maintains [a CLI tool](https://coreos.com/kubernetes/docs/latest/kubernetes-on-aws.html), `kube-aws` that will create and manage a Kubernetes cluster based on [CoreOS](http://www.coreos.com), using AWS tools: EC2, CloudFormation and Autoscaling.
+
+## Other Options
+
+* Other community projects exist that use tools such that use other configuration management tooling.
+
+TODO: add more options
+
+## Legacy Tooling
+
+`kube-up.sh` is a legacy tool that is an easy way to spin up a cluster.  This tool
+is being deprecated, and does not create a production ready environment.
 
 ## Prerequisites
 
@@ -97,12 +116,7 @@ If these already exist, make sure you want them to be used here.
 
 NOTE: If using an existing keypair named "kubernetes" then you must set the `AWS_SSH_KEY` key to point to your private key.
 
-### Alternatives
 
-* [kops](https://github.com/kubernetes/kops) "kubernetes-ops" is a complete Kubernetes cluster lifecycle management tool,
-  that supports AWS.
-
-* CoreOS maintains [a CLI tool](https://coreos.com/kubernetes/docs/latest/kubernetes-on-aws.html), `kube-aws` that will create and manage a Kubernetes cluster based on [CoreOS](http://www.coreos.com), using AWS tools: EC2, CloudFormation and Autoscaling.
 
 ## Getting started with your cluster
 
@@ -162,6 +176,3 @@ For support level information on all solutions, see the [Table of solutions](/do
 
 Please see the [Kubernetes docs](/docs/) for more details on administering
 and using a Kubernetes cluster.
-
-
-


### PR DESCRIPTION
This change moves kube-up.sh install path to a legacy status.  Many aws users are struggling with k8s when they use kube-up.sh.  It is an awesome tool, but it needs to be gently sunset.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1562)

<!-- Reviewable:end -->
