### PR TITLE
move -u so that it applies to minikube docker-env

### DIFF
--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -135,7 +135,7 @@ eval $(minikube docker-env)
 ```
 
 **Note:** Later, when you no longer wish to use the Minikube host, you can undo
-this change by running `eval $(minikube docker-env) -u`.
+this change by running `eval $(minikube docker-env -u)`.
 
 Build your Docker image, using the Minikube Docker daemon:
 


### PR DESCRIPTION
eval $(minikube docker-env) -u => eval $(minikube docker-env -u)
# This change will unset docker environment vars correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2312)
<!-- Reviewable:end -->
