### PR TITLE
Fix deployments link in federation page

### DIFF
--- a/docs/user-guide/federation/deployment.md
+++ b/docs/user-guide/federation/deployment.md
@@ -20,7 +20,7 @@ might also help you create a Federated Kubernetes cluster.
 
 You should also have a basic
 [working knowledge of Kubernetes](/docs/getting-started-guides/) in
-general and [Deployment](/docs/user-guide/deployment.md) in particular.
+general and [Deployment](/docs/user-guide/deployments) in particular.
 
 ## Overview
 


### PR DESCRIPTION
Fixes missing 404 link that leads from federation deployment page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2132)
<!-- Reviewable:end -->
