### PR TITLE
Fix broken path in pv configuration, minor doc improvement

### DIFF
--- a/docs/user-guide/persistent-volumes/volumes/local-01.yaml
+++ b/docs/user-guide/persistent-volumes/volumes/local-01.yaml
@@ -10,4 +10,4 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/somepath/data01"
+    path: "/tmp/data01"

--- a/docs/user-guide/persistent-volumes/walkthrough.md
+++ b/docs/user-guide/persistent-volumes/walkthrough.md
@@ -27,7 +27,7 @@ for ease of development and testing.  You'll create a local `HostPath` for this 
 support local storage on the host at this time.  There is no guarantee your pod ends up on the correct node where the `HostPath` resides.
 
 ```shell
-# This will be nginx's webroot
+# This will be nginx's webroot; execute this on the node where your pod will run.
 $ mkdir /tmp/data01
 $ echo 'I love Kubernetes storage!' > /tmp/data01/index.html
 ```


### PR DESCRIPTION
Working through the persistent-volumes tutorial, I noted that the pod could never come up, due to the PV path being set to /somepath/data01 instead of /tmp/data01 (as specified in the instructions)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1741)
<!-- Reviewable:end -->
