### PR TITLE
Flannel is not longer the only network addon that supports ARM

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -190,8 +190,6 @@ You can install a pod network add-on with the following command:
 
 Please refer to the specific add-on installation guide for exact details. You should only install one pod network per cluster.
 
-If you are on another architecture than amd64, you should use the flannel overlay network as described in [the multi-platform section](#kubeadm-is-multi-platform)
-
 NOTE: You can install **only one** pod network per cluster.
 
 Once a pod network has been installed, you can confirm that it is working by checking that the `kube-dns` pod is `Running` in the output of `kubectl get pods --all-namespaces`.
@@ -347,14 +345,6 @@ See the [list of add-ons](/docs/admin/addons/) to explore other add-ons, includi
 kubeadm deb packages and binaries are built for amd64, arm and arm64, following the [multi-platform proposal](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/multi-platform.md).
 
 deb-packages are released for ARM and ARM 64-bit, but not RPMs (yet, reach out if there's interest).
-
-Currently, only the pod network flannel is working on multiple architectures. You can install it this way:
-
-    # export ARCH=amd64
-    # curl -sSL "https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml?raw=true" | sed "s/amd64/${ARCH}/g" | kubectl create -f -
-
-Replace `ARCH=amd64` with `ARCH=arm` or `ARCH=arm64` depending on the platform you're running on.
-Note that the Raspberry Pi 3 is in ARM 32-bit mode, so for RPi 3 you should set `ARCH` to `arm`, not `arm64`.
 
 ## Cloudprovider integrations (experimental)
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2982)
<!-- Reviewable:end -->
