### PR TITLE
Align kubeconfig resolution with the rest of documentation

### DIFF
--- a/docs/user-guide/sharing-clusters.md
+++ b/docs/user-guide/sharing-clusters.md
@@ -105,8 +105,7 @@ and/or run `kubectl config -h`.
 
 1. `--kubeconfig=/path/to/.kube/config` command line flag
 2. `KUBECONFIG=/path/to/.kube/config` env variable
-3. `$PWD/.kube/config`
-4. `$HOME/.kube/config`
+3. `$HOME/.kube/config`
 
 If you create clusters A, B on host1, and clusters C, D on host2, you can
 make all four clusters available on both hosts by running


### PR DESCRIPTION
It seems that this part has a missing documentation. Here is the reference of `kubectl` configuration. 
https://kubernetes.io/docs/user-guide/kubectl/kubectl_config/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2286)
<!-- Reviewable:end -->
