### PR TITLE
fix codeblock formatting

### DIFF
--- a/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/docs/tasks/administer-cluster/safely-drain-node.md
@@ -44,11 +44,13 @@ down its physical machine or, if running on a cloud platform, deleting its
 virtual machine.
 
 First, identify the name of the node you wish to drain. You can list all of the nodes in your cluster with
+
 ```shell
 kubectl get nodes
 ```
 
 Next, tell Kubernetes to drain the node:
+
 ```shell
 kubectl drain <node name>
 ```
@@ -56,6 +58,7 @@ kubectl drain <node name>
 Once it returns (without giving an error), you can power down the node
 (or equivalently, if on a cloud platform, delete the virtual machine backing the node).
 If you leave the node in the cluster during the maintenance operation, you need to run
+
 ```shell
 kubectl uncordon <node name>
 ```


### PR DESCRIPTION
Currently it looks like this (notice that codeblocks are inline and have `shell` word in them):

![screenshot_2016-12-24_001](https://cloud.githubusercontent.com/assets/46573/21468119/ecd69f0e-ca1d-11e6-91b6-d37edbf7e8b2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2043)
<!-- Reviewable:end -->
