### PR TITLE
Remove some padding around Katacoda to give it a little more space.

### DIFF
--- a/docs/tutorials/kubernetes-basics/cluster-interactive.html
+++ b/docs/tutorials/kubernetes-basics/cluster-interactive.html
@@ -13,7 +13,7 @@ title: Interactive Tutorial - Creating a Cluster
 
 <div class="layout" id="top">
 
-	<main class="content">
+	<main class="content katacoda-content">
 
 		<div class="katacoda">
 			<div class="katacoda__alert">

--- a/docs/tutorials/kubernetes-basics/deploy-interactive.html
+++ b/docs/tutorials/kubernetes-basics/deploy-interactive.html
@@ -13,7 +13,7 @@ title: Interactive Tutorial - Deploying an App
 
 <div class="layout" id="top">
 
-	<main class="content">
+	<main class="content katacoda-content">
 
 		<br>
 		<div class="katacoda">

--- a/docs/tutorials/kubernetes-basics/explore-interactive.html
+++ b/docs/tutorials/kubernetes-basics/explore-interactive.html
@@ -13,7 +13,7 @@ title: Interactive Tutorial - Exploring Your App
 
 <div class="layout" id="top">
 
-	<main class="content">
+	<main class="content katacoda-content">
 
 		<br>
 		<div class="katacoda">

--- a/docs/tutorials/kubernetes-basics/expose-interactive.html
+++ b/docs/tutorials/kubernetes-basics/expose-interactive.html
@@ -13,7 +13,7 @@ title: Interactive Tutorial - Exposing Your App
 
 <div class="layout" id="top">
 
-	<main class="content">
+	<main class="content katacoda-content">
 
 		<div class="katacoda">
 			<div class="katacoda__alert">

--- a/docs/tutorials/kubernetes-basics/public/css/styles.css
+++ b/docs/tutorials/kubernetes-basics/public/css/styles.css
@@ -9883,12 +9883,21 @@ p a:hover
     background: #f8f8f8;
 }
 
+.content.katacoda-content {
+    padding: 0;
+    max-width: 100%;
+}
+
+.content.katacoda-content .btn-success {
+    margin-bottom: 50px;
+}
+
 .katacoda
 {
     display: table;
 
     width: 100%;
-    margin: 50px 0;
+    margin: 0 0 50px 0;
 }
 @media screen and (max-width: 762px)
 {

--- a/docs/tutorials/kubernetes-basics/scale-interactive.html
+++ b/docs/tutorials/kubernetes-basics/scale-interactive.html
@@ -13,7 +13,7 @@ title: Interactive Tutorial - Scaling Your App
 
 <div class="layout" id="top">
 
-	<main class="content">
+	<main class="content katacoda-content">
 
 		<div class="katacoda">
 			<div class="katacoda__alert">

--- a/docs/tutorials/kubernetes-basics/update-interactive.html
+++ b/docs/tutorials/kubernetes-basics/update-interactive.html
@@ -13,7 +13,7 @@ title: Interactive Tutorial - Updating Your App
 
 <div class="layout" id="top">
 
-	<main class="content">
+	<main class="content katacoda-content">
 
 		<div class="katacoda">
 			<div class="katacoda__alert">


### PR DESCRIPTION
After some feedback I had a quick look if I can improve the space used by Katacoda. These are some quick wins.

Changes when rendered on a standard laptop:
  - Remove 10px padding either size of iFrame
  - Remove padding at the top, requiring users not to scroll down as much
  - Add padding around the "Continue" button

On a larger display:
  - Expand iFrame to use full width:

Before:
![screenshot 2017-01-11 16 39 10](https://cloud.githubusercontent.com/assets/82614/22072420/3fa29ad2-dd9a-11e6-9bb5-a6b5c8f728ce.png)

After:
![screenshot 2017-01-11 16 38 52](https://cloud.githubusercontent.com/assets/82614/22072427/4659515e-dd9a-11e6-8239-d6a9e844977b.png)


Before:
![screenshot 2017-01-12 09 03 39](https://cloud.githubusercontent.com/assets/82614/22072511/86fb02ac-dd9a-11e6-8079-3883312862b1.png)


After:
![screenshot 2017-01-12 09 03 21](https://cloud.githubusercontent.com/assets/82614/22072515/8adcfc2c-dd9a-11e6-894c-61f021d00714.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2283)
<!-- Reviewable:end -->
