### PR TITLE
Instruct beginners to start minikube cluster with proxy

### DIFF
--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -82,7 +82,7 @@ If NO proxy is required, start the Minikube cluster:
 ```shell
 minikube start --vm-driver=xhyve
 ```
-If a proxy server is required, use below way to start Minikube cluster with proxy setting:
+If a proxy server is required, use the following method to start Minikube cluster with proxy setting:
 
 ```shell
 minikube start --vm-driver=xhyve --docker-env HTTP_PROXY=http://your-http-proxy-host:your-http-proxy-port  --docker-env HTTPS_PROXY=http(s)://your-https-proxy-host:your-https-proxy-port

--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -70,11 +70,22 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s htt
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 ```
+Determine whether you can access sites like https://cloud.google.com/container-registry/ directly without a proxy, by opening a new terminal and using
+```shell
+export http_proxy=""
+export https_proxy=""
+curl https://cloud.google.com/container-registry/ 
+```
 
-Start the Minikube cluster:
+If NO proxy is required, start the Minikube cluster: 
 
 ```shell
 minikube start --vm-driver=xhyve
+```
+If a proxy server is required, use below way to start Minikube cluster with proxy setting:
+
+```shell
+minikube start --vm-driver=xhyve --docker-env HTTP_PROXY=http://your-http-proxy-host:your-http-proxy-port  --docker-env HTTPS_PROXY=http(s)://your-https-proxy-host:your-https-proxy-port
 ```
 
 The `--vm-driver=xyhve` flag specifies that you are using Docker for Mac. The


### PR DESCRIPTION
Beginners don't know the details for troubleshooting, better instruction will save much time for beginners to troubleshoot logs in minikube complaining gcr.io not reachable and etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2250)
<!-- Reviewable:end -->
