### PR TITLE
Create prerequisites appropriate for load balancer.

### DIFF
--- a/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -12,7 +12,15 @@ external IP address.
 
 {% capture prerequisites %}
 
-{% include task-tutorial-prereqs.md %}
+ * Install [kubectl](http://kubernetes.io/docs/user-guide/prereqs).
+
+ * Use a cloud provider like Google Container Engine or Amazon Web Services to
+ create a Kubernetes cluster. This tutorial creates an
+ [external load balancer](/docs/user-guide/load-balancer/),
+ which requires a cloud provider.
+
+ * Configure `kubectl` to communicate with your Kubernetes API server. For
+ instructions, see the documentation for your cloud provider.
 
 {% endcapture %}
 


### PR DESCRIPTION
This tutorial creates a Service of type LoadBalancer, so the reader needs to be using a cloud provider. I have updated the Before You Begin section to say, "Use a cloud provider ...".

This text was in the document originally, but I accidentally removed it in https://github.com/kubernetes/kubernetes.github.io/commit/c60107ea1c8b560a57fd4d190d832abe7ce49f58.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2006)
<!-- Reviewable:end -->
