### PR TITLE
Add Weave to the list of NetworkPolicy implementations

### DIFF
--- a/docs/getting-started-guides/network-policy/walkthrough.md
+++ b/docs/getting-started-guides/network-policy/walkthrough.md
@@ -10,6 +10,7 @@ In this article, we assume a Kubernetes cluster has been created with network po
 
 * [Calico](/docs/getting-started-guides/network-policy/calico/)
 * [Romana](/docs/getting-started-guides/network-policy/romana/)
+* [Weave Net](/docs/getting-started-guides/network-policy/weave/)
 
 The reference implementation is [Calico](/docs/getting-started-guides/network-policy/calico) running on GCE.
 

--- a/docs/getting-started-guides/network-policy/weave.md
+++ b/docs/getting-started-guides/network-policy/weave.md
@@ -1,0 +1,11 @@
+---
+assignees:
+- bboreham
+
+---
+
+The [Weave Net Addon](https://www.weave.works/docs/net/latest/kube-addon/) for Kubernetes comes with a Network Policy Controller.
+
+This component automatically monitors Kubernetes for any NetworkPolicy annotations on all namespaces, and configures `iptables` rules to allow or block traffic as directed by the policies.
+
+Once you have installed the Weave Net Addon you can follow the [NetworkPolicy gettting started guide](/docs/getting-started-guides/network-policy/walkthrough) to try out Kubernetes NetworkPolicy.


### PR DESCRIPTION
Patterned after the Calico and Romana files in the same directory.

I don't know what "assignees" does.  Hope it's something good.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1777)
<!-- Reviewable:end -->
