### PR TITLE
Updates capabilities documentation to provide an example of usage.

### DIFF
--- a/docs/user-guide/capabilities-pod.yaml
+++ b/docs/user-guide/capabilities-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities-test-pod
+spec:
+  containers:
+    - name: test-container
+      image: gcr.io/google_containers/busybox
+      securityContext:
+        capabilities:
+          add:
+            - SYS_ADMIN
+      command: [ "/bin/sh", "-c" ]
+      args:
+        - |
+           hostname;
+           hostname over-ridden-hostname;
+           hostname;
+  restartPolicy: Never

--- a/docs/user-guide/containers.md
+++ b/docs/user-guide/containers.md
@@ -94,3 +94,7 @@ The relationship between Docker's capabilities and [Linux capabilities](http://m
 | SETFCAP |  CAP_SETFCAP |
 | WAKE_ALARM |  CAP_WAKE_ALARM |
 | BLOCK_SUSPEND |  CAP_BLOCK_SUSPEND |
+
+Here is an example pod that uses capabilities to allow a container to change its hostname:
+
+{% include code.html language="yaml" file="capabilities-pod.yaml" ghlink="/docs/user-guide/capabilities-pod.yaml" %}

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -257,6 +257,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 		},
 		"../docs/user-guide": {
 			"bad-nginx-deployment":       {&extensions.Deployment{}},
+			"capabilities-pod":           {&api.Pod{}},
 			"counter-pod":                {&api.Pod{}},
 			"curlpod":                    {&extensions.Deployment{}},
 			"deployment":                 {&extensions.Deployment{}},


### PR DESCRIPTION
The container capabilities documentation was lacking an example of how they could be applied. This commit adds a simple example of their usage.

Resolves: https://github.com/kubernetes/kubernetes.github.io/issues/2082

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2083)
<!-- Reviewable:end -->
