### PR TITLE
Update ui.md: appname can be end with a number

### DIFF
--- a/docs/user-guide/ui.md
+++ b/docs/user-guide/ui.md
@@ -66,7 +66,7 @@ The deploy wizard expects that you provide the following information:
 
 - **App name** (mandatory): Name for your application. A [label](/docs/user-guide/labels/) with the name will be added to the Deployment and Service, if any, that will be deployed.
 
-  The application name must be unique within the selected Kubernetes [namespace](/docs/admin/namespaces/). It must start and end with a lowercase character, and contain only lowercase letters, numbers and dashes (-). It is limited to 24 characters. Leading and trailing spaces are ignored.
+  The application name must be unique within the selected Kubernetes [namespace](/docs/admin/namespaces/). It must start with a lowercase character, and end with a lowercase character or a number, and contain only lowercase letters, numbers and dashes (-). It is limited to 24 characters. Leading and trailing spaces are ignored.
 
 - **Container image** (mandatory): The URL of a public Docker [container image](/docs/user-guide/images/) on any registry, or a private image (commonly hosted on the Google Container Registry or Docker Hub). The container image specification must end with a colon.
 


### PR DESCRIPTION
I installed gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0. When I deploy a containerized app through dashboad ui, the appname can be "dxltest1" . The "dxltest1" can be deployed successfully. so the appname can be end with a number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2319)
<!-- Reviewable:end -->
