### PR TITLE
Update centos_manual_config.md

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -132,11 +132,11 @@ $ etcdctl mk /kube-centos/network/config "{ \"Network\": \"172.30.0.0/16\", \"Su
 
 ```shell
 # etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD="http://centos-master:2379"
+FLANNEL_ETCD_ENDPOINTS="http://centos-master:2379"
 
 # etcd config key.  This is the configuration key that flannel queries
 # For address range assignment
-FLANNEL_ETCD_KEY="/kube-centos/network"
+FLANNEL_ETCD_PREFIX="/kube-centos/network"
 
 # Any additional options that you want to pass
 FLANNEL_OPTIONS=""
@@ -180,11 +180,11 @@ KUBELET_ARGS=""
 
 ```shell
 # etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD="http://centos-master:2379"
+FLANNEL_ETCD_ENDPOINTS="http://centos-master:2379"
 
 # etcd config key.  This is the configuration key that flannel queries
 # For address range assignment
-FLANNEL_ETCD_KEY="/kube-centos/network"
+FLANNEL_ETCD_PREFIX="/kube-centos/network"
 
 # Any additional options that you want to pass
 FLANNEL_OPTIONS=""


### PR DESCRIPTION
The current extras/flannel (flannel-0.5.5-1.el7) package changed the keys used for etcd configuration, see:

https://git.centos.org/blobdiff/rpms!flannel/7e924c9cf84caaf230f6a50c2a5ad5b0b6d93a9a/SOURCES!flanneld.service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2133)
<!-- Reviewable:end -->
