### PR TITLE
List Deployment next to ReplicationController

### DIFF
--- a/docs/user-guide/pod-states.md
+++ b/docs/user-guide/pod-states.md
@@ -66,8 +66,8 @@ The possible values for RestartPolicy are `Always`, `OnFailure`, or `Never`. If 
 Three types of controllers are currently available:
 
 - Use a [`Job`](/docs/user-guide/jobs/) for pods which are expected to terminate (e.g. batch computations).
-- Use a [`ReplicationController`](/docs/user-guide/replication-controller/) for pods which are not expected to
-  terminate (e.g. web servers).
+- Use a [`ReplicationController`](/docs/user-guide/replication-controller/) or  [`Deployment`](/docs/user-guide/deployments/)
+  for pods which are not expected to terminate (e.g. web servers).
 - Use a [`DaemonSet`](/docs/admin/daemons/): Use for pods which need to run 1 per machine because they provide a
   machine-specific system service.
 If you are unsure whether to use ReplicationController or Daemon, then see [Daemon Set versus


### PR DESCRIPTION
RestartPolicy section gives an example of what kind of controller
should be used for what type of workload. However it only lists
rc for web-server type workloads. Adding Deployment next to rc
as well.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1716)
<!-- Reviewable:end -->
