### PR TITLE
Requiring http in server.js

### DIFF
--- a/docs/tutorials/stateless-application/server.js
+++ b/docs/tutorials/stateless-application/server.js
@@ -1,3 +1,5 @@
+var http = require('http');
+
 var handleRequest = function(request, response) {
   console.log('Received request for URL: ' + request.url);
   response.writeHead(200);


### PR DESCRIPTION
I was just doing the tutorial and noticed the server.js file didn't have all the code needed to start the node server. `http` was undefined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2249)
<!-- Reviewable:end -->
