### PR TITLE
Mention that base64 may use -D flag instead of -d

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -158,7 +158,7 @@ type: Opaque
 Decode the password field:
 
 ```shell
-$ echo "MWYyZDFlMmU2N2Rm" | base64 -d
+$ echo "MWYyZDFlMmU2N2Rm" | base64 -d  # Or base64 -D, depending on the version of base64
 1f2d1e2e67df
 ```
 


### PR DESCRIPTION
More than one implementation of base64 uses -D for decode instead of -d, so it might save people just a little time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1882)
<!-- Reviewable:end -->
