### PR TITLE
Add title to disruption budget doc

### DIFF
--- a/docs/admin/disruptions.md
+++ b/docs/admin/disruptions.md
@@ -1,7 +1,7 @@
 ---
 assignees:
 - davidopp
-
+title: Disruption Budgets
 ---
 This guide is for anyone wishing to specify safety constraints on pods or anyone
 wishing to write software (typically automation software) that respects those


### PR DESCRIPTION
Without this, the page renders with "Rationale" as its title (http://kubernetes.io/docs/admin/disruptions/)

@erictune

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2019)
<!-- Reviewable:end -->
