### PR TITLE
Deprecate extensions/v1beta1.Job

### DIFF
--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -21,6 +21,12 @@ due to a node hardware failure or a node reboot).
 
 A Job can also be used to run multiple pods in parallel.
 
+### extensions/v1beta1.Job is deprecated
+
+Starting from version 1.5 `extensions/v1beta1.Job` is being deprecated, with a plan to be removed in
+version 1.6 of kubernetes (see this [issue](https://github.com/kubernetes/kubernetes/issues/32763)).
+Please use `batch/v1.Job` instead.
+
 ## Running an example Job
 
 Here is an example Job config.  It computes π to 2000 places and prints it out.

--- a/docs/user-guide/kubectl-conventions.md
+++ b/docs/user-guide/kubectl-conventions.md
@@ -36,7 +36,9 @@ In order for `kubectl run` to satisfy infrastructure as code:
 * Pod - use `run-pod/v1`.
 * Replication controller - use `run/v1`.
 * Deployment - use `deployment/v1beta1`.
-* Job (using `extension/v1beta1` endpoint) - use `job/v1beta1`.
+* Job (using `extension/v1beta1` endpoint) - use `job/v1beta1`. Starting from
+  version 1.5 of kuberentes this generator is deprecated, with a plan to be
+  removed in 1.6. Please use `job/v1` instead.
 * Job - use `job/v1`.
 * ScheduledJob - use `scheduledjob/v2alpha1`.
 


### PR DESCRIPTION
This is a pre-req for removing `extensions/v1beta1.Jobs` in the next release. 

I've submitted https://github.com/kubernetes/kubernetes/pull/36355, which is need before merging this one, so that I can update the api-reference docs with the information about `extensions/v1beta1.Job` being deprecated, I'll remove the do-not-merge label when that gets in and I'll update this PR.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1634)
<!-- Reviewable:end -->
