### PR TITLE
add “--show-all” to kubectl get pods

### DIFF
--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -66,7 +66,7 @@ To view completed pods of a job, use `kubectl get pods --show-all`.  The `--show
 To list all the pods that belong to a job in a machine readable form, you can use a command like this:
 
 ```shell
-$ pods=$(kubectl get pods --selector=job-name=pi --output=jsonpath={.items..metadata.name})
+$ pods=$(kubectl get pods --show-all --selector=job-name=pi --output=jsonpath={.items..metadata.name})
 echo $pods
 pi-aiw0a
 ```


### PR DESCRIPTION
add “--show-all” to "kubectl get pods  --selector=job-name=pi --output=jsonpath={.items..metadata.name}"，because the pod was ended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2515)
<!-- Reviewable:end -->
