### PR TITLE
Fix services partners -> tech partners for Tigera

### DIFF
--- a/_includes/partner-script.js
+++ b/_includes/partner-script.js
@@ -190,7 +190,7 @@
 			blurb: 'Jetstack is an organisation focused entirely on Kubernetes. They will help you to get the most out of Kubernetes through expert professional services and open source tooling. Get in touch, and accelerate your project.'
 		},
 		{
-			type: 1,
+			type: 0,
 			name: 'Tigera',
 			logo: 'tigera',
 			link: 'http://docs.projectcalico.org/v1.5/getting-started/kubernetes/',


### PR DESCRIPTION
I'm rather dull, and accidentally added Tigera to the _Services_ section rather than the _Tech_ partners section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1610)
<!-- Reviewable:end -->
