### PR TITLE
Update documentation about alpha provisioning.

### DIFF
--- a/docs/user-guide/persistent-volumes/index.md
+++ b/docs/user-guide/persistent-volumes/index.md
@@ -547,7 +547,8 @@ and need persistent storage, we recommend that you use the following pattern:
   - If the user provides a storage class name, and the cluster is version 1.4 or newer, put that value into the `volume.beta.kubernetes.io/storage-class` annotation of the PVC.
     This will cause the PVC to match the right storage class if the cluster has StorageClasses enabled by the admin.
   - If the user does not provide a storage class name or the cluster is version 1.3, then instead put a `volume.alpha.kubernetes.io/storage-class: default` annotation on the PVC.
-    - This will cause a PV to be automatically provisioned for the user with sane default characteristics on some clusters.  
+    - This will cause a PV to be automatically provisioned for the user with sane default characteristics on some clusters with Kubernetes up to 1.5.
+    - In Kubernetes 1.6, a default storage class will be used to provision a volume for such PVC.
     - Despite the word `alpha` in the name, the code behind this annotation has `beta` level support.
     - Do not use `volume.beta.kubernetes.io/storage-class:` with any value including the empty string since it will prevent DefaultStorageClass admission controller
       from running if enabled.
@@ -556,5 +557,5 @@ and need persistent storage, we recommend that you use the following pattern:
   PVCs).
 - In the future, we expect most clusters to have `DefaultStorageClass` enabled, and to have some form of storage available.  However, there may not be any
   storage class names which work on all clusters, so continue to not set one by default.
-  At some point, the alpha annotation will cease to have meaning, but the unset `storageClass` field on the PVC
-  will have the desired effect.
+  In Kubernetes 1.6 the alpha annotation ceases to have meaning, but a default storage class should be
+  configured there to provisions all PVCs, including those with the alpha annotation.


### PR DESCRIPTION
In 1.6 the alpha annotation does not have any meaning. Reflect it in portable
configuration documentation.

I explicitly did not update any example in this repository that still uses alpha provisioning, as it is the best portable solution for now. It should be updated few releases after 1.6 where all clusters will have a default storage class and alpha annotation won't be needed there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2557)
<!-- Reviewable:end -->
