### PR TITLE
Inconsistent command in section (5/5)

### DIFF
--- a/docs/getting-started-guides/kops.md
+++ b/docs/getting-started-guides/kops.md
@@ -134,7 +134,7 @@ GPU and non-GPU instances.
 
 Run "kops update cluster" to create your cluster in AWS:
 
-`kops update cluster useast1.dev.awsdata.com --yes`
+`kops update cluster useast1.dev.example.com --yes`
 
 That takes a few seconds to run, but then your cluster will likely take a few minutes to actually be ready.
 `kops update cluster` will be the tool you'll use whenever you change the configuration of your cluster; it


### PR DESCRIPTION
The original command to create cluster in section "(5/5) Create the cluster in AWS" is: "kops update cluster useast1.dev.awsdata.com --yes"
However, the previous steps used useast1.dev.example.com to create configuration file.
So, the "awsdata" should be changed into "example".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/1999)
<!-- Reviewable:end -->
