### PR TITLE
Ingress resource was released in v1.2

### DIFF
--- a/docs/user-guide/services/index.md
+++ b/docs/user-guide/services/index.md
@@ -183,7 +183,7 @@ iptables proxy was added, but was not the default operating mode.  Since
 Kubernetes v1.2, the iptables proxy is the default.
 
 As of Kubernetes v1.0, `Services` are a "layer 4" (TCP/UDP over IP) construct.
-In Kubernetes v1.1 the `Ingress` API was added (beta) to represent "layer 7"
+In Kubernetes v1.2 the `Ingress` API was added to represent "layer 7"
 (HTTP) services.
 
 ### Proxy-mode: userspace


### PR DESCRIPTION
Removed "beta" mark for Ingress resource in v1.1. Changed to v1.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2855)
<!-- Reviewable:end -->
