### PR TITLE
Fixing broken http://kubernetes.io/kubernetes/third_party/swagger-ui/

### DIFF
--- a/js/redirects.js
+++ b/js/redirects.js
@@ -6,10 +6,6 @@ $( document ).ready(function() {
     var forwardingURL=window.location.href;
 
     var redirects = [{
-        "from": "third_party/swagger-ui",
-        "to": "http://kubernetes.io/kubernetes/third_party/swagger-ui/"
-    },
-    {
         "from": "resource-quota",
         "to": "http://kubernetes.io/docs/admin/resourcequota/"
     },

--- a/kubernetes/third_party/swagger-ui/index.md
+++ b/kubernetes/third_party/swagger-ui/index.md
@@ -1,0 +1,4 @@
+---
+
+Kubernetes swagger UI has now been replaced by our generated API reference docs
+which can be accessed at http://kubernetes.io/docs/api-reference/README/.


### PR DESCRIPTION
http://kubernetes.io/kubernetes/third_party/swagger-ui/ broke when we removed the gh-pages branch (https://github.com/kubernetes/kubernetes/pull/38309#issuecomment-265601073).

Adding an index.md file at http://kubernetes.io/kubernetes/third_party/swagger-ui/ to inform users that they should now be using the API reference docs.
http://kubernetes.io/kubernetes/third_party/swagger-ui/ is still one of the top results when searching for "kubernetes swagger" so we cannot abandon it.

cc @thockin who removed the gh-pages branch.
Also cc @devin-donnelly @jaredbhatti

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1921)
<!-- Reviewable:end -->
