### PR TITLE
Fix minor issues

### DIFF
--- a/docs/user-guide/labels.md
+++ b/docs/user-guide/labels.md
@@ -99,10 +99,10 @@ _Set-based_ requirements can be mixed with _equality-based_ requirements. For ex
 
 ### LIST and WATCH filtering
 
-LIST and WATCH operations may specify label selectors to filter the sets of objects returned using a query parameter. Both requirements are permitted:
+LIST and WATCH operations may specify label selectors to filter the sets of objects returned using a query parameter. Both requirements are permitted (presented here as they would appear in a URL query string):
 
-    * _equality-based_ requirements: `?labelSelector=environment%3Dproduction,tier%3Dfrontend`
-    * _set-based_ requirements: `?labelSelector=environment+in+%28production%2Cqa%29%2Ctier+in+%28frontend%29`
+  * _equality-based_ requirements: `?labelSelector=environment%3Dproduction,tier%3Dfrontend`
+  * _set-based_ requirements: `?labelSelector=environment+in+%28production%2Cqa%29%2Ctier+in+%28frontend%29`
 
 Both label selector styles can be used to list or watch resources via a REST client. For example, targeting `apiserver` with `kubectl` and using _equality-based_ one may write:
 


### PR DESCRIPTION
The two affected lines:
- Were both represented entirely in a code block due to indentation,
which does not appear to be the intent.
- Look like a mess if you don't know they are formatted as a URL query
string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1851)
<!-- Reviewable:end -->
