### PR TITLE
Very basic kubeadm reset command formatting fix.

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -260,7 +260,7 @@ If there is a firewall, make sure it exposes this port to the internet before yo
 
 * To undo what `kubeadm` did, simply run:
 
-    # kubeadm reset
+      # kubeadm reset
 
   If you wish to start over, run `systemctl start kubelet` followed by `kubeadm init` or `kubeadm join`.
 


### PR DESCRIPTION
This is a very basic fix for the code block not being displayed for the `kubeadm reset` command properly. Wanted to submit this primarily to get familiar with the docs commit process and this was low hanging fruit!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1721)
<!-- Reviewable:end -->
