### PR TITLE
Wrong path for cloud-config in kubeadm.md

### DIFF
--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -82,7 +82,7 @@ of the box. You can specify a cloud provider using `--cloud-provider`.
 Valid values are the ones supported by `controller-manager`, namely `"aws"`,
 `"azure"`, `"cloudstack"`, `"gce"`, `"mesos"`, `"openstack"`, `"ovirt"`,
 `"rackspace"`, `"vsphere"`. In order to provide additional configuration for
-the cloud provider, you should create a `/etc/kubernetes/cloud-config.json`
+the cloud provider, you should create a `/etc/kubernetes/cloud-config`
 file manually, before running `kubeadm init`. `kubeadm` automatically
 picks those settings up and ensures other nodes are configured correctly.
 You must also set the `--cloud-provider` and `--cloud-config` parameters


### PR DESCRIPTION
The cloud-config file should be located under `/etc/kubernetes/cloud-config` instead of /etc/kubernetes/cloud-config.json.
(See: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/master/manifests.go#L41 )
If the file is not in this location the controller-manager will fail to start, as he is given the --cloud-provider option without --cloud-config. (--cloud-config will only be used when  `/etc/kubernetes/cloud-config` exists https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/master/manifests.go#L367 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1965)
<!-- Reviewable:end -->
