### PR TITLE
docs/admin: clarify SecurityContextDeny and when it should be used

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -197,7 +197,7 @@ We strongly recommend using this plug-in if you intend to make use of Kubernetes
 
 ### SecurityContextDeny
 
-This plug-in will deny any pod with a [SecurityContext](/docs/user-guide/security-context) that defines options that were not available on the `Container`.
+This plug-in will deny any pod that attempts to set certain escalating [SecurityContext](/docs/user-guide/security-context) fields. This should be enabled if a cluster doesn't utilize [pod security policies](/docs/user-guide/pod-security-policy) to restrict the set of values a security context can take.
 
 ### ResourceQuota
 


### PR DESCRIPTION
This is based on my current understanding of the feature, which may be wrong. Needs review.

cc @kubernetes/sig-auth-pr-reviews  @gurvindersingh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3011)
<!-- Reviewable:end -->
