### PR TITLE
Document cross-region ECR support

### DIFF
--- a/docs/user-guide/images.md
+++ b/docs/user-guide/images.md
@@ -89,7 +89,7 @@ The kubelet will fetch and periodically refresh ECR credentials.  It needs the f
 Requirements:
 
 - You must be using kubelet version `v1.2.0` or newer.  (e.g. run `/usr/bin/kubelet --version=true`).
-- Your nodes must be in the same region as the registry you are using
+- If your nodes are in region A and your registry in a different region B, you need version `v1.3.0`.
 - ECR must be offered in your region
 
 Troubleshooting:

--- a/docs/user-guide/images.md
+++ b/docs/user-guide/images.md
@@ -89,7 +89,7 @@ The kubelet will fetch and periodically refresh ECR credentials.  It needs the f
 Requirements:
 
 - You must be using kubelet version `v1.2.0` or newer.  (e.g. run `/usr/bin/kubelet --version=true`).
-- If your nodes are in region A and your registry in a different region B, you need version `v1.3.0`.
+- If your nodes are in region A and your registry in a different region B, you need version `v1.3.0` or newer.
 - ECR must be offered in your region
 
 Troubleshooting:


### PR DESCRIPTION
Fetching images from a registry hosted in a different region has been supported since 1.3 with
https://github.com/kubernetes/kubernetes/pull/24369

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2359)
<!-- Reviewable:end -->
