### PR TITLE
Include require for http module.

### DIFF
--- a/docs/tutorials/stateless-application/server.js
+++ b/docs/tutorials/stateless-application/server.js
@@ -1,3 +1,5 @@
+var http = require('http');
+
 var handleRequest = function(request, response) {
   console.log('Received request for URL: ' + request.url);
   response.writeHead(200);


### PR DESCRIPTION
Running the tutorial on Ubuntu without this change, I see:

$ kubectl get pods
NAME                          READY     STATUS             RESTARTS   AGE
hello-node-2399519400-403sg   0/1       CrashLoopBackOff   2          35s


$ kubectl logs hello-node-2399519400-403sg                                                                                                                                           
/server.js:6
var www = http.createServer(handleRequest);
               ^

ReferenceError: http is not defined
    at Object.<anonymous> (/server.js:6:16)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3

With the change, it works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2227)
<!-- Reviewable:end -->
