### PR TITLE
optional:true is supported for Kubernetes 1.6

### DIFF
--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -604,3 +604,5 @@ Kubelet only supports use of ConfigMap for pods it gets from the API server.  Th
 created using kubectl, or indirectly via a replication controller.  It does not include pods created
 via the Kubelet's `--manifest-url` flag, its `--config` flag, or its REST API (these are not common
 ways to create pods.)
+
+NOTE: The key-value optional:true is supported for Kubernetes 1.6 and above.

--- a/docs/user-guide/configmap/index.md
+++ b/docs/user-guide/configmap/index.md
@@ -605,4 +605,4 @@ created using kubectl, or indirectly via a replication controller.  It does not 
 via the Kubelet's `--manifest-url` flag, its `--config` flag, or its REST API (these are not common
 ways to create pods.)
 
-NOTE: The key-value optional:true is supported for Kubernetes 1.6 and above.
+**NOTE:** The key-value `optional:true` is supported for Kubernetes 1.6 and above.


### PR DESCRIPTION
NOTE: The key-value optional:true is supported for Kubernetes 1.6 and above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2551)
<!-- Reviewable:end -->
