### PR TITLE
Update staging container

### DIFF
--- a/docs/contribute/stage-documentation-changes.md
+++ b/docs/contribute/stage-documentation-changes.md
@@ -61,7 +61,7 @@ for this image.
 1. In the root of your cloned repository, enter this command to start a local
 web server:
 
-        docker run -ti --rm -v "$PWD":/k8sdocs -p 4000:4000 gcr.io/google-samples/k8sdocs:1.0
+        docker run -ti --rm -v "$PWD":/k8sdocs -p 4000:4000 gcr.io/google-samples/k8sdocs:1.1
 
 1. View your staged content at
 [http://localhost:4000](http://localhost:4000){: target="_blank"}.


### PR DESCRIPTION
Manually uploaded a :1.1 tag for the staging container, now it's alpine based
(1/4th in image size) and no longer has the warning mentioned in #2837.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

cc: @steveperry-53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3017)
<!-- Reviewable:end -->
