### PR TITLE
Fix grammar in docs/admin/daemon.md

### DIFF
--- a/docs/admin/daemons.md
+++ b/docs/admin/daemons.md
@@ -21,8 +21,8 @@ Some typical uses of a DaemonSet are:
   https://github.com/prometheus/node_exporter), `collectd`, New Relic agent, or Ganglia `gmond`.
 
 In a simple case, one DaemonSet, covering all nodes, would be used for each type of daemon.
-A more complex setup might use multiple DaemonSets would be used for a single type of daemon,
-but with different flags and/or different memory and cpu requests for different hardware types.
+A more complex setup might use multiple DaemonSets for a single type of daemon, but with
+different flags and/or different memory and cpu requests for different hardware types.
 
 ## Writing a DaemonSet Spec
 


### PR DESCRIPTION
A sentence in the "What is a DaemonSet" section had an extra "would be
used" which made the sentence grammatically incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2766)
<!-- Reviewable:end -->
