### PR TITLE
Fix admission-control-config-file example

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -87,7 +87,8 @@ The ImagePolicyWebhook plug-in allows a backend webhook to make admission decisi
 ```
 
 #### Configuration File Format
-ImagePolicyWebhook uses the admission controller config file (`--admission-controller-config-file`) to set configuration options for the behavior of the backend. This file may be json or yaml and has the following format:
+ImagePolicyWebhook uses the admission 
+config file (`--admission-control-config-file`) to set configuration options for the behavior of the backend. This file may be json or yaml and has the following format:
 
 ```javascript
 {


### PR DESCRIPTION
It was using controller instead of control, but that's a wrong option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2525)
<!-- Reviewable:end -->
