### PR TITLE
Remove extensions/v1beta1 Job

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -104,6 +104,7 @@ to pick up the `--runtime-config` changes.
 ## Enabling resources in the groups
 
 DaemonSets, Deployments, HorizontalPodAutoscalers, Ingress, Jobs and ReplicaSets are enabled by default.
+
 Other extensions resources can be enabled by setting `--runtime-config` on
 apiserver. `--runtime-config` accepts comma separated values. For ex: to disable deployments and jobs, set
-`--runtime-config=extensions/v1beta1/deployments=false,extensions/v1beta1/jobs=false`
+`--runtime-config=extensions/v1beta1/deployments=false,extensions/v1beta1/ingress=false`

--- a/docs/tasks/configure-pod-container/define-environment-variable-container.md
+++ b/docs/tasks/configure-pod-container/define-environment-variable-container.md
@@ -22,8 +22,8 @@ in a Kubernetes Pod.
 ## Defining an environment variable for a container
 
 When you create a Pod, you can set environment variables for the containers
-that run in the Pod. To set environment variables, include the `env` field in
-the configuration file.
+that run in the Pod. To set environment variables, include the `env` or
+`envFrom` field in the configuration file.
 
 In this exercise, you create a Pod that runs one container. The configuration
 file for the Pod defines an environment variable with name `DEMO_GREETING` and

--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -244,8 +244,8 @@ metadata:
 
 ### Use-Case: Consume ConfigMap in environment variables
 
-ConfigMaps can be used to populate environment variables.  As an example, consider
-the following ConfigMap:
+ConfigMaps can be used to populate individual environment variables or used in
+its entirety.  As an example, consider the following ConfigMaps:
 
 ```yaml
 apiVersion: v1
@@ -256,6 +256,16 @@ metadata:
 data:
   special.how: very
   special.type: charm
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env-config
+  namespace: default
+data:
+  log_level: INFO
 ```
 
 We can consume the keys of this ConfigMap in a pod like so:
@@ -281,6 +291,9 @@ spec:
             configMapKeyRef:
               name: special-config
               key: special.type
+      envFrom:
+        - configMapRef:
+            name: env-config
   restartPolicy: Never
 ```
 
@@ -289,6 +302,7 @@ When this pod is run, its output will include the lines:
 ```shell
 SPECIAL_LEVEL_KEY=very
 SPECIAL_TYPE_KEY=charm
+log_level=INFO
 ```
 
 #### Optional ConfigMap in environment variables

--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -244,7 +244,7 @@ metadata:
 
 ### Use-Case: Consume ConfigMap in environment variables
 
-ConfigMaps can be used to populate individual environment variables or used in
+ConfigMaps can be used to populate individual environment variables or be used in
 its entirety.  As an example, consider the following ConfigMaps:
 
 ```yaml

--- a/docs/user-guide/cron-jobs.md
+++ b/docs/user-guide/cron-jobs.md
@@ -184,3 +184,9 @@ cron jobs, their respective jobs are always allowed to run concurrently.
 
 The `.spec.suspend` field is also optional. If set to `true`, all subsequent executions will be suspended. It does not
 apply to already started executions. Defaults to false.
+
+### Jobs History Limits
+
+The `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields are optional. These fields specify how many completed and failed jobs should be kept.
+
+By default, the last 3 completed jobs and the last failed job are kept. Setting a limit to `0` corresponds to keeping none of the corresponding kind of jobs after they finish.

--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -21,12 +21,6 @@ due to a node hardware failure or a node reboot).
 
 A Job can also be used to run multiple pods in parallel.
 
-### extensions/v1beta1.Job is deprecated
-
-Starting from version 1.5 `extensions/v1beta1.Job` is being deprecated, with a plan to be removed in
-version 1.6 of Kubernetes (see this [issue](https://github.com/kubernetes/kubernetes/issues/32763)).
-Please use `batch/v1.Job` instead.
-
 ## Running an example Job
 
 Here is an example Job config.  It computes π to 2000 places and prints it out.

--- a/docs/user-guide/kubectl-conventions.md
+++ b/docs/user-guide/kubectl-conventions.md
@@ -36,9 +36,6 @@ In order for `kubectl run` to satisfy infrastructure as code:
 * Pod - use `run-pod/v1`.
 * Replication controller - use `run/v1`.
 * Deployment - use `deployment/v1beta1`.
-* Job (using `extension/v1beta1` endpoint) - use `job/v1beta1`. Starting from
-  version 1.5 of kuberentes this generator is deprecated, with a plan to be
-  removed in 1.6. Please use `job/v1` instead.
 * Job - use `job/v1`.
 * CronJob - use `cronjob/v2alpha1`.
 


### PR DESCRIPTION
This is the last part of removing `extensions/v1beta1.Job` resource. The remaining pieces (api-reference) will be updated when we switch to 1.6 and run `update-imported-docs.sh`.

@janetkuo ptal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2100)
<!-- Reviewable:end -->
