### PR TITLE
Link to http://kubernetes.io/docs/admin/networking broken, formatting

### DIFF
--- a/docs/admin/networking.md
+++ b/docs/admin/networking.md
@@ -5,18 +5,8 @@ assignees:
 
 ---
 
-Kubernetes approaches networking somewhat differently than Docker does by
-default.  There are 4 distinct networking problems to solve:
-
-1. Highly-coupled container-to-container communications: this is solved by
-   [pods](/docs/user-guide/pods/) and `localhost` communications.
-2. Pod-to-Pod communications: this is the primary focus of this document.
-3. Pod-to-Service communications: this is covered by [services](/docs/user-guide/services/).
-4. External-to-Service communications: this is covered by [services](/docs/user-guide/services/).
-
 * TOC
 {:toc}
-
 
 ## Summary
 
@@ -55,6 +45,15 @@ coordinate which ports they use very carefully or else be allocated ports
 dynamically.
 
 ## Kubernetes model
+
+Kubernetes approaches networking somewhat differently than Docker does by
+default.  There are 4 distinct networking problems to solve:
+
+1. Highly-coupled container-to-container communications: this is solved by
+   [pods](/docs/user-guide/pods/) and `localhost` communications.
+2. Pod-to-Pod communications: this is the primary focus of this document.
+3. Pod-to-Service communications: this is covered by [services](/docs/user-guide/services/).
+4. External-to-Service communications: this is covered by [services](/docs/user-guide/services/).
 
 Coordinating ports across multiple developers is very difficult to do at
 scale and exposes users to cluster-level issues outside of their control.


### PR DESCRIPTION
Hi there! So, the current link to http://kubernetes.io/docs/admin/networking is broken, and I can only see that the "toc" has to be at the top, and the text with no heading needs to to in the introduction section to kubernetes networking (not above Summary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1582)
<!-- Reviewable:end -->
