### PR TITLE
Use external link for pod declaration?

### DIFF
--- a/docs/user-guide/walkthrough/index.md
+++ b/docs/user-guide/walkthrough/index.md
@@ -46,7 +46,7 @@ See the [design document](https://github.com/kubernetes/kubernetes/blob/{{page.g
 Create a pod containing an nginx server ([pod-nginx.yaml](/docs/user-guide/walkthrough/pod-nginx.yaml)):
 
 ```shell
-$ kubectl create -f docs/user-guide/walkthrough/pod-nginx.yaml
+$ kubectl create -f https://kubernetes.io/docs/user-guide/walkthrough/pod-nginx.yaml
 ```
 
 List all pods:


### PR DESCRIPTION
In case users have not locally cloned the [kubernetes.github.io](https://github.com/kubernetes/kubernetes.github.io) repo, use link for pod declaration to quickly get up-and-running with the provided example.

Potentially related: https://github.com/kubernetes/kubernetes.github.io/pull/2263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2923)
<!-- Reviewable:end -->
