### PR TITLE
change the flag which controlls the cbr0's create

### DIFF
--- a/docs/admin/networking.md
+++ b/docs/admin/networking.md
@@ -130,7 +130,7 @@ We start Docker with:
 DOCKER_OPTS="--bridge=cbr0 --iptables=false --ip-masq=false"
 ```
 
-This bridge is created by Kubelet (controlled by the `--configure-cbr0=true`
+This bridge is created by Kubelet (controlled by the `--network-plugin=kubenet`
 flag) according to the `Node`'s `spec.podCIDR`.
 
 Docker will now allocate IPs from the `cbr-cidr` block.  Containers can reach


### PR DESCRIPTION
    The flag "--configure-cbr0=true" has been removed, so we can't controller the cbr0's create by it. In fact, cbr0 will be created by kubelet if '--network-plugin=true', so i changed it, thank you!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2126)
<!-- Reviewable:end -->
