### PR TITLE
fix incorrect links and other doc errors in tutorials

### DIFF
--- a/docs/tutorials/kubernetes-basics/deploy-intro.html
+++ b/docs/tutorials/kubernetes-basics/deploy-intro.html
@@ -70,7 +70,7 @@
 
                 <p>You can create and manage a Deployment by using the Kubernetes command line interface, <b>Kubectl</b>. Kubectl uses the Kubernetes API to interact with the cluster. In this module, you'll learn the most common Kubectl commands needed to create Deployments that run your applications on a Kubernetes cluster.</p>
 
-				<p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="5-0.html">5</a> and <a href="5-0.html">6</a> of the bootcamp discuss how you can update your Deployments.</p>
+				<p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="/docs/tutorials/kubernetes-basics/scale-intro/">5</a> and <a href="/docs/tutorials/kubernetes-basics/update-intro/">6</a> of the bootcamp discuss how you can scale and update your Deployments.</p>
 
 
 
@@ -85,7 +85,7 @@
 
 		<div class="row">
 			<div class="col-md-8">
-				<p>For our first Deployment, we’ll use a <a href="https://nodejs.org">NodeJS</a> application packaged in a Docker container. The source code and the Dockerfile are available in the <a href="https://github.com/kubernetes/kubernetes-bootcamp">GitHub repository</a> for the Kubernetes Bootcamp.</p>
+				<p>For our first Deployment, we’ll use a <a href="https://nodejs.org">Node.js</a> application packaged in a Docker container. The source code and the Dockerfile are available in the <a href="https://github.com/kubernetes/kubernetes-bootcamp">GitHub repository</a> for the Kubernetes Bootcamp.</p>
 
 				<p>Now that you know what Deployments are, let’s go to the online tutorial and deploy our first app!</p>
 

--- a/docs/tutorials/kubernetes-basics/expose-intro.html
+++ b/docs/tutorials/kubernetes-basics/expose-intro.html
@@ -71,7 +71,7 @@
 
 				<p>A Service provides load balancing of traffic across the contained set of Pods. This is useful when a service is created to group all Pods from a specific Deployment (our application will make use of this in the next module, when we’ll have multiple instances running).</p>
 
-				<p>Services are also responsible for service-discovery within the cluster (covered in Module 6). This will for example allow a frontend service (like a web server) to receive traffic from a backend service (like a database) without worrying about Pods.</p>
+				<p>Services are also responsible for service-discovery within the cluster (covered in <a href="/docs/user-guide/connecting-applications/#accessing-the-service">Accessing the Service</a>). This will for example allow a frontend service (like a web server) to receive traffic from a backend service (like a database) without worrying about Pods.</p>
 
 				<p>Services match a set of Pods using Label Selectors, a grouping primitive that allows logical operation on Labels.</p>
 
@@ -119,7 +119,7 @@
 				<p>Labels can be attached to objects at the creation time or later and can be modified at any time.
 				The kubectl run command sets some default Labels/Label Selectors on the new Pods/ Deployment. The link between Labels and Label Selectors defines the relationship between the Deployment and the Pods it creates.</p>
 
-				<p>Let’s expose now our application with the help of a Service, and apply some new Labels.</p>
+				<p>Now let’s expose our application with the help of a Service, and apply some new Labels.</p>
 			</div>
 		</div>
 		<br>

--- a/docs/tutorials/stateless-application/expose-external-ip-address-service.md
+++ b/docs/tutorials/stateless-application/expose-external-ip-address-service.md
@@ -103,7 +103,7 @@ provides load balancing for an application that has two running instances.
 
         curl http://<public-node-ip>:<node-port>
 
-    where `<public-node-ip>` us the public IP address of your node,
+    where `<public-node-ip>` is the public IP address of your node,
     and `<node-port>` is the NodePort value for your service.
 
     The response to a successful request is a hello message:

--- a/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -64,7 +64,7 @@ external IP address.
         NAME         CLUSTER-IP     EXTERNAL-IP      PORT(S)    AGE
         my-service   10.3.245.137   104.198.205.71   8080/TCP   54s
 
-    Note: If the external IP address is shown as <pending>, wait for a minute
+    Note: If the external IP address is shown as \<pending\>, wait for a minute
     and enter the same command again.
 
 1. Display detailed information about the Service:
@@ -110,7 +110,7 @@ external IP address.
 
         curl http://<external-ip>:<port>
 
-    where `<external-ip>` us the external IP address of your Service,
+    where `<external-ip>` is the external IP address of your Service,
     and `<port>` is the value of `Port` in your Service description.
 
     The response to a successful request is a hello message:


### PR DESCRIPTION
_docs/tutorials/kubernetes-basics/deploy-intro.html_
1. fix incorrect module 5 and 6 links.
2. use `Node.js` instead of `NodeJS`

_docs/tutorials/kubernetes-basics/expose-intro.html_
1. module 6 actually is not about service discovery at all, i add a doc link related with service discovery here
2. minor doc tuning.

_docs/tutorials/stateless-application/expose-external-ip-address-service.md_

1.typo fix

_docs/tutorials/stateless-application/expose-external-ip-address.md_
1. `<pending>` should be escaped to `\<pending\>`, otherwise it will not be displayed correctly.
2. typo fix


Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1864)
<!-- Reviewable:end -->
