### PR TITLE
Remove accidentally nested {% raw %} tags.

### DIFF
--- a/docs/user-guide/kubectl/kubectl_get.md
+++ b/docs/user-guide/kubectl/kubectl_get.md
@@ -69,7 +69,7 @@ kubectl get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file
   kubectl get -f pod.yaml -o json
 
   # Return only the phase value of the specified pod.
-  kubectl get -o template pod/web-pod-13je7 --template={% raw %}{{.status.phase}}{% endraw %}
+  kubectl get -o template pod/web-pod-13je7 --template={{.status.phase}}
 
   # List all replication controllers and services together in ps output format.
   kubectl get rc,services


### PR DESCRIPTION
These tags cannot be nested, causing a Liquid syntax error:

```
Liquid Exception: Liquid syntax error (line 75): Unknown tag 'endraw' in docs/user-guide/kubectl/kubectl_get.md
```

The nesting was introduced accidentally by concurrent PRs https://github.com/kubernetes/kubernetes.github.io/pull/1974 and https://github.com/kubernetes/kubernetes.github.io/pull/1994.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2017)
<!-- Reviewable:end -->
