### PR TITLE
authentication/#creating-certificates document inconsistent in naming for the server certificate.

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -444,7 +444,7 @@ The script will generate three files: `ca.crt`, `server.crt`, and `server.key`.
 Finally, add the following parameters into API server start parameters:
 
 - `--client-ca-file=/srv/kubernetes/ca.crt`
-- `--tls-cert-file=/srv/kubernetes/server.cert`
+- `--tls-cert-file=/srv/kubernetes/server.crt`
 - `--tls-private-key-file=/srv/kubernetes/server.key`
 
 #### easyrsa
@@ -468,7 +468,7 @@ Finally, add the following parameters into API server start parameters:
 1.  Fill in and add the following parameters into the API server start parameters:
 
           --client-ca-file=/yourdirectory/ca.crt
-          --tls-cert-file=/yourdirectory/server.cert
+          --tls-cert-file=/yourdirectory/server.crt
           --tls-private-key-file=/yourdirectory/server.key
 
 #### openssl


### PR DESCRIPTION
fixed server.cert text to server.crt which is consistent with the res…t of the document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2032)
<!-- Reviewable:end -->
