### PR TITLE
fix incorrect link and other doc errors

### DIFF
--- a/docs/tutorials/kubernetes-basics/cluster-intro.html
+++ b/docs/tutorials/kubernetes-basics/cluster-intro.html
@@ -72,7 +72,7 @@ redirect_from:
 
 		<div class="row">
 			<div class="col-md-8">
-				<p><b>The Master is responsible for managing the cluster.</b> The master coordinates all activity in your cluster, such as scheduling applications, maintaining applications' desired state, scaling applications, and rolling out new updates.</p>
+				<p><b>The Master is responsible for managing the cluster.</b> The master coordinates all activities in your cluster, such as scheduling applications, maintaining applications' desired state, scaling applications, and rolling out new updates.</p>
 				<p><b>A node is a VM or a physical computer that serves as a worker machine in a Kubernetes cluster.</b> Each node has a Kubelet, which is an agent for managing the node and communicating with the Kubernetes master. The node should also have tools for handling container operations, such as Docker or rkt. A Kubernetes cluster that handles production traffic should have a minimum of three nodes.</p>
 
 			</div>
@@ -87,7 +87,7 @@ redirect_from:
 			<div class="col-md-8">
 				<p>When you deploy applications on Kubernetes, you tell the master to start the application containers. The master schedules the containers to run on the cluster's nodes. <b>The nodes communicate with the master using the Kubernetes API</b>, which the master exposes. End users can also use the Kubernetes API directly to interact with the cluster.</p>
 
-				<p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use <a href="https://github.com/kubernetes/minikube">minikube</a>.  Minikube is a lightweight Kubernetes implementation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, Mac OS  and Windows systems. The minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete. For this bootcamp, however, you'll use a provided online terminal with minikube pre-installed.</p>
+				<p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use <a href="https://github.com/kubernetes/minikube">Minikube</a>.  Minikube is a lightweight Kubernetes implementation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, Mac OS  and Windows systems. The Minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete. For this bootcamp, however, you'll use a provided online terminal with Minikube pre-installed.</p>
 
 				<p>Now that you know what Kubernetes is, let’s go to the online tutorial and start our first cluster!</p>
 

--- a/docs/tutorials/kubernetes-basics/explore-intro.html
+++ b/docs/tutorials/kubernetes-basics/explore-intro.html
@@ -27,7 +27,7 @@
 
 			<div class="col-md-8">
 				<h2>Kubernetes Pods</h2>
-				<p>When you created a Deployment in Module <a href="/docs/tutorials/kubernetes-basics/deploy-app.html">2</a>, Kubernetes created a <b>Pod</b> to host your application instance. A Pod is Kubernetes abstraction that represents a group of one or more application containers (such as Docker or rkt), and some shared resources for those containers. Those resources include:</p>
+				<p>When you created a Deployment in Module <a href="/docs/tutorials/kubernetes-basics/deploy-intro/">2</a>, Kubernetes created a <b>Pod</b> to host your application instance. A Pod is Kubernetes abstraction that represents a group of one or more application containers (such as Docker or rkt), and some shared resources for those containers. Those resources include:</p>
 				<ul>
 					<li>Shared storage, as Volumes</li>
 					<li>Networking, as a unique cluster IP address</li>
@@ -106,7 +106,7 @@
 		<div class="row">
 			<div class="col-md-8">
 				<h2>Troubleshooting with kubectl</h2>
-				<p>In Module <a href="2-0.html">2</a>, you used Kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl commands:</p>
+				<p>In Module <a href="/docs/tutorials/kubernetes-basics/deploy-intro/">2</a>, you used Kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl commands:</p>
 				<ul>
 					<li><b>kubectl get</b> - list resources</li>
 					<li><b>kubectl describe</b> - show detailed information about a resource</li>
@@ -114,7 +114,7 @@
 					<li><b>kubectl exec</b> - execute a command on a container in a pod</li>
 				</ul>
 
-				<p>You can use these commands to see when applications were deployed, what their current status is, where they are running and what their configuration is.</p>
+				<p>You can use these commands to see when applications were deployed, what their current statuses are, where they are running and what their configurations are.</p>
 
 				<p>Now that we know more about our cluster components and the command line, let’s explore our application.</p>
 

--- a/docs/tutorials/kubernetes-basics/scale-intro.html
+++ b/docs/tutorials/kubernetes-basics/scale-intro.html
@@ -25,7 +25,7 @@
 			<div class="col-md-8">
        <h3>Scaling an application</h3>
 
-			<p>In the previous modules we created a <a href="http://kubernetes.io/docs/user-guide/deployments/"> Deployment</a>, and then exposed it publicly via a <a href="http://kubernetes.io/docs/user-guide/services/"> Service </a>. The Deployment created  only one Pod for running our application.  When traffic increases, we will need to scale the application to keep up with  user demand.</p>
+			<p>In the previous modules we created a <a href="http://kubernetes.io/docs/user-guide/deployments/"> Deployment</a>, and then exposed it publicly via a <a href="http://kubernetes.io/docs/user-guide/services/">Service</a>. The Deployment created only one Pod for running our application.  When traffic increases, we will need to scale the application to keep up with  user demand.</p>
 
 			<p><b>Scaling</b> is accomplished by changing the number of replicas in a Deployment</p>
 

--- a/docs/tutorials/kubernetes-basics/update-intro.html
+++ b/docs/tutorials/kubernetes-basics/update-intro.html
@@ -25,10 +25,10 @@
 			<div class="col-md-8">
 			<h3>Updating an application</h3>
 
-			<p>Users expect applications to be available all the time and developers are expected to deploy new versions of them several times a day. In Kubernetes this is done with rolling updates. <b>Rolling updates</b> allows Deployments to occur with zero downtime by incrementally updating Pods instances with new ones. The new Pods will be scheduled on Nodes with available resources.</p>
+			<p>Users expect applications to be available all the time and developers are expected to deploy new versions of them several times a day. In Kubernetes this is done with rolling updates. <b>Rolling updates</b> allow Deployments' update to take place with zero downtime by incrementally updating Pods instances with new ones. The new Pods will be scheduled on Nodes with available resources.</p>
 
 			<p>In the previous module we scaled our application to run multiple instances. This is a requirement for performing updates without affecting application availability. By default, the maximum number of Pods that can be unavailable during the update and the maximum number of new Pods that can be created, is one. Both options can be configured to either numbers or percentages (of Pods).
-			In Kubernetes, updates are versioned and any Deployment update can be reverted to a previously (stable) version.</p>
+			In Kubernetes, updates are versioned and any Deployment update can be reverted to previous (stable) version.</p>
 
 			</div>
 			<div class="col-md-4">
@@ -39,7 +39,7 @@
 					</ul>
 				</div>
 				<div class="content__box content__box_fill">
-					<p><i>Rolling updates allows Deployments update with zero downtime by incrementally updating Pods instances with new ones. </i></p>
+					<p><i>Rolling updates allow Deployments' update to take place with zero downtime by incrementally updating Pods instances with new ones. </i></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
_docs/tutorials/kubernetes-basics/cluster-intro.html_ 
1. modify activity to plural form
2. capitalize occurences of word "minikube" because it's a proper noun.

_docs/tutorials/kubernetes-basics/explore-intro.html_
1. module 2 link fix
2. plural form fix

_docs/tutorials/kubernetes-basics/scale-intro.html_
1. delete extra suffix whitespace after word `Service` and other redundant whitespaces.

_docs/tutorials/kubernetes-basics/update-intro.html_
1. `take place` is more suitable than `occur` because rolling updates are planed.
2. other doc grammar error fixes.

Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1853)
<!-- Reviewable:end -->
