### PR TITLE
fixed capitalization typo

### DIFF
--- a/docs/admin/limitrange/index.md
+++ b/docs/admin/limitrange/index.md
@@ -145,9 +145,9 @@ spec:
     volumeMounts:
 ```
 
-Note that our nginx container has picked up the namespace default cpu and memory resource *limits* and *requests*.
+Note that our nginx container has picked up the namespace default CPU and memory resource *limits* and *requests*.
 
-Let's create a pod that exceeds our allowed limits by having it have a container that requests 3 cpu cores.
+Let's create a pod that exceeds our allowed limits by having it have a container that requests 3 CPU cores.
 
 ```shell
 $ kubectl create -f docs/admin/limitrange/invalid-pod.yaml --namespace=limit-example


### PR DESCRIPTION
changed 'cpu' to 'CPU' when not in config text

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2335)
<!-- Reviewable:end -->
