### PR TITLE
Authorization admin docs: s/Wildard/Wildcard/

### DIFF
--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -90,10 +90,10 @@ properties:
     - Resource-matching properties:
       - `apiGroup`, type string; an API group.
         - Ex: `extensions`
-        - Wildard: `*` matches all API groups.
+        - Wildcard: `*` matches all API groups.
       - `namespace`, type string; a namespace.
         - Ex: `kube-system`
-        - Wildard: `*` matches all resource requests.
+        - Wildcard: `*` matches all resource requests.
       - `resource`, type string; a resource type
         - Ex: `pods`
         - Wildcard: `*` matches all resource requests.


### PR DESCRIPTION
This replaces two instances where "Wildcard" was inadvertently spelled "Wildard".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3014)
<!-- Reviewable:end -->
