### PR TITLE
[UX] "View $PAGE on GitHub" without forking the repo

### DIFF
--- a/editdocs.md
+++ b/editdocs.md
@@ -13,6 +13,8 @@ $( document ).ready(function() {
     	$("#continueEdit").show();
     	$("#continueEditButton").text("Edit " + forwarding);
     	$("#continueEditButton").attr("href", "https://github.com/kubernetes/kubernetes.github.io/edit/master/" + forwarding)
+    	$("#viewOnGithubButton").text("View " + forwarding + " on GitHub");
+    	$("#viewOnGithubButton").attr("href", "https://github.com/kubernetes/kubernetes.github.io/tree/master/" + forwarding)
     } else {
         $("#generalInstructions").show();
     	$("#continueEdit").hide();
@@ -26,6 +28,7 @@ $( document ).ready(function() {
 <p>Click the button below to edit the page you were just on. When you are done, click <b>Commit Changes</b> at the bottom of the screen. This creates a copy of our site in your GitHub account called a <i>fork</i>. You can make other changes in your fork after it is created, if you want. When you are ready to send us all your changes, go to the index page for your fork and click <b>New Pull Request</b> to let us know about it.</p>
 
 <p><a id="continueEditButton" class="button"></a></p>
+<p><a id="viewOnGithubButton" class="button"></a></p>
 
 </div>
 <div id="generalInstructions">


### PR DESCRIPTION
Adding a "View docs/bla-bla.md on GitHub" button next to the
"Edit docs/bla-bla.md" button so that people can view the file
first without clicking the Edit button (which does not work without
forking the repository).

I did not need this because I was trying to do something without
forking. I just found it to be bit difficult to view source of a page
on GitHub.

I'm open to ideas, perhaps we can instead add an article footer button
named "View on GitHub" next to the "Edit this Page".

## Screenshot

![image](https://cloud.githubusercontent.com/assets/159209/24118808/4edda580-0d6c-11e7-8a14-f7d56b8d8a60.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2924)
<!-- Reviewable:end -->
