### PR TITLE
Fix shell example in sharing-clusters.md

### DIFF
--- a/docs/user-guide/sharing-clusters.md
+++ b/docs/user-guide/sharing-clusters.md
@@ -115,12 +115,12 @@ make all four clusters available on both hosts by running
 # on host2, copy host1's default kubeconfig, and merge it from env
 $ scp host1:/path/to/home1/.kube/config /path/to/other/.kube/config
 
-$ export $KUBECONFIG=/path/to/other/.kube/config
+$ export KUBECONFIG=/path/to/other/.kube/config
 
 # on host1, copy host2's default kubeconfig and merge it from env
 $ scp host2:/path/to/home2/.kube/config /path/to/other/.kube/config
 
-$ export $KUBECONFIG=/path/to/other/.kube/config
+$ export KUBECONFIG=/path/to/other/.kube/config
 ```
 
 Detailed examples and explanation of `kubeconfig` loading/merging rules can be found in [kubeconfig-file](/docs/user-guide/kubeconfig-file).


### PR DESCRIPTION
'export' command should not include dollar signs in variable declaration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1709)
<!-- Reviewable:end -->
