### PR TITLE
Fix the number of processes on Kubernetes master

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -10,7 +10,7 @@ To work with Kubernetes, you use *Kubernetes API objects* to describe your clust
 
 Once you've set your desired state, the *Kubernetes Control Plane* works to make the cluster's current state match the desired state. To do so, Kubernetes performs a variety of tasks automatically--such as starting or restarting containers, scaling the number of replicas of a given application, and more. The Kubernetes Control Plane consists of a collection of processes running on your cluster: 
 
-* The **Kubernetes Master** is a collection of four processes that run on a single node in your cluster, which is designated as the master node.
+* The **Kubernetes Master** is a collection of three processes that run on a single node in your cluster, which is designated as the master node.
 * Each individual non-master node in your cluster runs two processes:
   * **kubelet**, which communicates with the Kubernetes Master.
   * **kube-proxy**, a network proxy which reflects Kubernetes networking services on each node.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -10,7 +10,7 @@ To work with Kubernetes, you use *Kubernetes API objects* to describe your clust
 
 Once you've set your desired state, the *Kubernetes Control Plane* works to make the cluster's current state match the desired state. To do so, Kubernetes performs a variety of tasks automatically--such as starting or restarting containers, scaling the number of replicas of a given application, and more. The Kubernetes Control Plane consists of a collection of processes running on your cluster: 
 
-* The **Kubernetes Master** is a collection of three processes that run on a single node in your cluster, which is designated as the master node.
+* The **Kubernetes Master** is a collection of three processes that run on a single node in your cluster, which is designated as the master node. Those processes are: kube-apiserver, kube-controller-manager and kube-scheduler. 
 * Each individual non-master node in your cluster runs two processes:
   * **kubelet**, which communicates with the Kubernetes Master.
   * **kube-proxy**, a network proxy which reflects Kubernetes networking services on each node.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -10,7 +10,7 @@ To work with Kubernetes, you use *Kubernetes API objects* to describe your clust
 
 Once you've set your desired state, the *Kubernetes Control Plane* works to make the cluster's current state match the desired state. To do so, Kubernetes performs a variety of tasks automatically--such as starting or restarting containers, scaling the number of replicas of a given application, and more. The Kubernetes Control Plane consists of a collection of processes running on your cluster: 
 
-* The **Kubernetes Master** is a collection of three processes that run on a single node in your cluster, which is designated as the master node. Those processes are: kube-apiserver, kube-controller-manager and kube-scheduler. 
+* The **Kubernetes Master** is a collection of three processes that run on a single node in your cluster, which is designated as the master node. Those processes are: kube-apiserver, kube-controller-manager and kube-scheduler.
 * Each individual non-master node in your cluster runs two processes:
   * **kubelet**, which communicates with the Kubernetes Master.
   * **kube-proxy**, a network proxy which reflects Kubernetes networking services on each node.


### PR DESCRIPTION
According to https://kubernetes.io/docs/getting-started-guides/centos/centos_manual_config/, we can know that there are only three processes of Kubernetes running on the master. etcd and flannel are third-party softwares. These are kube-apiserver, kube-controller-manager, and kube-scheduler. If we want to deploy pod on master, we need to start other two processes: kube-proxy and kubelet. So Three or Five is correct. In this case, I perfer Three. Pure master without Pod is fine.

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2985)
<!-- Reviewable:end -->
