### PR TITLE
Updated user guide for `kubectl taint` by adding `NoExecute`.

### DIFF
--- a/docs/user-guide/kubectl/kubectl_taint.md
+++ b/docs/user-guide/kubectl/kubectl_taint.md
@@ -12,7 +12,7 @@ Update the taints on one or more nodes.
   * A taint consists of a key, value, and effect. As an argument here, it is expressed as key=value:effect.
   * The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to  253 characters.
   * The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to  253 characters.
-  * The effect must be NoSchedule or PreferNoSchedule.
+  * The effect must be `NoSchedule`, `PreferNoSchedule` or `NoExecute`.
   * Currently taint can only apply to node.
 
 ```


### PR DESCRIPTION
Fixed part of #2737

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2744)
<!-- Reviewable:end -->
