### PR TITLE
Added local channels to Support page

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,6 +59,13 @@ interest. For example, people new to Kubernetes may also want to join the
 `#kubernetes-novice` channel. As another example, developers should join the
 `#kubernetes-dev` channel.
 
+There are also many country specific/local language channels. Feel free to join
+these channels for localized support and info:
+
+- France: `#fr-users`, `#fr-events`
+- Germany: `#de-users`, `#de-events`
+- Japan: `#jp-users`, `#jp-events`
+
 ### Mailing List
 
 The Kubernetes / Google Container Engine mailing list is [kubernetes-users@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-users)


### PR DESCRIPTION
This change adds info on the local country specific support channels. The rationale for including them here is that local language folks will assume the entire Slack community is English speaking and will look elsewhere for other localized support channels.

This also provides info that local support folks can point users to for local community support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1809)
<!-- Reviewable:end -->
