### PR TITLE
ReplicaSets: Correct paragraph spacing error

### DIFF
--- a/docs/user-guide/replicasets.md
+++ b/docs/user-guide/replicasets.md
@@ -37,7 +37,6 @@ their ReplicaSets.
 
 A ReplicaSet ensures that a specified number of pod “replicas” are running at any given
 time. However, a Deployment is a higher-level concept that manages ReplicaSets and
-
 provides declarative updates to pods along with a lot of other useful features.
 Therefore, we recommend using Deployments instead of directly using ReplicaSets, unless
 you require custom update orchestration or don't require updates at all.


### PR DESCRIPTION
There was an added newline in the RepliaSets user guide. Corrected that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2121)
<!-- Reviewable:end -->
