### PR TITLE
Fix Docs Home, remove redundancy

### DIFF
--- a/_data/docs-home.yml
+++ b/_data/docs-home.yml
@@ -3,8 +3,6 @@ abstract: "Documentation for using and learning about Kubernetes."
 toc:
 - docs/home/index.md
 
-- docs/home/index.md
-
 - title: Contributing to the Kubernetes Docs
   section:
   - editdocs.md


### PR DESCRIPTION
Get rid of redundant "Kubernetes Documentation" header in ToC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3118)
<!-- Reviewable:end -->
