### PR TITLE
Remove superfluous headers in kubectl page

### DIFF
--- a/docs/user-guide/kubectl/index.md
+++ b/docs/user-guide/kubectl/index.md
@@ -2,13 +2,6 @@
 title: kubectl
 ---
 
-## kubectl
-
-kubectl controls the Kubernetes cluster manager
-
-### Synopsis
-
-
 kubectl controls the Kubernetes cluster manager.
 
 Find more information at [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes).


### PR DESCRIPTION
Get rid of extra "kubectl" header and description.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3121)
<!-- Reviewable:end -->
