### PR TITLE
Increase font-size and line-height Values

### DIFF
--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -894,6 +894,7 @@ dd
 	li
 		margin-bottom: 0.75em
 		font-size: 16px
+		line-height: 1.75em
 
 	table
 		width: 100%

--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -816,9 +816,9 @@ dd
 		font-weight: 500
 
 	p
-		font-size: 14px
+		font-size: 16px
 		font-weight: 300
-		line-height: 1.25em
+		line-height: 1.75em
 
 	p + p
 		margin-top: 10px
@@ -893,6 +893,7 @@ dd
 
 	li
 		margin-bottom: 0.75em
+		font-size: 16px
 
 	table
 		width: 100%


### PR DESCRIPTION
For desktop, increase the font-size and 
line-height CSS property values for the paragraph 
and list items within the documentation body 
content. Adjusting these properties will make 
the information a little easier to read.

Currently, the information is a bit too condensed
making it difficult to read.
**Before:** 
<img width="561" alt="screen shot 2016-12-30 at 10 01 51 am" src="https://cloud.githubusercontent.com/assets/1526861/21570064/6ac28c5e-ce77-11e6-8e54-014cafda7d5c.png">
**After:**
<img width="570" alt="screen shot 2016-12-30 at 10 02 14 am" src="https://cloud.githubusercontent.com/assets/1526861/21570073/7659a7d2-ce77-11e6-8138-4f9a0df30b7a.png">


 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2094)
<!-- Reviewable:end -->
