### PR TITLE
deprecation policy bug: at X+9 we remove v1

### DIFF
--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -161,7 +161,7 @@ versions are supported in a series of subsequent releases.
     </tr>
     <tr>
       <td>X+9</td>
-      <td>v1, v2</td>
+      <td>v2</td>
       <td>
         <ul>
           <li>v1 is removed, "action required" relnote</li>


### PR DESCRIPTION
Sigh.  Not sure how I missed this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2131)
<!-- Reviewable:end -->
