### PR TITLE
fix the named anchor

### DIFF
--- a/docs/user-guide/kubeconfig-file.md
+++ b/docs/user-guide/kubeconfig-file.md
@@ -16,7 +16,7 @@ So in order to easily switch between multiple clusters, for multiple users, a ku
 
 This file contains a series of authentication mechanisms and cluster connection information associated with nicknames.  It also introduces the concept of a tuple of authentication information (user) and cluster connection information called a context that is also associated with a nickname.
 
-Multiple kubeconfig files are allowed, if specified explicitly.  At runtime they are loaded and merged along with override options specified from the command line (see [rules](#loading-and-merging) below).
+Multiple kubeconfig files are allowed, if specified explicitly.  At runtime they are loaded and merged along with override options specified from the command line (see [rules](#loading-and-merging-rules) below).
 
 ## Related discussion
 


### PR DESCRIPTION
named anchor `loading-and-merging` should be `loading-and-merging-rules` 
see the section's title in the line 187, it's `Loading and merging rules` .

i tested it , only use anchor `#loading-and-merging-rules` appended to the url the page could scroll to the right section place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2242)
<!-- Reviewable:end -->
