### PR TITLE
Delete italic style markdown symbol

### DIFF
--- a/docs/admin/daemons.md
+++ b/docs/admin/daemons.md
@@ -7,7 +7,7 @@ assignees:
 * TOC
 {:toc}
 
-## What is a _Daemon Set_?
+## What is a Daemon Set?
 
 A _Daemon Set_ ensures that all (or some) nodes run a copy of a pod.  As nodes are added to the
 cluster, pods are added to them.  As nodes are removed from the cluster, those pods are garbage

--- a/docs/user-guide/cron-jobs.md
+++ b/docs/user-guide/cron-jobs.md
@@ -9,7 +9,7 @@ assignees:
 * TOC
 {:toc}
 
-## What is a _Cron Job_?
+## What is a Cron Job?
 
 A _Cron Job_ manages time based [Jobs](/docs/user-guide/jobs/), namely:
 

--- a/docs/user-guide/deployments.md
+++ b/docs/user-guide/deployments.md
@@ -8,7 +8,7 @@ assignees:
 * TOC
 {:toc}
 
-## What is a _Deployment_?
+## What is a Deployment?
 
 A _Deployment_ provides declarative updates for [Pods](/docs/user-guide/pods/) and [Replica Sets](/docs/user-guide/replicasets/) (the next-generation Replication Controller).
 You only need to describe the desired state in a Deployment object, and the Deployment

--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -8,7 +8,7 @@ assignees:
 * TOC
 {:toc}
 
-## What is a _job_?
+## What is a job?
 
 A _job_ creates one or more pods and ensures that a specified number of them successfully terminate.
 As pods successfully complete, the _job_ tracks the successful completions.  When a specified number

--- a/docs/user-guide/pod-security-policy/index.md
+++ b/docs/user-guide/pod-security-policy/index.md
@@ -13,7 +13,7 @@ See [PodSecurityPolicy proposal](https://github.com/kubernetes/kubernetes/blob/{
 * TOC
 {:toc}
 
-## What is a _Pod Security Policy_?
+## What is a Pod Security Policy?
 
 A _Pod Security Policy_ is a cluster-level resource that controls the 
 actions that a pod can perform and what it has the ability to access. The

--- a/docs/user-guide/pods/index.md
+++ b/docs/user-guide/pods/index.md
@@ -10,7 +10,7 @@ assignees:
 _pods_ are the smallest deployable units of computing that can be created and
 managed in Kubernetes.
 
-## What is a _pod_?
+## What is a pod?
 
 A _pod_ (as in a pod of whales or pea pod) is a group of one or more containers
 (such as Docker containers), the shared storage for those containers, and

--- a/docs/user-guide/replicasets.md
+++ b/docs/user-guide/replicasets.md
@@ -9,7 +9,7 @@ assignees:
 * TOC
 {:toc}
 
-## What is a _Replica Set_?
+## What is a Replica Set?
 
 Replica Set is the next-generation Replication Controller. The only difference
 between a _Replica Set_ and a

--- a/docs/user-guide/replication-controller/index.md
+++ b/docs/user-guide/replication-controller/index.md
@@ -8,7 +8,7 @@ assignees:
 * TOC
 {:toc}
 
-## What is a _replication controller_?
+## What is a replication controller?
 
 A _replication controller_ ensures that a specified number of pod "replicas" are running at any one
 time. In other words, a replication controller makes sure that a pod or homogeneous set of pods are


### PR DESCRIPTION
These doc titles which with italic style markdown symbol(underscore) could not rendered as italic style normally.
e.g http://kubernetes.io/docs/admin/daemons/
So i deleted these underscores and seems it looks better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2000)
<!-- Reviewable:end -->
