### PR TITLE
revert issue URL, turn into link

### DIFF
--- a/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig.md
+++ b/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig.md
@@ -20,7 +20,7 @@ Multiple kubeconfig files are allowed, if specified explicitly.  At runtime they
 
 ## Related discussion
 
-https://github.com/kubernetes/kubernetes/issues/1755
+[http://issue.k8s.io/1755](http://issue.k8s.io/1755)
 
 ## Components of a kubeconfig file
 


### PR DESCRIPTION
As per discussion in PR #3041, using compact http://issue.k8s.io/1755 form is fine. So revert to that and turn it into a link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3047)
<!-- Reviewable:end -->
