### PR TITLE
Dollar signs used before commands without showing output

### DIFF
--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -196,7 +196,7 @@ for changes to this variable to take effect.
 You can use `kubectl convert` command to convert config files between different API versions.
 
 ```shell
-$ kubectl convert -f pod.yaml --output-version v1
+kubectl convert -f pod.yaml --output-version v1
 ```
 
 For more options, please refer to the usage of [kubectl convert](/docs/user-guide/kubectl/kubectl_convert/) command.


### PR DESCRIPTION
Please see [dollar-signs-used-before-commands-without-showing-output](https://github.com/DavidAnson/markdownlint/blob/v0.4.1/doc/Rules.md#md014---dollar-signs-used-before-commands-without-showing-output)

Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/2996)
<!-- Reviewable:end -->
