### PR TITLE
Fix #1552: dead link to kube-dns/README.md

### DIFF
--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -384,7 +384,7 @@ for more information.
 
 ## References
 
-- [Docs for the DNS cluster addon](http://releases.k8s.io/{{page.githubbranch}}/build-tools/kube-dns/README.md)
+- [Docs for the DNS cluster addon](http://releases.k8s.io/{{page.githubbranch}}/build/kube-dns/README.md)
 
 ## What's next
 - [Autoscaling the DNS Service in a Cluster](/docs/tasks/administer-cluster/dns-horizontal-autoscaling/).


### PR DESCRIPTION
Fix dead link caused by renaming build-tools back to build in https://github.com/kubernetes/kubernetes/issues/38126

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2099)
<!-- Reviewable:end -->
