### PR TITLE
Fix typo in authorization docs

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -516,7 +516,7 @@ current-context: webhook
 contexts:
 - context:
     cluster: name-of-remote-authz-service
-    user: name-of-api-sever
+    user: name-of-api-server
   name: webhook
 ```
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2995)
<!-- Reviewable:end -->
