### PR TITLE
Update kubefed.md to show the trailing dot

### DIFF
--- a/docs/admin/federation/kubefed.md
+++ b/docs/admin/federation/kubefed.md
@@ -91,11 +91,12 @@ the name `fellowship`, a host cluster context `rivendell`, and the
 domain suffix `example.com`:
 
 ```shell
-kubefed init fellowship --host-cluster-context=rivendell  --dns-zone-name="example.com"
+kubefed init fellowship --host-cluster-context=rivendell  --dns-zone-name="example.com."
 ```
 
 The domain suffix specified in `--dns-zone-name` must be an existing
 domain that you control, and that is programmable by your DNS provider.
+It's important to have the trailing dot.
 
 `kubefed init` sets up the federation control plane in the host
 cluster and also adds an entry for the federation API server in your


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/28335 is still open. The trailing dot is required for federation w/ Cloud DNS to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2735)
<!-- Reviewable:end -->
