### PR TITLE
fix typo

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -251,7 +251,7 @@ while `kubeadm init` is initializing your master:
 #### Master Isolation
 
 By default, your cluster will not schedule pods on the master for security
-reasons. If you want to be able to schedule pods on the master, e.g a
+reasons. If you want to be able to schedule pods on the master, e.g. a
 single-machine Kubernetes cluster for development, run:
 
 ``` bash


### PR DESCRIPTION
fix `e.g` to `e.g.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3129)
<!-- Reviewable:end -->
