### PR TITLE
Don't overwrite the global page object

### DIFF
--- a/_includes/tree.html
+++ b/_includes/tree.html
@@ -12,9 +12,9 @@
         {% assign path   = item.path %}
         {% assign title  = item.title %}
       {% else %}
-        {% assign page  = site.pages | where: "path", item | first %}
-        {% assign title = page.title %}
-        {% assign path  = page.url %}
+        {% assign found_page = site.pages | where: "path", item | first %}
+        {% assign title = found_page.title %}
+        {% assign path  = found_page.url %}
       {% endif %}
     {% endcapture %}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes.github.io/issues/2088.

When we traverse the table of contents tree, we look up the page by its path. Before, we were assigning the found page as `page`, which pollutes the `page` object in the global namespace meaning calls to `page.title` or `page.url` after we build the TOC will pull from the last found page, not the current page.

/cc @shyamjvs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2095)
<!-- Reviewable:end -->
