### PR TITLE
Updated link for etcd to point at latest docs

### DIFF
--- a/docs/admin/etcd.md
+++ b/docs/admin/etcd.md
@@ -4,7 +4,7 @@ assignees:
 title: Configuring Kubernetes Use of etcd
 ---
 
-[etcd](https://coreos.com/etcd/docs/2.2.1/) is a highly-available key value
+[etcd](https://coreos.com/etcd/docs/latest/) is a highly-available key value
 store which Kubernetes uses for persistent storage of all of its REST API
 objects.
 


### PR DESCRIPTION
Current link is broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2147)
<!-- Reviewable:end -->
