### PR TITLE
docs/user-guide/secrets: fix invalid syntax of Pod.spec.containers.command

### DIFF
--- a/docs/user-guide/secrets/index.md
+++ b/docs/user-guide/secrets/index.md
@@ -763,7 +763,7 @@ make that key begin with a dot.  For example, when the following secret is mount
       {
         "name": "dotfile-test-container",
         "image": "gcr.io/google_containers/busybox",
-        "command": "ls -l /etc/secret-volume",
+        "command": [ "ls", "-l", "/etc/secret-volume" ],
         "volumeMounts": [
           {
             "name": "secret-volume",


### PR DESCRIPTION
Example in https://kubernetes.io/docs/user-guide/secrets/#use-case-dotfiles-in-secret-volume section doesn't work:
```console
$ kubectl create -f secret-test.json
secret "dotfile-secret" created
error: error validating "secret-test.json": error validating data: expected type array, for field spec.containers[0].command, got string; if you choose to ignore these errors, turn validation off with --validate=false
```

This commit fixes invalid syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2253)
<!-- Reviewable:end -->
