### PR TITLE
Fix the standard storageClass for GCE

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -396,7 +396,7 @@ parameters:
   zone: us-central1-a
 ```
 
-* `type`: `pd-standard` or `pd-ssd`. Default: `pd-ssd`
+* `type`: `pd-standard` or `pd-ssd`. Default: `pd-standard`
 * `zone`: GCE zone. If not specified, a random zone in the same region as controller-manager will be chosen.
 
 #### Glusterfs


### PR DESCRIPTION
As you can see here: https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/gce/gce.go#L117-L121
The default is not ssd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2524)
<!-- Reviewable:end -->
