### PR TITLE
[authorization] update doc about roleRef

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -341,7 +341,7 @@ subjects:
     name: manager
 roleRef:
   kind: ClusterRole
-  name: secret-reader-global
+  name: secret-reader
   apiGroup: rbac.authorization.k8s.io
 ```
 

--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -297,9 +297,8 @@ subjects:
     name: jane
 roleRef:
   kind: Role
-  namespace: default
   name: pod-reader
-  apiVersion: rbac.authorization.k8s.io/v1alpha1
+  apiGroup: rbac.authorization.k8s.io
 ```
 
 `RoleBindings` may also refer to a `ClusterRole`. However, a `RoleBinding` that
@@ -324,7 +323,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: secret-reader
-  apiVersion: rbac.authorization.k8s.io/v1alpha1
+  apiGroup: rbac.authorization.k8s.io
 ```
 
 Finally a `ClusterRoleBinding` may be used to grant permissions in all
@@ -336,14 +335,14 @@ namespaces. The following `ClusterRoleBinding` allows any user in the group
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
-  name: read-secrets
+  name: read-secrets-global
 subjects:
   - kind: Group # May be "User", "Group" or "ServiceAccount"
     name: manager
 roleRef:
   kind: ClusterRole
-  name: secret-reader
-  apiVersion: rbac.authorization.k8s.io/v1alpha1
+  name: secret-reader-global
+  apiGroup: rbac.authorization.k8s.io
 ```
 
 ### Referring to Resources


### PR DESCRIPTION
This update is made according to this commit in code:
https://github.com/kubernetes/kubernetes/commit/8c788233e778f3b0ebef560762c1433c12ea1d43

It has already be released  with k8s v1.5, so it's reasonable to
update the doc now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1888)
<!-- Reviewable:end -->
