### PR TITLE
re: issue #2034; fix docker image link

### DIFF
--- a/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md
@@ -23,7 +23,7 @@ heapster monitoring will be turned-on by default).
 ## Step One: Run & expose php-apache server
 
 To demonstrate Horizontal Pod Autoscaler we will use a custom docker image based on the php-apache image.
-The image can be found [here](https://gcr.io/google_containers/hpa-example).
+The image can be found [here](/docs/user-guide/horizontal-pod-autoscaling/image/Dockerfile).
 It defines an [index.php](/docs/user-guide/horizontal-pod-autoscaling/image/index.php) page which performs some CPU intensive computations.
 
 First, we will start a deployment running the image and expose it as a service:

--- a/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md
@@ -23,7 +23,7 @@ heapster monitoring will be turned-on by default).
 ## Step One: Run & expose php-apache server
 
 To demonstrate Horizontal Pod Autoscaler we will use a custom docker image based on the php-apache image.
-The image can be found [here](/docs/user-guide/horizontal-pod-autoscaling/image/Dockerfile).
+The Dockerfile can be found [here](/docs/user-guide/horizontal-pod-autoscaling/image/Dockerfile).
 It defines an [index.php](/docs/user-guide/horizontal-pod-autoscaling/image/index.php) page which performs some CPU intensive computations.
 
 First, we will start a deployment running the image and expose it as a service:

--- a/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md
@@ -23,7 +23,7 @@ heapster monitoring will be turned-on by default).
 ## Step One: Run & expose php-apache server
 
 To demonstrate Horizontal Pod Autoscaler we will use a custom docker image based on the php-apache image.
-The image can be found [here](/docs/user-guide/horizontal-pod-autoscaling/image).
+The image can be found [here](https://gcr.io/google_containers/hpa-example).
 It defines an [index.php](/docs/user-guide/horizontal-pod-autoscaling/image/index.php) page which performs some CPU intensive computations.
 
 First, we will start a deployment running the image and expose it as a service:


### PR DESCRIPTION
change link in line 26 to: /docs/user-guide/horizontal-pod-autoscaling/image/Dockerfile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2532)
<!-- Reviewable:end -->
