### PR TITLE
Update daemons.md to remove reference to future support for DaemonSet updates

### DIFF
--- a/docs/admin/daemons.md
+++ b/docs/admin/daemons.md
@@ -126,9 +126,9 @@ the new DaemonSet with the different template will recognize all the existing po
 matching labels.  It will not modify or delete them despite a mismatch in the pod template.
 You will need to force new pod creation by deleting the pod or deleting the node.
 
-Starting from Kubernetes version 1.6, you can [perform a rolling update](/docs/tasks/manage-daemon/update-daemon-set/) on a DaemonSet.
+In Kubernetes version 1.6 and later, you can [perform a rolling update](/docs/tasks/manage-daemon/update-daemon-set/) on a DaemonSet.
 
-Support for updating DaemonSets and controlled updating of nodes is planned.
+Future releases of Kubernetes will support controlled updating of nodes.
 
 ## Alternatives to DaemonSet
 


### PR DESCRIPTION
The future is now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2964)
<!-- Reviewable:end -->
