### PR TITLE
Apply typo fixes from #2791

### DIFF
--- a/docs/getting-started-guides/kargo.md
+++ b/docs/getting-started-guides/kargo.md
@@ -2,10 +2,6 @@
 title: Installing Kubernetes On-premise/Cloud Providers with Kargo
 ---
 
-<style>
-li>.highlighter-rouge {position:relative; top:3px;}
-</style>
-
 ## Overview
 
 This quickstart helps to install a Kubernetes cluster hosted

--- a/docs/getting-started-guides/kops.md
+++ b/docs/getting-started-guides/kops.md
@@ -2,10 +2,6 @@
 title: Installing Kubernetes on AWS with kops
 ---
 
-<style>
-li>.highlighter-rouge {position:relative; top:3px;}
-</style>
-
 ## Overview
 
 This quickstart shows you how to easily install a Kubernetes cluster on AWS.

--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -7,10 +7,6 @@ assignees:
 title: Installing Kubernetes on Linux with kubeadm
 ---
 
-<style>
-li>.highlighter-rouge {position:relative; top:3px;}
-</style>
-
 ## Overview
 
 This quickstart shows you how to easily install a secure Kubernetes cluster on machines running Ubuntu 16.04, CentOS 7 or HypriotOS v1.0.1+.

--- a/docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
+++ b/docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
@@ -383,7 +383,7 @@ The `kubectl apply` command writes the contents of the configuration file to the
 `kubectl.kubernetes.io/last-applied-configuration` annotation. This
 is used to identify fields that have been removed from the configuration
 file and need to be cleared from the live configuration. Here are the steps used
-to caluculate which fields should be deleted or set:
+to calculate which fields should be deleted or set:
 
 1. Calculate the fields to delete. These are the fields present in `last-applied-configuration` and missing from the configuration file.
 2. Calculate the fields to add or set. These are the fields present in the configuration file whose values don't match the live configuration.

--- a/docs/tutorials/object-management-kubectl/imperative-object-management-configuration.md
+++ b/docs/tutorials/object-management-kubectl/imperative-object-management-configuration.md
@@ -62,7 +62,7 @@ The `create`, `replace`, and `delete` commands work well when each object's
 configuration is fully defined and recorded in its configuration
 file. However when a live object is updated, and the updates are not merged
 into its configuration file, the updates will be lost the next time a `replace`
-is executed. This is can happen if a controller, such as
+is executed. This can happen if a controller, such as
 a HorizontalPodAutoscaler, makes updates directly to a live object. Here's 
 an example:
 


### PR DESCRIPTION
Because of the content migration, the docs in PR #2791 moved, so I'm applying those changes to the proper location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2949)
<!-- Reviewable:end -->
