### PR TITLE
Slight improvement to clarity of Nodes.md

### DIFF
--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -20,7 +20,15 @@ architecture design doc for more details.
 
 ## Node Status
 
-A node's status is comprised of the following information.
+A node's status contains the following information:
+
+* [Addresses](#Addresses)
+* ~~[Phase](#Phase)~~ **deprecated**
+* [Condition](#Condition)
+* [Capacity](#Capacity)
+* [Info](#Info)
+
+Each section is described in detail below.
 
 ### Addresses
 


### PR DESCRIPTION
changes to node.md for clarity since sections and subsections visually are NOT that different in sizes and single line comment was not clear enough and looked incomplete, specially at first read. Added .idea/ directory in gitignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1925)
<!-- Reviewable:end -->
