### PR TITLE
remove its name from file content

### DIFF
--- a/docs/admin/service-accounts-admin.md
+++ b/docs/admin/service-accounts-admin.md
@@ -71,8 +71,9 @@ account. To create additional API tokens for a service account, create a secret
 of type `ServiceAccountToken` with an annotation referencing the service
 account, and the controller will update it with a generated token:
 
-```json
 secret.json:
+
+```json
 {
     "kind": "Secret",
     "apiVersion": "v1",


### PR DESCRIPTION
remove its name from file content


and, I  do nothing about the last line, 

`a ServiceAccount named "default" exists in every active namespace.`

but the change  appears , it makes me confused

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2548)
<!-- Reviewable:end -->
