### PR TITLE
Add missing environment variables

### DIFF
--- a/docs/user-guide/jobs/work-queue-1/job.yaml
+++ b/docs/user-guide/jobs/work-queue-1/job.yaml
@@ -12,4 +12,9 @@ spec:
       containers:
       - name: c
         image: gcr.io/<project>/job-wq-1
+        env:
+        - name: BROKER_URL
+          value: amqp://guest:guest@rabbitmq-service:5672
+        - name: QUEUE
+          value: job1
       restartPolicy: OnFailure


### PR DESCRIPTION
Hi,

the container which is created within the [Coarse Parallel Processing using a Work Queue](https://kubernetes.io/docs/user-guide/jobs/work-queue-1/) user guide depends on some environment variables being set. When running the jobs as described in the guide without the variables, users will see failing jobs.

This PR adds these variables to the shown example job configuration to avoid confusion for beginners.

Cheers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2379)
<!-- Reviewable:end -->
