### PR TITLE
Remove reference to port-forward to services

### DIFF
--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -203,7 +203,6 @@ $ kubectl logs -f my-pod -c my-container              # stream pod container log
 $ kubectl run -i --tty busybox --image=busybox -- sh  # Run pod as interactive shell
 $ kubectl attach my-pod -i                            # Attach to Running Container
 $ kubectl port-forward my-pod 5000:6000               # Forward port 6000 of Pod to your to 5000 on your local machine
-$ kubectl port-forward my-svc 6000                    # Forward port to service
 $ kubectl exec my-pod -- ls /                         # Run command in existing pod (1 container case)
 $ kubectl exec my-pod -c my-container -- ls /         # Run command in existing pod (multi-container case)
 $ kubectl top pod POD_NAME --containers               # Show metrics for a given pod and its containers


### PR DESCRIPTION
port forwarding to services isn't supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2569)
<!-- Reviewable:end -->
