### PR TITLE
Fixed Typo

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -77,7 +77,7 @@ groups*](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/doc
 same underlying resources.  The API group is specified in a REST path and in the `apiVersion` field
 of a serialized object.
 
-Currently there are two API groups in use:
+Currently there are several API groups in use:
 
 1. the "core" group, which is at REST path `/api/v1` and is not specified as part of the `apiVersion` field, e.g.
    `apiVersion: v1`.


### PR DESCRIPTION
Fixed a small typo for API Groups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2246)
<!-- Reviewable:end -->
