### PR TITLE
Fix unmatched closing paren

### DIFF
--- a/docs/concepts/abstractions/pod.md
+++ b/docs/concepts/abstractions/pod.md
@@ -57,7 +57,7 @@ Pods do not, by themselves, self-heal. If a Pod is scheduled to a Node that fail
 
 ### Pods and Controllers
 
-A Controller can create and manage multiple Pods for you, handling replication and rollout and providing self-healing capabilities at cluster scope. For example, if a Node fails, the Controller might automatically replace the Pod by scheduling an identical replacement on a different Node). 
+A Controller can create and manage multiple Pods for you, handling replication and rollout and providing self-healing capabilities at cluster scope. For example, if a Node fails, the Controller might automatically replace the Pod by scheduling an identical replacement on a different Node. 
 
 Some examples of Controllers that contain one or more pods include:
 


### PR DESCRIPTION
End of line 60 had a closing parenthesis, with no opening one to match. Probably left over from a previous version of the document

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2513)
<!-- Reviewable:end -->
