### PR TITLE
fix unsupported parameter of wget command

### DIFF
--- a/docs/getting-started-guides/network-policy/walkthrough.md
+++ b/docs/getting-started-guides/network-policy/walkthrough.md
@@ -50,7 +50,7 @@ Waiting for pod default/busybox-472357175-y0m47 to be running, status is Pending
 
 Hit enter for command prompt
 
-/ # wget -s --timeout=1 nginx
+/ # wget --spider --timeout=1 nginx
 Connecting to nginx (10.100.0.16:80)
 / #
 ```
@@ -96,7 +96,7 @@ Waiting for pod default/busybox-472357175-y0m47 to be running, status is Pending
 
 Hit enter for command prompt
 
-/ # wget -s --timeout=1 nginx 
+/ # wget --spider --timeout=1 nginx 
 Connecting to nginx (10.100.0.16:80)
 wget: download timed out
 / #
@@ -110,7 +110,7 @@ Waiting for pod default/busybox-472357175-y0m47 to be running, status is Pending
 
 Hit enter for command prompt
 
-/ # wget -s --timeout=1 nginx
+/ # wget --spider --timeout=1 nginx
 Connecting to nginx (10.100.0.16:80)
 / #
 ```


### PR DESCRIPTION
What this PR does / why we need it: 

   According to my test, "-s" is not supported for wget command now, so i changed it to "--spider", thank you!

   The test command as follow:
   / # wget -s --timeout=1 nginx
wget: invalid option -- s
BusyBox v1.26.2 (2017-01-12 18:09:33 UTC) multi-call binary.

Usage: wget [-c|--continue] [--spider] [-q|--quiet] [-O|--output-document FILE]
        [--header 'header: value'] [-Y|--proxy on/off] [-P DIR]
        [-U|--user-agent AGENT] [-T SEC] URL...

Retrieve files via HTTP or FTP

        --spider        Spider mode - only check file existence
        -c              Continue retrieval of aborted transfer
        -q              Quiet
        -P DIR          Save to DIR (default .)
        -T SEC          Network read timeout is SEC seconds
        -O FILE         Save to FILE ('-' for stdout)
        -U STR          Use STR for User-Agent header
        -Y on/off       Use proxy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2711)
<!-- Reviewable:end -->
