### PR TITLE
Add redirect generator to make Netlify's CDN redirect to the right places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Session.vim
 tags
 
 kubernetes.github.io.iml
+_redirects

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-preview help serve
+.PHONY: all build build-preview generate-redirects help serve
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -10,6 +10,9 @@ build: ## Build site with production settings and put deliverables in _site.
 
 build-preview: ## Build site with drafts and future posts enabled.
 	jekyll build --drafts --future
+
+generate-redirects: ## Generate a redirects file and copy it into the _site directory.
+	mkdir -p _site && REDIRECTS_PATH=_site/_redirects ruby redirects.rb
 
 serve: ## Boot the development server.
 	jekyll serve

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  command = "make build"
+  command = "make build generate-redirects"
   publish = "_site"
 
 [context.deploy-preview]
-  command = "make build-preview"
+  command = "make build-preview generate-redirects"

--- a/redirects.rb
+++ b/redirects.rb
@@ -1,0 +1,22 @@
+REPO_TMPL = "https://github.com/kubernetes/kubernetes/tree/%s/%s/:splat"
+
+fixed_redirects = """# 301 redirects (301 is the default status when no other one is provided for each line)
+/third_party/swagger-ui		/kubernetes/third_party/swagger-ui/
+/resource-quota			/docs/admin/resourcequota/
+/horizontal-pod-autoscaler	/docs/user-guide/horizontal-pod-autoscaling/
+/docs/user-guide/overview	/docs/whatisk8s/
+/docs/roadmap			https://github.com/kubernetes/kubernetes/milestones/
+/api-ref			https://github.com/kubernetes/kubernetes/milestones/
+"""
+
+branch_redirects = ["examples" , "cluster", "docs/devel", "docs/design"]
+
+branch_redirects.each do |name|
+  dest = REPO_TMPL % [ENV.fetch("HEAD", "master"), name]
+  rule = "\n/#{name}/* #{dest}"
+
+  fixed_redirects << rule
+end
+
+output = ENV["DEBUG"] ? STDOUT : File.open(ENV.fetch("REDIRECTS_PATH", "_redirects"), "w+")
+output.puts fixed_redirects


### PR DESCRIPTION
Netlify will redirect with a 301 status to the right places without the
need of a custom javascript file.

The current redirects.js is not removed so production can keep working
as it is for now.

This is related to #1575.

Signed-off-by: David Calavera <david.calavera@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2271)
<!-- Reviewable:end -->
