### PR TITLE
Provide correct location for KUBE_ETCD_SERVERS

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -61,9 +61,6 @@ echo "192.168.121.9	centos-master
 * Edit /etc/kubernetes/config which will be the same on all hosts to contain:
 
 ```shell
-# Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers=http://centos-master:2379"
-
 # logging to stderr means we get it in the systemd journal
 KUBE_LOGTOSTDERR="--logtostderr=true"
 
@@ -110,6 +107,9 @@ KUBE_API_PORT="--port=8080"
 
 # Port kubelets listen on
 KUBELET_PORT="--kubelet-port=10250"
+
+# Comma separated list of nodes in the etcd cluster
+KUBE_ETCD_SERVERS="--etcd-servers=http://centos-master:2379"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"


### PR DESCRIPTION
Provide correct location for KUBE_ETCD_SERVERS configuration key. It was
previously listed as being in /etc/kubernetes/config but is actually in
/etc/kubernetes/apiserver.

Related: https://github.com/kubernetes/kubernetes.github.io/issues/1600

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2619)
<!-- Reviewable:end -->
