### PR TITLE
Address formatting

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -65,6 +65,7 @@ export GOVC_DATACENTER='ha-datacenter' # The datacenter to be used by vSphere cl
 ```
 
 Sample environment
+
 ```shell
 export GOVC_URL='10.161.236.217'
 export GOVC_USERNAME='administrator'
@@ -79,6 +80,7 @@ export GOVC_DATACENTER='Datacenter'
 ```
 
 Import this VMDK into your vSphere datastore:
+
 ```shell
 govc import.vmdk kube.vmdk ./kube/
 ```


### PR DESCRIPTION
Currently the 'sample environment' code block all shows on one line at http://kubernetes.io/docs/getting-started-guides/vsphere/, hoping this will fix it (github preview looks correct either way).

<img width="894" alt="screen shot 2016-11-17 at 2 20 48 pm" src="https://cloud.githubusercontent.com/assets/25628/20404006/0ffd8160-acd1-11e6-8b0b-36ebc16e123d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1713)
<!-- Reviewable:end -->
