### PR TITLE
Correct the certificate name

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -541,8 +541,8 @@ Finally, add the following parameters into API server start parameters:
 1.  Generate server certificate and key.
     (build-server-full [filename]: Generate a keypair and sign locally for a client or server)
 
-          ./easyrsa --subject-alt-name="IP:${MASTER_IP}" build-server-full kubernetes-master nopass
-1.  Copy `pki/ca.crt`, `pki/issued/kubernetes-master.crt`, and `pki/private/kubernetes-master.key` to your directory.
+          ./easyrsa --subject-alt-name="IP:${MASTER_IP}" build-server-full server nopass
+1.  Copy `pki/ca.crt`, `pki/issued/server.crt`, and `pki/private/server.key` to your directory.
 1.  Fill in and add the following parameters into the API server start parameters:
 
           --client-ca-file=/yourdirectory/ca.crt


### PR DESCRIPTION
In https://kubernetes.io/docs/admin/authentication/#appendix page under easyrsa section in step 5 certificate name passed to the apiserver in the example does not match the certificate generated in step 3. So this PR is to fix the certificate name across the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2652)
<!-- Reviewable:end -->
