### PR TITLE
Parallel Jobs with a  work queue:

### DIFF
--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -120,7 +120,7 @@ There are three main types of jobs:
   - the job is complete when there is one successful pod for each value in the range 1 to `.spec.completions`.
   - **not implemented yet:** each pod passed a different index in the range 1 to `.spec.completions`.
 1. Parallel Jobs with a *work queue*:
-  - do not specify `.spec.completions`
+  - do not specify `.spec.completions`, default to `.spec.Parallelism`
   - the pods must coordinate with themselves or an external service to determine what each should work on
   - each pod is independently capable of determining whether or not all its peers are done, thus the entire Job is done.
   - when _any_ pod terminates with success, no new pods are created.


### PR DESCRIPTION
do not specify  .spec.completions, default to .spec.Parallelism, not  default to 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2549)
<!-- Reviewable:end -->
