### PR TITLE
Fix invalid links

### DIFF
--- a/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -72,9 +72,9 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 ### Reference
 
-* [PersistentVolume](/docs/api-reference/v1/definitions/#_v1_persistentvolume)
-* [PersistentVolumeClaim](/docs/api-reference/v1/definitions/#_v1_persistentvolumeclaim)
-* See the `persistentVolumeReclaimPolicy` field of [PersistentVolumeSpec](http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_persistentvolumespec).
+* [PersistentVolume](/docs/api-reference/v1.6/#persistentvolume-v1-core)
+* [PersistentVolumeClaim](/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core)
+* See the `persistentVolumeReclaimPolicy` field of [PersistentVolumeSpec](/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core).
 {% endcapture %}
 
 {% include templates/task.md %}


### PR DESCRIPTION
PersistentVolumeSpec is not independent and belongs to persistentvolumeclaim. So I use "/docs/api-reference/v1.6/#persistentvolumeclaim-v1-core".

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3115)
<!-- Reviewable:end -->
