### PR TITLE
add required images in kubeadm init step

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -103,7 +103,15 @@ Note: Disabling SELinux by running `setenforce 0` is required in order to allow 
 ### (2/4) Initializing your master
 
 The master is the machine where the "control plane" components run, including `etcd` (the cluster database) and the API server (which the `kubectl` CLI communicates with).
-All of these components run in pods started by `kubelet`.
+All of these components run in pods started by `kubelet` and the following images are required and will be automatically pulled by `kubelet` if they are absent while `kubeadm init` is initializing your master:
+
+    gcr.io/google_containers/kube-proxy-amd64                v1.5.3         
+    gcr.io/google_containers/kube-controller-manager-amd64   v1.5.3         
+    gcr.io/google_containers/kube-scheduler-amd64            v1.5.3         
+    gcr.io/google_containers/kube-apiserver-amd64            v1.5.3         
+    gcr.io/google_containers/etcd-amd64                      3.0.14-kubeadm 
+    gcr.io/google_containers/kube-discovery-amd64            1.0            
+    gcr.io/google_containers/pause-amd64                     3.0 
 
 Right now you can't run `kubeadm init` twice without tearing down the cluster in between, see [Tear down](#tear-down).
 


### PR DESCRIPTION
i think we better documenting required images here than https://kubernetes.io/docs/admin/kubeadm/  because most new-coming users always find this document and then follow to bootstrap a cluster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2670)
<!-- Reviewable:end -->
