### PR TITLE
[OpenStack-Heat] Use openstackclient to list the Heat stack

### DIFF
--- a/docs/getting-started-guides/openstack-heat.md
+++ b/docs/getting-started-guides/openstack-heat.md
@@ -183,7 +183,7 @@ First, set your environment variables:
 To get all information about your cluster, use heat:
 
 ```sh
-heat stack-show $STACK_NAME
+openstack stack show $STACK_NAME
 ```
 
 To see a list of nodes, use nova:


### PR DESCRIPTION
python-openstackclient is a more modern tool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2290)
<!-- Reviewable:end -->
