### PR TITLE
Adding minimal set of privileges required for vSphere Cloud Provider

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -55,6 +55,32 @@ export GOVC_INSECURE=1
 govc vm.change -e="disk.enableUUID=1" -vm=<VMNAME>
 ```
 
+* Create Role and User with Required Privileges for vSphere Cloud Provider
+
+vSphere Cloud Provider requires the following minimal set of privileges to interact with vCenter:
+
+Please refer [vSphere Documentation Center](http://pubs.vmware.com/vsphere-65/index.jsp?topic=%2Fcom.vmware.vsphere.security.doc%2FGUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html&resultof=%22%43%72%65%61%74%65%22%20%22%63%72%65%61%74%22%20%22%43%75%73%74%6f%6d%22%20%22%63%75%73%74%6f%6d%22%20%22%52%6f%6c%65%22%20%22%72%6f%6c%65%22%20) to know about steps for creating a Custom Role, User and Role Assignment.
+
+Note: Assign Permissions at vCenter Level and make sure to check Propagate.
+
+```
+Datastore > Allocate space
+Datastore > Low level file Operations
+Virtual Machine > Configuration > Add existing disk
+Virtual Machine > Configuration > Add or remove device
+Virtual Machine > Configuration > Remove disk
+```
+
+For VSAN policy based volume provisioning feature, following additional privileges are required.
+
+```
+Network > Assign network
+Virtual machine > Configuration > Add new disk
+Virtual Machine > Inventory > Create new
+Virtual machine > Configuration > Add new disk
+Resource > Assign virtual machine to resource pool
+```
+
 * Provide the cloud config file to each instance of kubelet, apiserver and controller manager via ```--cloud-config=<path to file>``` flag. Cloud config [template can be found at Kubernetes-Anywhere](https://github.com/kubernetes/kubernetes-anywhere/blob/master/phase1/vsphere/vsphere.conf)
 
 Sample Config:
@@ -79,8 +105,6 @@ Sample Config:
 * When upgrading to 1.6 install the default storage class addons, [click here for more details](https://github.com/kubernetes/kubernetes/issues/40070)
 
 #### Known issues
-
-* [Unable to execute command on pod container using kubectl exec](https://github.com/kubernetes/kubernetes-anywhere/issues/337)
 
 ### Kube-up (Deprecated)
 


### PR DESCRIPTION
**Changes:**
Added minimal set of privileges required for vSphere Cloud Provider.
Removed resolved known issues.

**Notes of Reviewers:**
Verified privileges on vCenter 6.5 with Kubernetes 1.5.3 cluster. 

Performed following operations
Create Storage Class, Create PVC, Create POD, Delete POD, Delete Volume.
Verified Disk attach/detach volume create/delete is working fine with these set of privileges.

CC:  @abrarshivani @BaluDontu @luomiao @tusharnt @pdhamdhere @kerneltime

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2989)
<!-- Reviewable:end -->
