### PR TITLE
Update stale Host folder sharing docs

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -254,10 +254,11 @@ spec:
 ```
 
 ## Mounted Host Folders
-Some drivers will mount a host folder within the VM so that you can easily share files between the VM and host.  These are not configurable at the moment and different for the driver and OS you are using.  Note: Host folder sharing is not implemented on Linux yet.
+Some drivers will mount a host folder within the VM so that you can easily share files between the VM and host.  These are not configurable at the moment and different for the driver and OS you are using.  Note: Host folder sharing is not implemented in the KVM driver yet.
 
 | Driver | OS | HostFolder | VM |
 | --- | --- | --- | --- |
+| Virtualbox | Linux | /home | /hosthome |
 | Virtualbox | OSX | /Users | /Users |
 | Virtualbox | Windows | C://Users | /c/Users |
 | VMWare Fusion | OSX | /Users | /Users |


### PR DESCRIPTION
Updated to match https://github.com/kubernetes/minikube/blob/master/README.md.

I can't see why this file even exists - it will get out of date frequently. Why not just link to the minikube project?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3152)
<!-- Reviewable:end -->
