### PR TITLE
Add instructions for using bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ Make any changes you want. Then, to see your changes locally:
 	cd kubernetes.github.io
 	jekyll serve
 
-Your copy of the site will then be viewable at: [http://localhost:4000](http://localhost:4000)
+If you do not want jekyll to interfere with your other globally installed gems, you can use bundler:
+
+	gem install bundler
+	bundle install
+	bundler exec jekyll serve
+
+Regardless of whether you use `bundler` or not, your copy of the site will then be viewable at: [http://localhost:4000](http://localhost:4000)
 (or wherever Jekyll tells you).
 
 ## GitHub help


### PR DESCRIPTION
Alternative to using a global installation of all required gems.

Also, there seems to be a mixed usage of tabs and spaces in the README file's code blocks. Could add that to this PR as well, unless there's a specific reason not to (I did test converting tabs to spaces, GH still displays the code blocks correctly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1796)
<!-- Reviewable:end -->
