### PR TITLE
use check mark when it's  a supported access mode

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -172,23 +172,23 @@ In the CLI, the access modes are abbreviated to:
 
 | Volume Plugin        | ReadWriteOnce| ReadOnlyMany| ReadWriteMany|
 | :---                 |     :---:    |    :---:    |    :---:     |
-| AWSElasticBlockStore | x            | -           | -            |
-| AzureFile            | x            | x           | x            |
-| AzureDisk            | x            | -           | -            |
-| CephFS               | x            | x           | x            |
-| Cinder               | x            | -           | -            |
-| FC                   | x            | x           | -            |
-| FlexVolume           | x            | x           | -            |
-| Flocker              | x            | -           | -            |
-| GCEPersistentDisk    | x            | x           | -            |
-| Glusterfs            | x            | x           | x            |
-| HostPath             | x            | -           | -            |
-| iSCSI                | x            | x           | -            |
-| PhotonPersistentDisk | x            | -           | -            |
-| Quobyte              | x            | x           | x            |
-| NFS                  | x            | x           | x            |
-| RBD                  | x            | x           | -            |
-| VsphereVolume        | x            | -           | -            |
+| AWSElasticBlockStore | &#x2713;     | -           | -            |
+| AzureFile            | &#x2713;     | &#x2713;    | &#x2713;     |
+| AzureDisk            | &#x2713;     | -           | -            |
+| CephFS               | &#x2713;     | &#x2713;    | &#x2713;     |
+| Cinder               | &#x2713;     | -           | -            |
+| FC                   | &#x2713;     | &#x2713;    | -            |
+| FlexVolume           | &#x2713;     | &#x2713;    | -            |
+| Flocker              | &#x2713;     | -           | -            |
+| GCEPersistentDisk    | &#x2713;     | &#x2713;    | -            |
+| Glusterfs            | &#x2713;     | &#x2713;    | &#x2713;     |
+| HostPath             | &#x2713;     | -           | -            |
+| iSCSI                | &#x2713;     | &#x2713;    | -            |
+| PhotonPersistentDisk | &#x2713;     | -           | -            |
+| Quobyte              | &#x2713;     | &#x2713;    | &#x2713;     |
+| NFS                  | &#x2713;     | &#x2713;    | &#x2713;     |
+| RBD                  | &#x2713;     | &#x2713;    | -            |
+| VsphereVolume        | &#x2713;     | -           | -            |
 
 ### Class
 


### PR DESCRIPTION
a symbol like `X` usually means `wrong`, `not`, i think using a symbol like this for supported access modes is confusing. so i use check mark (`&#x2713;`&#x2713;) for supported access modes and BALLOT X(`&#x2717;`&#x2717;) for non-supported ones

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2504)
<!-- Reviewable:end -->
