### PR TITLE
Update dead link with link to ubuntu.com

### DIFF
--- a/docs/getting-started-guides/ubuntu/index.md
+++ b/docs/getting-started-guides/ubuntu/index.md
@@ -9,7 +9,7 @@ There are multiple ways to run a Kubernetes cluster with Ubuntu. These pages exp
 {% capture body %}
 ## Official Ubuntu Guides
 
-- [The Canonical Distribution of Kubernetes](/docs/getting-started-guides/ubuntu)
+- [The Canonical Distribution of Kubernetes](https://www.ubuntu.com/cloud/kubernetes)
 
 Supports AWS, GCE, Azure, Joyent, OpenStack, Bare Metal and local workstation deployment.
 


### PR DESCRIPTION
Hi,
the link to offical guides on https://kubernetes.io/docs/getting-started-guides/ubuntu/ is atm. a link to the current page which doesn't get you anywhere. This PR updates it so it points to the related landing page to ubuntu.com. I assume that's what @castrojo had in mind when the content was updated.
Cheers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2311)
<!-- Reviewable:end -->
