### PR TITLE
Update Federation API resource listing

### DIFF
--- a/docs/user-guide/federation/index.md
+++ b/docs/user-guide/federation/index.md
@@ -37,13 +37,15 @@ Once we have the control plane setup, we can start creating federation API
 resources.
 The following guides explain some of the resources in detail:
 
+* [ConfigMap](/docs/user-guide/federation/configmap/)
+* [DaemonSets](/docs/user-guide/federation/daemonsets/)
+* [Deployment](/docs/user-guide/federation/deployment/)
 * [Events](/docs/user-guide/federation/events/)
 * [Ingress](/docs/user-guide/federation/federated-ingress/)
 * [Namespaces](/docs/user-guide/federation/namespaces/)
 * [ReplicaSets](/docs/user-guide/federation/replicasets/)
 * [Secrets](/docs/user-guide/federation/secrets/)
 * [Services](/docs/user-guide/federation/federated-services/)
-<!-- TODO: Add more guides here -->
 
 [API reference docs](/docs/federation/api-reference/) lists all the
 resources supported by federation apiserver.


### PR DESCRIPTION
Hi,
the API resource listing on https://kubernetes.io/docs/user-guide/federation/ misses three of the available documentations. This PR adds them and removes a TODO.
Cheers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2310)
<!-- Reviewable:end -->
