### PR TITLE
pod-nginx.yaml location has changed.

### DIFF
--- a/docs/user-guide/walkthrough/index.md
+++ b/docs/user-guide/walkthrough/index.md
@@ -43,10 +43,10 @@ See the [design document](https://github.com/kubernetes/kubernetes/blob/{{page.g
 
 #### Pod Management
 
-Create a pod containing an nginx server ([pod-nginx.yaml](/docs/user-guide/walkthrough/pod-nginx.yaml)):
+Create a pod containing an nginx server ([pod-nginx.yaml](/test/fixtures/doc-yaml/user-guide/walkthrough/pod-nginx.yaml)):
 
 ```shell
-$ kubectl create -f docs/user-guide/walkthrough/pod-nginx.yaml
+$ kubectl create -f test/fixtures/doc-yaml/user-guide/walkthrough/pod-nginx.yaml
 ```
 
 List all pods:


### PR DESCRIPTION
pod-nginx.yaml is no longer in the given location. It can be found in the test/fixtures dir however.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2263)
<!-- Reviewable:end -->
