### PR TITLE
Remove autogenerate todo from docs

### DIFF
--- a/docs/user-guide/kubectl-overview.md
+++ b/docs/user-guide/kubectl-overview.md
@@ -7,8 +7,6 @@ title: kubectl Overview
 
 `kubectl` is a command line interface for running commands against Kubernetes clusters. This overview covers `kubectl` syntax, describes the command operations, and provides common examples. For details about each command, including all the supported flags and subcommands, see the [kubectl](/docs/user-guide/kubectl) reference documentation. For installation instructions see [prerequisites](/docs/user-guide/prereqs).
 
-TODO: Auto-generate this file to ensure it's always in sync with any `kubectl` changes, see [#14177](http://pr.k8s.io/14177).
-
 ## Syntax
 
 Use the following syntax to run `kubectl` commands from your terminal window:


### PR DESCRIPTION
- This should be captured via a GitHub issue
  and not a `TODO` in the README documentation
  which leads to confusion for users.
- If the documentation is out of date with `kubectl`
  then we need to update the docs accordingly.
- The `TODO` in the documentation leads users
  to believe that the docs are always out of sync
  because they weren't "autogenerated".

I looked through pages and pages of issues that could be related but maybe my search skills aren't up to par on a Sunday.  If anyone has it, it would be good to reference in the commit body.

In any case, the docs shouldn't contain these todos like source code.

Open to discussion of course 👍

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2781)
<!-- Reviewable:end -->
