### PR TITLE
Add kubelet eviction in GC doc

### DIFF
--- a/docs/admin/garbage-collection.md
+++ b/docs/admin/garbage-collection.md
@@ -42,15 +42,34 @@ to free. Default is 80%.
 We also allow users to customize garbage collection policy through the following kubelet flags:
 
 1. `minimum-container-ttl-duration`, minimum age for a finished container before it is
-garbage collected. Default is 1 minute.
+garbage collected. Default is 0 minute, means any finshed container will be GC.
 2. `maximum-dead-containers-per-container`, maximum number of old instances to retain
-per container. Default is 2.
+per container. Default is 1.
 3. `maximum-dead-containers`, maximum number of old instances of containers to retain globally.
-Default is 100.
+Default is -1, means this flag is disabled.
 
 Containers can potentially be garbage collected before their usefulness has expired. These containers
 can contain logs and other data that can be useful for troubleshooting. A sufficiently large value for
-`maximum-dead-containers-per-container` is highly recommended to allow at least 2 dead containers to be
+`maximum-dead-containers-per-container` is highly recommended to allow at least 1 dead containers to be
 retained per expected container. A higher value for `maximum-dead-containers` is also recommended for a
 similar reason.
 See [this issue](https://github.com/kubernetes/kubernetes/issues/13287) for more details.
+
+
+### Deprecation
+
+Some kubelet Garbage Collection features in this doc will be replaced by kubelet eviction in the future.
+
+Including:
+
+| Existing Flag | New Flag | Rationale |
+| ------------- | -------- | --------- |
+| `--image-gc-high-threshold` | `--eviction-hard` or `eviction-soft` | existing eviction signals can capture image garbage collection |
+| `--image-gc-low-threshold` | `--eviction-minimum-reclaim` | eviction reclaims achieve the same behavior |
+| `--maximum-dead-containers` | | deprecated once old logs are stored outside of container's context |
+| `--maximum-dead-containers-per-container` | | deprecated once old logs are stored outside of container's context |
+| `--minimum-container-ttl-duration` | | deprecated once old logs are stored outside of container's context |
+| `--low-diskspace-threshold-mb` | `--eviction-hard` or `eviction-soft` | this use case is better handled by this proposal |
+| `--outofdisk-transition-frequency` | `--eviction-pressure-transition-period` | make the flag generic to suit all compute resources |
+
+See [kubelet eviction design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-eviction.md) for more details.


### PR DESCRIPTION
This fixes:

1. The default values in GC doc is very outdated.
2. Claim GC features which will be replaced by kubelet eviction in the future, ref https://github.com/kubernetes/kubernetes/issues/40753

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2484)
<!-- Reviewable:end -->
