### PR TITLE
fix Kubenetes typo

### DIFF
--- a/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -247,7 +247,7 @@ where you would set it. Suppose the Container listens on 127.0.0.1 and the Pod's
 If your pod relies on virtual hosts, which is probably the more common case,
 you should not use `host`, but rather set the `Host` header in `httpHeaders`.
 
-In addition to command probes and HTTP probes, Kubenetes supports
+In addition to command probes and HTTP probes, Kubernetes supports
 [TCP probes](/docs/api-reference/v1/definitions/#_v1_tcpsocketaction).
 
 {% endcapture %}


### PR DESCRIPTION
Kubenetes -> Kubernetes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2528)
<!-- Reviewable:end -->
