### PR TITLE
kubectl_apply.md-change it for label key

### DIFF
--- a/docs/user-guide/kubectl/kubectl_apply.md
+++ b/docs/user-guide/kubectl/kubectl_apply.md
@@ -32,7 +32,7 @@ kubectl apply -f FILENAME
   # Apply the configuration in manifest.yaml that matches label app=nginx and delete all the other resources that are not in the file and match label app=nginx.
   kubectl apply --prune -f manifest.yaml -l app=nginx
   
-  # Apply the configuration in manifest.yaml and delete all the other configmaps that are not in the file.
+  # Apply the configuration in manifest.yaml and delete all the other configmaps with the same label key that are not in the file.
   kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap
 ```
 


### PR DESCRIPTION
When I test this command, if the configmap has a label, it just delete the configmaps which has the same label key and that are not in the file.
kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap
So I advise change the description like this:
"Apply the configuration in manifest.yaml and delete all the other configmaps with the same label key that are not in the file."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2536)
<!-- Reviewable:end -->
