### PR TITLE
[Doc] Format JSON: missing comma

### DIFF
--- a/docs/user-guide/pods/pod-spec-common.json
+++ b/docs/user-guide/pods/pod-spec-common.json
@@ -24,7 +24,7 @@
         }
       ],
       "resources": {
-        "cpu": ""
+        "cpu": "",
         "memory": ""
       }
     }


### PR DESCRIPTION
**This is a...** 
- [ ] Feature Request
- [x] Bug Report

**Problem:**
A json file for the documentation misses a comma.

**Proposed Solution:**
Add the comma.

**Page to Update:**
https://kubernetes.io/docs/user-guide/pods/multi-container/#the-spec-schema

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2336)
<!-- Reviewable:end -->
