### PR TITLE
fix indentation of a few lines

### DIFF
--- a/docs/user-guide/kubectl-overview.md
+++ b/docs/user-guide/kubectl-overview.md
@@ -18,7 +18,6 @@ kubectl [command] [TYPE] [NAME] [flags]
 ```
 
 where `command`, `TYPE`, `NAME`, and `flags` are:
-
 * `command`: Specifies the operation that you want to perform on one or more resources, for example `create`, `get`, `describe`, `delete`.
 * `TYPE`: Specifies the [resource type](#resource-types). Resource types are case-sensitive and you can specify the singular, plural, or abbreviated forms. For example, the following commands produce the same output:
 
@@ -27,11 +26,9 @@ where `command`, `TYPE`, `NAME`, and `flags` are:
     $ kubectl get pods pod1
     $ kubectl get po pod1
    ```
-
 * `NAME`: Specifies the name of the resource. Names are case-sensitive. If the name is omitted, details for all resources are displayed, for example `$ kubectl get pods`.
 
    When performing an operation on multiple resources, you can specify each resource by type and name or specify one or more files:
-
    * To specify resources by type and name:
         * To group resources if they are all the same type: `TYPE1 name1 name2 name<#>`<br/>
         Example: `$ kubectl get pod example-pod1 example-pod2`


### PR DESCRIPTION
w/o this change these lines appeared all on the same line:
```
$ kubectl get pod pod1
$ kubectl get pods pod1
$ kubectl get po pod1
```
and the "shell" directive was visible

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1972)
<!-- Reviewable:end -->
