### PR TITLE
Update .gitignore to include vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,19 @@ _site/**
 CNAME
 .travis.yml
 .idea/
+
+# Vim ignore
+# source: https://github.com/github/gitignore/blob/master/Global/Vim.gitignore
+
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags


### PR DESCRIPTION
Updates .gitignore to not include swap files and misc files generated by
vim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2129)
<!-- Reviewable:end -->
