### PR TITLE
Fix link to kube-dns docs

### DIFF
--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -384,7 +384,7 @@ for more information.
 
 ## References
 
-- [Docs for the DNS cluster addon](http://releases.k8s.io/{{page.githubbranch}}/build/kube-dns/README.md)
+- [Docs for the DNS cluster addon](http://releases.k8s.io/{{page.githubbranch}}/cluster/addons/dns/README.md)
 
 ## What's next
 - [Autoscaling the DNS Service in a Cluster](/docs/tasks/administer-cluster/dns-horizontal-autoscaling/).


### PR DESCRIPTION
The link to kube-dns is broken, I believe this is the current location of kube-dns documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2170)
<!-- Reviewable:end -->
