### PR TITLE
Add deprecation warning on PetSet guide.

### DIFF
--- a/docs/user-guide/petset.md
+++ b/docs/user-guide/petset.md
@@ -10,7 +10,7 @@ assignees:
 
 ---
 
-Starting in Kubernetes version 1.5, PetSet has been renamed to
+__Warning:__ Starting in Kubernetes version 1.5, PetSet has been renamed to
 [StatefulSet](/docs/concepts/abstractions/controllers/statefulsets/).
 To use (or continue to use) PetSet in Kubernetes 1.5 or higher, you must
 [migrate your existing PetSets to StatefulSets](/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set/).

--- a/docs/user-guide/petset.md
+++ b/docs/user-guide/petset.md
@@ -1,9 +1,22 @@
 ---
 assignees:
 - bprashanth
+- enisoc
+- erictune
 - foxish
+- janetkuo
+- kow3ns
+- smarterclayton
 
 ---
+
+Starting in Kubernetes version 1.5, PetSet has been renamed to
+[StatefulSet](/docs/concepts/abstractions/controllers/statefulsets/).
+To use (or continue to use) PetSet in Kubernetes 1.5 or higher, you must
+[migrate your existing PetSets to StatefulSets](/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set/).
+
+__This document has been deprecated__, but can still apply if you're using
+  Kubernetes version 1.4 or earlier.
 
 * TOC
 {:toc}
@@ -424,4 +437,8 @@ Deploying one RC of size 1/Service per pod is a popular alternative, as is simpl
 
 ## Next steps
 
-The deployment and maintenance of stateful applications is a vast topic. The next step is to explore cluster bootstrapping and initialization, [here](/docs/user-guide/petset/bootstrapping/).
+* Learn about [StatefulSet](/docs/concepts/abstractions/controllers/statefulsets/),
+  the replacement for PetSet introduced in Kubernetes version 1.5.
+* [Migrate your existing PetSets to StatefulSets](/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set/)
+  when upgrading to Kubernetes version 1.5 or higher.
+

--- a/docs/user-guide/petset.yaml
+++ b/docs/user-guide/petset.yaml
@@ -14,8 +14,8 @@ spec:
   selector:
     app: nginx
 ---
-apiVersion: apps/v1beta1
-kind: StatefulSet
+apiVersion: apps/v1alpha1
+kind: PetSet
 metadata:
   name: web
 spec:

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -264,7 +264,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"nginx-probe-deployment":     {&extensions.Deployment{}},
 			"nginx-secure-app":           {&api.Service{}, &extensions.Deployment{}},
 			"nginx-svc":                  {&api.Service{}},
-			"petset":                     {&api.Service{}, &apps.StatefulSet{}},
+			"petset":                     {&api.Service{}, nil},
 			"pod":                        {&api.Pod{}},
 			"pod-w-message":              {&api.Pod{}},
 			"redis-deployment":           {&extensions.Deployment{}},


### PR DESCRIPTION
cc @erictune @foxish @kow3ns @janetkuo @kubernetes/sig-apps

Note that I flipped the `petset.yaml` back to `v1alpha1` since the goal is for this document to still apply to pre-1.5 users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1874)
<!-- Reviewable:end -->
