### PR TITLE
Fix typo in concepts

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -17,7 +17,7 @@ Once you've set your desired state, the *Kubernetes Control Plane* works to make
 
 ## Kubernetes Objects
 
-Kubernetes contains a number of abstractions that represent your the state of your system: deployed containerized applications and workloads, their associated network and disk resources, and other information about what your cluster is doing. These abstractions are represented by objects in the Kubernetes API; see the [Kubernetes Objects overview](/docs/concepts/abstractions/overview/) for more details. 
+Kubernetes contains a number of abstractions that represent the state of your system: deployed containerized applications and workloads, their associated network and disk resources, and other information about what your cluster is doing. These abstractions are represented by objects in the Kubernetes API; see the [Kubernetes Objects overview](/docs/concepts/abstractions/overview/) for more details. 
 
 The basic Kubernetes objects include:
 


### PR DESCRIPTION
Unnecessary `your`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2591)
<!-- Reviewable:end -->
