### PR TITLE
The key-value "optional:true"  doesn't work

### DIFF
--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -590,3 +590,5 @@ Kubelet only supports use of ConfigMap for pods it gets from the API server.  Th
 created using kubectl, or indirectly via a replication controller.  It does not include pods created
 via the Kubelet's `--manifest-url` flag, its `--config` flag, or its REST API (these are not common
 ways to create pods.)
+
+The key-value "optional:true" will be work after kubernetes 1.5.2.

--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -591,4 +591,4 @@ created using kubectl, or indirectly via a replication controller.  It does not 
 via the Kubelet's `--manifest-url` flag, its `--config` flag, or its REST API (these are not common
 ways to create pods.)
 
-The key-value "optional:true" will be work after kubernetes 1.5.2.
+NOTE: The key-value optional:true is supported for kubernetes 1.5.3 and above.


### PR DESCRIPTION
The key-value "optional:true"  doesn't work in 1.5.2 yet. 
So should we add a note here? "The key-value "optional:true" will be work after kubernetes 1.5.2."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2522)
<!-- Reviewable:end -->
