### PR TITLE
Update CronJob doc. with history limits

### DIFF
--- a/docs/user-guide/cron-jobs.md
+++ b/docs/user-guide/cron-jobs.md
@@ -184,3 +184,9 @@ cron jobs, their respective jobs are always allowed to run concurrently.
 
 The `.spec.suspend` field is also optional. If set to `true`, all subsequent executions will be suspended. It does not
 apply to already started executions. Defaults to false.
+
+### Jobs History Limits
+
+The `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields are optional. These fields specify how many completed and failed jobs should be kept.
+
+By default, the last 3 completed jobs and the last failed job are kept. Setting a limit to `0` corresponds to keeping none of the corresponding kind of jobs after they finish.


### PR DESCRIPTION
Documentation changes for kubernetes/kubernetes#40932 which adds new properties to`CronJobSpec`.

I assume we want `do-not-merge` and milestone `1.6` on this (I didn't find a `release-1.6` branch to send the PR like the `README` suggests, so sending to `master`).

cc @soltysh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2511)
<!-- Reviewable:end -->
