### PR TITLE
Update CronJob history limits

### DIFF
--- a/docs/user-guide/cron-jobs.md
+++ b/docs/user-guide/cron-jobs.md
@@ -189,4 +189,4 @@ apply to already started executions. Defaults to false.
 
 The `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields are optional. These fields specify how many completed and failed jobs should be kept.
 
-By default, the last 3 completed jobs and the last failed job are kept. Setting a limit to `0` corresponds to keeping none of the corresponding kind of jobs after they finish.
+By default, there are no limits, and all successful and failed jobs are kept. However, jobs can pile up quickly when running a cron job, and setting these fields is recommended. Setting a limit to `0` corresponds to keeping none of the corresponding kind of jobs after they finish.


### PR DESCRIPTION
Documentation for the limits was introduced in #2511. Default limits were initially planned to make it in 1.6 through kubernetes/kubernetes#41901 but this is not going to happen. 

This small PR reflects the fact that 1.6 will have history limits without any default limits instead.

cc @soltysh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2790)
<!-- Reviewable:end -->
