### PR TITLE
Add backlink to the related example

### DIFF
--- a/docs/user-guide/jobs/work-queue-1/index.md
+++ b/docs/user-guide/jobs/work-queue-1/index.md
@@ -40,7 +40,7 @@ $ kubectl create -f examples/celery-rabbitmq/rabbitmq-controller.yaml
 replicationController "rabbitmq-controller" created
 ```
 
-We will only use the rabbitmq part from the celery-rabbitmq example.
+We will only use the rabbitmq part from the [celery-rabbitmq example](https://github.com/kubernetes/kubernetes/tree/release-1.3/examples/celery-rabbitmq).
 
 ## Testing the message queue service
 


### PR DESCRIPTION
Hi,
the [Coarse Parallel Processing using a Work Queue](https://kubernetes.io/docs/user-guide/jobs/work-queue-1/) user guide reuses some configuration which was part of the "celery" example. Unfortunately that example application was removed during the 1.4 release and doesn't reside in the master branch anymore.

To help others getting started with the user guide, this PR adds a backlink to the old example folder within the old release-1.3 branch.

Cheers