### PR TITLE
fixing broken link to container initialization doc

### DIFF
--- a/docs/user-guide/production-pods.md
+++ b/docs/user-guide/production-pods.md
@@ -204,7 +204,7 @@ The status of the init containers is returned as another annotation - `pod.beta.
 
 Init containers support all of the same features as normal containers, including resource limits, volumes, and security settings. The resource requests and limits for an init container are handled slightly different than normal containers since init containers are run one at a time instead of all at once - any limits or quotas will be applied based on the largest init container resource quantity, rather than as the sum of quantities. Init containers do not support readiness probes since they will run to completion before the pod can be ready.
 
-[Complete Init Container Documentation](/docs/user-guide/pods/init-containers.md)
+[Complete Init Container Documentation](/docs/user-guide/pods/init-container/)
 
 
 ## Lifecycle hooks and termination notice


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1867)
<!-- Reviewable:end -->
