### PR TITLE
Fedora docs fixes

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_ansible_config.md
+++ b/docs/getting-started-guides/fedora/fedora_ansible_config.md
@@ -37,7 +37,7 @@ master,etcd = kube-master.example.com
 If not
 
 ```shell
-yum install -y ansible git python-netaddr
+dnf install -y ansible git python-netaddr
 ```
 
 **Now clone down the Kubernetes repository**

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -76,7 +76,7 @@ systemctl stop iptables-services firewalld
 KUBE_API_ADDRESS="--address=0.0.0.0"
 
 # Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:4001"
+KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
@@ -85,10 +85,10 @@ KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 KUBE_API_ARGS=""
 ```
 
-* Edit /etc/etcd/etcd.conf to let etcd listen on all available IPs instead of 127.0.0.1; If you have not done this, you might see an error such as "connection refused". Note that Fedora 22 uses etcd 2.0, One of the changes in etcd 2.0 is that now uses port 2379 and 2380 (as opposed to etcd 0.46 which userd 4001 and 7001).
+* Edit /etc/etcd/etcd.conf to let etcd listen on all available IPs instead of 127.0.0.1; If you have not done this, you might see an error such as "connection refused".
 
 ```shell
-ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:4001"
+ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
 ```
 
 * Create /var/run/kubernetes on master:

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -52,20 +52,12 @@ echo "192.168.121.9	fed-master
 192.168.121.65	fed-node" >> /etc/hosts
 ```
 
-* Edit /etc/kubernetes/config which will be the same on all hosts (master and node) to contain:
+* Edit /etc/kubernetes/config (which should be the same on all hosts) to set
+the name of the master server:
 
 ```shell
 # Comma separated list of nodes in the etcd cluster
 KUBE_MASTER="--master=http://fed-master:8080"
-
-# logging to stderr means we get it in the systemd journal
-KUBE_LOGTOSTDERR="--logtostderr=true"
-
-# journal message level, 0 is debug
-KUBE_LOG_LEVEL="--v=0"
-
-# Should this cluster be allowed to run privileged docker containers
-KUBE_ALLOW_PRIV="--allow-privileged=false"
 ```
 
 * Disable the firewall on both the master and node, as docker does not play well with other firewall rule managers.  Please note that iptables-services does not exist on default fedora server install.
@@ -93,7 +85,7 @@ KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 KUBE_API_ARGS=""
 ```
 
-* Edit /etc/etcd/etcd.conf,let the etcd to listen all the ip instead of 127.0.0.1, if not, you will get the error like "connection refused". Note that Fedora 22 uses etcd 2.0, One of the changes in etcd 2.0 is that now uses port 2379 and 2380 (as opposed to etcd 0.46 which userd 4001 and 7001).
+* Edit /etc/etcd/etcd.conf to let etcd listen on all available IPs instead of 127.0.0.1; If you have not done this, you might see an error such as "connection refused". Note that Fedora 22 uses etcd 2.0, One of the changes in etcd 2.0 is that now uses port 2379 and 2380 (as opposed to etcd 0.46 which userd 4001 and 7001).
 
 ```shell
 ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:4001"

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -91,14 +91,6 @@ KUBE_API_ARGS=""
 ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
 ```
 
-* Create /var/run/kubernetes on master:
-
-```shell
-mkdir /var/run/kubernetes
-chown kube:kube /var/run/kubernetes
-chmod 750 /var/run/kubernetes
-```
-
 * Start the appropriate services on master:
 
 ```shell

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -11,7 +11,7 @@ assignees:
 
 ## Prerequisites
 
-1. You need 2 or more machines with Fedora installed.
+1. You need 2 or more machines with Fedora installed. These can be either bare metal machines or virtual machines.
 
 ## Instructions
 

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -33,18 +33,18 @@ fed-node = 192.168.121.65
 **Prepare the hosts:**
 
 * Install Kubernetes on all hosts - fed-{master,node}.  This will also pull in docker. Also install etcd on fed-master.  This guide has been tested with kubernetes-0.18 and beyond.
-* The [--enablerepo=updates-testing](https://fedoraproject.org/wiki/QA:Updates_Testing) directive in the yum command below will ensure that the most recent Kubernetes version that is scheduled for pre-release will be installed. This should be a more recent version than the Fedora "stable" release for Kubernetes that you would get without adding the directive.
-* If you want the very latest Kubernetes release [you can download and yum install the RPM directly from Fedora Koji](http://koji.fedoraproject.org/koji/packageinfo?packageID=19202) instead of using the yum install command below.
+* The [--enablerepo=updates-testing](https://fedoraproject.org/wiki/QA:Updates_Testing) directive in the dnf command below will ensure that the most recent Kubernetes version that is scheduled for pre-release will be installed. This should be a more recent version than the Fedora "stable" release for Kubernetes that you would get without adding the directive.
+* If you want the very latest Kubernetes release [you can download and dnf install the RPM directly from Fedora Koji](http://koji.fedoraproject.org/koji/packageinfo?packageID=19202) instead of using the dnf install command below.
 * Running on AWS EC2 with RHEL 7.2, you need to enable "extras" repository for yum by editing `/etc/yum.repos.d/redhat-rhui.repo` and changing the changing the `enable=0` to `enable=1` for extras.
 
 ```shell
-yum -y install --enablerepo=updates-testing kubernetes
+dnf -y install --enablerepo=updates-testing kubernetes
 ```
 
 * Install etcd and iptables
 
 ```shell
-yum -y install etcd iptables
+dnf -y install etcd iptables
 ```
 
 * Add master and node to /etc/hosts on all machines (not needed if hostnames already in DNS). Make sure that communication works between fed-master and fed-node by using a utility such as ping.

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -39,10 +39,10 @@ fed-node = 192.168.121.65
 dnf -y install kubernetes
 ```
 
-* Install etcd and iptables
+* Install etcd
 
 ```shell
-dnf -y install etcd iptables
+dnf -y install etcd
 ```
 
 * Add master and node to /etc/hosts on all machines (not needed if hostnames already in DNS). Make sure that communication works between fed-master and fed-node by using a utility such as ping.

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -33,12 +33,10 @@ fed-node = 192.168.121.65
 **Prepare the hosts:**
 
 * Install Kubernetes on all hosts - fed-{master,node}.  This will also pull in docker. Also install etcd on fed-master.  This guide has been tested with kubernetes-0.18 and beyond.
-* The [--enablerepo=updates-testing](https://fedoraproject.org/wiki/QA:Updates_Testing) directive in the dnf command below will ensure that the most recent Kubernetes version that is scheduled for pre-release will be installed. This should be a more recent version than the Fedora "stable" release for Kubernetes that you would get without adding the directive.
-* If you want the very latest Kubernetes release [you can download and dnf install the RPM directly from Fedora Koji](http://koji.fedoraproject.org/koji/packageinfo?packageID=19202) instead of using the dnf install command below.
 * Running on AWS EC2 with RHEL 7.2, you need to enable "extras" repository for yum by editing `/etc/yum.repos.d/redhat-rhui.repo` and changing the changing the `enable=0` to `enable=1` for extras.
 
 ```shell
-dnf -y install --enablerepo=updates-testing kubernetes
+dnf -y install kubernetes
 ```
 
 * Install etcd and iptables

--- a/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
+++ b/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
@@ -49,6 +49,12 @@ etcdctl get /coreos.com/network/config
 
 **Perform following commands on all Kubernetes nodes**
 
+Install the flannel package
+
+```shell
+# dnf -y install flannel
+```
+
 Edit the flannel configuration file /etc/sysconfig/flanneld as follows:
 
 ```shell

--- a/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
+++ b/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
@@ -55,7 +55,7 @@ Edit the flannel configuration file /etc/sysconfig/flanneld as follows:
 # Flanneld configuration options
 
 # etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD="http://fed-master:4001"
+FLANNEL_ETCD="http://fed-master:2379"
 
 # etcd config key.  This is the configuration key that flannel queries
 # For address range assignment
@@ -104,7 +104,7 @@ Now check the interfaces on the nodes. Notice there is now a flannel.1 interface
 From any node in the cluster, check the cluster members by issuing a query to etcd server via curl (only partial output is shown using `grep -E "\{|\}|key|value"`). If you set up a 1 master and 3 nodes cluster, you should see one block for each node showing the subnets they have been assigned. You can associate those subnets to each node by the MAC address (VtepMAC) and IP address (Public IP) that is listed in the output.
 
 ```shell
-curl -s http://fed-master:4001/v2/keys/coreos.com/network/subnets | python -mjson.tool
+curl -s http://fed-master:2379/v2/keys/coreos.com/network/subnets | python -mjson.tool
 ```
 
 ```json

--- a/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
+++ b/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
@@ -148,7 +148,7 @@ bash-4.3#
 This will place you inside the container. Install iproute and iputils packages to install ip and ping utilities. Due to a [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1142311), it is required to modify capabilities of ping binary to work around "Operation not permitted" error.
 
 ```shell
-bash-4.3# yum -y install iproute iputils
+bash-4.3# dnf -y install iproute iputils
 bash-4.3# setcap cap_net_raw-ep /usr/bin/ping
 ```
 


### PR DESCRIPTION
The Fedora getting-started docs is quite outdated still written from the POV of Fedora 21/22. Update the content to reflect currently supported Fedora version (23/24/25)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1665)
<!-- Reviewable:end -->
