### PR TITLE
delete redundant example

### DIFF
--- a/docs/concepts/storage/volumes.md
+++ b/docs/concepts/storage/volumes.md
@@ -171,26 +171,6 @@ spec:
       path: /data
 ```
 
-#### Example pod
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-hostpath
-spec:
-  containers:
-  - image: myimage
-    name: test-container
-    volumeMounts:
-    - mountPath: /test-hostpath
-      name: test-volume
-  volumes:
-  - name: test-volume
-    hostPath:
-      path: /path/to/my/dir
-```
-
 ### gcePersistentDisk
 
 A `gcePersistentDisk` volume mounts a Google Compute Engine (GCE) [Persistent


### PR DESCRIPTION
The example does not offer other aspects about the hostPath, it's some kind of duplicate to the preceding one. So, maybe only the preceding one is enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3026)
<!-- Reviewable:end -->
