### PR TITLE
Remove redundant User Guide header in ToC

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -2,7 +2,6 @@ bigheader: "Guides"
 abstract: "How to get started, and accomplish tasks, using Kubernetes."
 toc:
 - docs/user-guide/index.md
-- docs/user-guide/index.md
 
 - title: Accessing the Cluster
   section:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3120)
<!-- Reviewable:end -->
