### PR TITLE
Fix the formatting of bullet lists on the kubelet auth page.

### DIFF
--- a/docs/admin/kubelet-authentication-authorization.md
+++ b/docs/admin/kubelet-authentication-authorization.md
@@ -17,35 +17,40 @@ This document describes how to authenticate and authorize access to the kubelet'
 ## Kubelet authentication
 
 By default, requests to the kubelet's HTTPS endpoint that are not rejected by other configured
-authentication methods are treated as anonymous requests, and given a username of `system:anonymous` 
+authentication methods are treated as anonymous requests, and given a username of `system:anonymous`
 and a group of `system:unauthenticated`.
 
 To disable anonymous access and send `401 Unauthorized` responses to unauthenticated requests:
+
 * start the kubelet with the `--anonymous-auth=false` flag
 
 To enable X509 client certificate authentication to the kubelet's HTTPS endpoint:
-* start the kubelet with the `--client-ca-file` flag, providing a CA bundle to verify client certificates with 
+
+* start the kubelet with the `--client-ca-file` flag, providing a CA bundle to verify client certificates with
 * start the apiserver with `--kubelet-client-certificate` and `--kubelet-client-key` flags
 * see the [apiserver authentication documentation](/docs/admin/authentication/#x509-client-certs) for more details
 
 To enable API bearer tokens (including service account tokens) to be used to authenticate to the kubelet's HTTPS endpoint:
+
 * ensure the `authentication.k8s.io/v1beta1` API group is enabled in the API server
 * start the kubelet with the `--authentication-token-webhook`, `--kubeconfig`, and `--require-kubeconfig` flags
-* the kubelet calls the `TokenReview` API on the configured API server to determine user information from bearer tokens 
+* the kubelet calls the `TokenReview` API on the configured API server to determine user information from bearer tokens
 
 ## Kubelet authorization
 
 Any request that is successfully authenticated (including an anonymous request) is then authorized. The default authorization mode is `AlwaysAllow`, which allows all requests.
 
 There are many possible reasons to subdivide access to the kubelet API:
+
 * anonymous auth is enabled, but anonymous users' ability to call the kubelet API should be limited
 * bearer token auth is enabled, but arbitrary API users' (like service accounts) ability to call the kubelet API should be limited
 * client certificate auth is enabled, but only some of the client certificates signed by the configured CA should be allowed to use the kubelet API
 
 To subdivide access to the kubelet API, delegate authorization to the API server:
+
 * ensure the `authorization.k8s.io/v1beta1` API group is enabled in the API server
 * start the kubelet with the `--authorization-mode=Webhook`, `--kubeconfig`, and `--require-kubeconfig` flags
-* the kubelet calls the `SubjectAccessReview` API on the configured API server to determine whether each request is authorized 
+* the kubelet calls the `SubjectAccessReview` API on the configured API server to determine whether each request is authorized
 
 The kubelet authorizes API requests using the same [request attributes](/docs/admin/authorization/#request-attributes) approach as the apiserver.
 
@@ -63,19 +68,20 @@ The resource and subresource is determined from the incoming request's path:
 
 Kubelet API  | resource | subresource
 -------------|----------|------------
-/stats/*     | nodes    | stats
-/metrics/*   | nodes    | metrics
-/logs/*      | nodes    | log
-/spec/*      | nodes    | spec
+/stats/\*     | nodes    | stats
+/metrics/\*   | nodes    | metrics
+/logs/\*      | nodes    | log
+/spec/\*      | nodes    | spec
 *all others* | nodes    | proxy
 
-The namespace and API group attributes are always an empty string, and 
+The namespace and API group attributes are always an empty string, and
 the resource name is always the name of the kubelet's `Node` API object.
 
-When running in this mode, ensure the user identified by the `--kubelet-client-certificate` and `--kubelet-client-key` 
+When running in this mode, ensure the user identified by the `--kubelet-client-certificate` and `--kubelet-client-key`
 flags passed to the apiserver is authorized for the following attributes:
-* verb=*, resource=nodes, subresource=proxy
-* verb=*, resource=nodes, subresource=stats
-* verb=*, resource=nodes, subresource=log
-* verb=*, resource=nodes, subresource=spec
-* verb=*, resource=nodes, subresource=metrics 
+
+* verb=\*, resource=nodes, subresource=proxy
+* verb=\*, resource=nodes, subresource=stats
+* verb=\*, resource=nodes, subresource=log
+* verb=\*, resource=nodes, subresource=spec
+* verb=\*, resource=nodes, subresource=metrics


### PR DESCRIPTION
The bullet lists on this page currently aren't rendering on the website because of missing blank lines. This fixes that. I also escaped some of the asterisks that were interpreted by Markdown as having special meaning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1961)
<!-- Reviewable:end -->
