### PR TITLE
fix typo: remove "the the" in zookeeper.md

### DIFF
--- a/docs/tutorials/stateful-application/zookeeper.md
+++ b/docs/tutorials/stateful-application/zookeeper.md
@@ -799,7 +799,7 @@ Examine the process tree for the ZooKeeper server running in the `zk-0` Pod.
 kubectl exec zk-0 -- ps -ef
 ```
 
-The command used as the container's entry point has PID 1, and the 
+The command used as the container's entry point has PID 1, and 
 the ZooKeeper process, a child of the entry point, has PID 23.
 
 


### PR DESCRIPTION
<!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->

<!--Required Information-->

**This is a...** 
<!-- choose one by changing [ ] to [x] -->
- [ ] Feature Request
- [X] Bug Report

**Problem:**
Typo in Managing the ZooKeeper Process : Handling Process Failure : paragraph 4 :
"The command used as the container's entry point has PID 1, and **the the** ZooKeeper process, a child of the entry point, has PID 23." has double word typo, i.e. "... the the ZooKeeper ...""

**Proposed Solution:**

"The command used as the container's entry point has PID 1, and **the** ZooKeeper process, a child of the entry point, has PID 23."

**Page to Update:**
http://kubernetes.io/docs/tutorials/stateful-application/zookeeper/

<!--Optional Information (remove the comment tags around information you would like to include)-->
<!--Kubernetes Version:-->

<!--Additional Information:-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2062)
<!-- Reviewable:end -->
