### PR TITLE
Corrected syntax of Networking Section

### DIFF
--- a/docs/concepts/abstractions/pod.md
+++ b/docs/concepts/abstractions/pod.md
@@ -41,7 +41,7 @@ Pods provide two kinds of shared resources for their constituent containers: *ne
 
 #### Networking
 
-Each Pod is assigned a unique IP address. Every the container in a Pod shares the network namespace, including the IP address and network ports. Containers *inside a Pod* can communicate with one another using `localhost`. When containers in a Pod communicate with entities *outside the Pod*, they must coordinate how they use the shared network resources (such as ports).
+Each Pod is assigned a unique IP address. Every container in a Pod shares the network namespace, including the IP address and network ports. Containers *inside a Pod* can communicate with one another using `localhost`. When containers in a Pod communicate with entities *outside the Pod*, they must coordinate how they use the shared network resources (such as ports).
 
 #### Storage
 


### PR DESCRIPTION
Removed an unnecessary 'the' from a sentence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2464)
<!-- Reviewable:end -->
