### PR TITLE
Headless service spec missing attribute

### DIFF
--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -100,6 +100,7 @@ metadata:
 spec:
   selector:
     name: busybox
+  clusterIP: None
   ports:
     - name: foo # Actually, no port is needed.
       port: 1234 


### PR DESCRIPTION
The headless service spec example requires the attribute clusterIP: None. Without this, the service that is created is not headless and the two example pods will not be able to nslookup one another.
@thockin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2090)
<!-- Reviewable:end -->
