### PR TITLE
Change reviewers of minikube to r2d4 and aprindle

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -1,8 +1,8 @@
 ---
 assignees:
 - dlorenc
-- janetkuo
-- jlowdermilk
+- r2d4 
+- aaron-prindle
 title: Running Kubernetes Locally via Minikube
 ---
 


### PR DESCRIPTION
Switching owners of minikube docs to myself and @aaron-prindle.  We work under @dlorenc on minkube full time at Google.  Happy to start reviewing all the docs requests for minikube

cc @janetkuo @jlowdermilk @dlorenc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2300)
<!-- Reviewable:end -->
