### PR TITLE
Fixed example for "Accession the Service"

### DIFF
--- a/docs/tutorials/kubernetes-basics/expose-intro.html
+++ b/docs/tutorials/kubernetes-basics/expose-intro.html
@@ -72,7 +72,7 @@ title: Using a Service to Expose Your App
 
                 <p>A Service provides load balancing of traffic across the contained set of Pods. This is useful when a service is created to group all Pods from a specific Deployment (our application will make use of this in the next module, when we'll have multiple instances running).</p>
 
-                <p>Services are also responsible for service-discovery within the cluster (covered in <a href="/docs/user-guide/connecting-applications/#accessing-the-service">Accessing the Service</a>). This will for example allow a frontend service (like a web server) to receive traffic from a backend service (like a database) without worrying about Pods.</p>
+                <p>Services are also responsible for service-discovery within the cluster (covered in <a href="/docs/user-guide/connecting-applications/#accessing-the-service">Accessing the Service</a>). This will for example allow a frontend service (like a web server) to send traffic to a backend service (like a database) without worrying about Pods.</p>
 
                 <p>Services match a set of Pods using Label Selectors, a grouping primitive that allows logical operation on Labels.</p>
 


### PR DESCRIPTION
Example stated that a "frontend receives traffic from backend". It should be "frontend sends traffic to backend"

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3154)
<!-- Reviewable:end -->
