### PR TITLE
Adding missing api-reference docs for new API groups

### DIFF
--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -5,10 +5,17 @@
 
 Use the following reference docs to understand the kubernetes REST API for various API group versions:
 
-* v1: [operations](/docs/api-reference/v1/operations.html), [model definitions](/docs/api-reference/v1/definitions.html)
-* extensions/v1beta1: [operations](/docs/api-reference/extensions/v1beta1/operations.html), [model definitions](/docs/api-reference/extensions/v1beta1/definitions.html)
-* batch/v1: [operations](/docs/api-reference/batch/v1/operations.html), [model definitions](/docs/api-reference/batch/v1/definitions.html)
+* apps/v1alpha1: [operations](/docs/api-reference/apps/v1alpha1/operations.html), [model definitions](/docs/api-reference/apps/v1alpha1/definitions.html)
+* authentication.k8s.io/v1beta1: [operations](/docs/api-reference/authentication.k8s.io/v1beta1/operations.html), [model definitions](/docs/api-reference/authentication.k8s.io/v1beta1/definitions.html)
+* authorization.k8s.io/v1beta1: [operations](/docs/api-reference/authorization.k8s.io/v1beta1/operations.html), [model definitions](/docs/api-reference/authorization.k8s.io/v1beta1/definitions.html)
 * autoscaling/v1: [operations](/docs/api-reference/autoscaling/v1/operations.html), [model definitions](/docs/api-reference/autoscaling/v1/definitions.html)
+* batch/v1: [operations](/docs/api-reference/batch/v1/operations.html), [model definitions](/docs/api-reference/batch/v1/definitions.html)
+* certificates.k8s.io/v1alpha1: [operations](/docs/api-reference/certificates.k8s.io/v1alpha1/operations.html), [model definitions](/docs/api-reference/certificates.k8s.io/v1alpha1/definitions.html)
+* extensions/v1beta1: [operations](/docs/api-reference/extensions/v1beta1/operations.html), [model definitions](/docs/api-reference/extensions/v1beta1/definitions.html)
+* policy/v1: [operations](/docs/api-reference/policy/v1/operations.html), [model definitions](/docs/api-reference/policy/v1/definitions.html)
+* rbac.authorization.k8s.io/v1alpha1: [operations](/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/operations.html), [model definitions](/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/definitions.html)
+* storage.k8s.io/v1beta1: [operations](/docs/api-reference/storage.k8s.io/v1beta1/operations.html), [model definitions](/docs/api-reference/storage.k8s.io/v1beta1/definitions.html)
+* v1: [operations](/docs/api-reference/v1/operations.html), [model definitions](/docs/api-reference/v1/definitions.html)
 
 
 


### PR DESCRIPTION
cc @caesarxuchao @thockin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1928)
<!-- Reviewable:end -->
