### PR TITLE
Fix references to restartPolicy spec location

### DIFF
--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -172,20 +172,20 @@ parallelism, for a variety or reasons:
 
 A Container in a Pod may fail for a number of reasons, such as because the process in it exited with
 a non-zero exit code, or the Container was killed for exceeding a memory limit, etc.  If this
-happens, and the `.spec.template.containers[].restartPolicy = "OnFailure"`, then the Pod stays
+happens, and the `.spec.template.spec.restartPolicy = "OnFailure"`, then the Pod stays
 on the node, but the Container is re-run.  Therefore, your program needs to handle the case when it is
-restarted locally, or else specify `.spec.template.containers[].restartPolicy = "Never"`.
+restarted locally, or else specify `.spec.template.spec.restartPolicy = "Never"`.
 See [pods-states](/docs/user-guide/pod-states) for more information on `restartPolicy`.
 
 An entire Pod can also fail, for a number of reasons, such as when the pod is kicked off the node
 (node is upgraded, rebooted, deleted, etc.), or if a container of the Pod fails and the
-`.spec.template.containers[].restartPolicy = "Never"`.  When a Pod fails, then the Job controller
+`.spec.template.spec.restartPolicy = "Never"`.  When a Pod fails, then the Job controller
 starts a new Pod.  Therefore, your program needs to handle the case when it is restarted in a new
 pod.  In particular, it needs to handle temporary files, locks, incomplete output and the like
 caused by previous runs.
 
 Note that even if you specify `.spec.parallelism = 1` and `.spec.completions = 1` and
-`.spec.template.containers[].restartPolicy = "Never"`, the same program may
+`.spec.template.spec.restartPolicy = "Never"`, the same program may
 sometimes be started twice.
 
 If you do specify `.spec.parallelism` and `.spec.completions` both greater than 1, then there may be


### PR DESCRIPTION
This document currently indicates that restartPolicy is part of the v1.Container spec, however according to the definitions it is actually in the v1.PodSpec.

References:

http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_pod

http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_container

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2134)
<!-- Reviewable:end -->
