### PR TITLE
Mention kubectl as a requirement for running kops

### DIFF
--- a/docs/getting-started-guides/kops.md
+++ b/docs/getting-started-guides/kops.md
@@ -26,6 +26,12 @@ a building block.  kops builds on the kubeadm work.
 
 ### (1/5) Install kops
 
+#### Requirements
+
+You must have [kubectl](http://kubernetes.io/docs/getting-started-guides/kubectl/) installed in order for kops to work.
+
+#### Installation
+
 Download kops from the [releases page](https://github.com/kubernetes/kops/releases) (it is also easy to build from source):
 
 On MacOS:


### PR DESCRIPTION
When deploying a cluster and kubectl is not installed, kops exits
with an error. Need to mention kubectl as a requirement in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1735)
<!-- Reviewable:end -->
