### PR TITLE
Fix minor syntax bug in the authentication docs

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -420,7 +420,7 @@ enterprise directory, kerberos, etc.)
 ### Creating Certificates
 
 When using client certificate authentication, you can generate certificates
-using an existing deployment script or manually through `easyrsa` or `openssl.``
+using an existing deployment script or manually through `easyrsa` or `openssl.`
 
 #### Using an Existing Deployment Script
 


### PR DESCRIPTION
Without this, there is a trailing `.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1881)
<!-- Reviewable:end -->
