### PR TITLE
Fixed broken link

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -55,7 +55,7 @@ A request has the following attributes that can be considered for authorization:
   - what resource is being accessed (for resource requests only)
   - what subresource is being accessed (for resource requests only)
   - the namespace of the object being accessed (for namespaced resource requests only)
-  - the API group being accessed (for resource requests only); an empty string designates the [core API group](../api.md#api-groups)
+  - the API group being accessed (for resource requests only); an empty string designates the [core API group](/docs/api/)
 
 The request verb for a resource API endpoint can be determined by the HTTP verb used and whether or not the request acts on an individual resource or a collection of resources:
 


### PR DESCRIPTION
[core API group] should link to (/docs/api/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2187)
<!-- Reviewable:end -->
