### PR TITLE
Issue with Kubernetes API Conventions link (overview.md)

### DIFF
--- a/docs/concepts/abstractions/overview.md
+++ b/docs/concepts/abstractions/overview.md
@@ -25,7 +25,7 @@ Every Kubernetes object includes two nested object fields that govern the object
 
 For example, a Kubernetes Deployment is an object that can represent an application running on your cluster. When you create the Deployment, you might set the Deployment spec to specify that you want three replicas of the application to be running. The Kubernetes system reads the Deployment spec and starts three instances of your desired application--updating the status to match your spec. If any of those instances should fail (a status change), the Kubernetes system responds to the difference between spec and status by making a correction--in this case, starting a replacement instance.
 
-For more information on the object spec, status, and metadata, see the [Kubernetes API Conventions](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/api-conventions.md#spec-and-status).
+For more information on the object spec, status, and metadata, see the [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md).
 
 ### Describing a Kubernetes Object
 


### PR DESCRIPTION
Update link to Kubernetes API Conventions to point to current document location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2475)
<!-- Reviewable:end -->
