### PR TITLE
Fix api-reference/v1/definitions links

### DIFF
--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -256,4 +256,4 @@ on each kubelet where you want to reserve resources.
 
 Node is a top-level resource in the Kubernetes REST API. More details about the
 API object can be found at: [Node API
-object](/docs/api-reference/v1/definitions/#_v1_node).
+object](/docs/api-reference/v1.6/#node-v1-core).

--- a/docs/concepts/services-networking/connect-applications-service.md
+++ b/docs/concepts/services-networking/connect-applications-service.md
@@ -64,7 +64,7 @@ This is equivalent to `kubectl create -f` the following yaml:
 
 {% include code.html language="yaml" file="nginx-svc.yaml" ghlink="/docs/concepts/services-networking/nginx-svc.yaml" %}
 
-This specification will create a Service which targets TCP port 80 on any Pod with the `run: my-nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](/docs/api-reference/v1/definitions/#_v1_service) to see the list of supported fields in service definition.
+This specification will create a Service which targets TCP port 80 on any Pod with the `run: my-nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](/docs/api-reference/v1.6/#service-v1-core) to see the list of supported fields in service definition.
 Check your Service:
 
 ```shell

--- a/docs/tutorials/stateless-application/run-stateless-ap-replication-controller.md
+++ b/docs/tutorials/stateless-application/run-stateless-ap-replication-controller.md
@@ -102,7 +102,7 @@ below:
   section of the Creating Multi-Container Pods page covers required and
   frequently-used fields.
 * The entire `spec` schema is documented in the
-  [Kubernetes API reference](/docs/api-reference/v1/definitions/#_v1_podspec).
+  [Kubernetes API reference](/docs/api-reference/v1.6/#podspec-v1-core).
 
 ### Sample file
 

--- a/docs/user-guide/pods/index.md
+++ b/docs/user-guide/pods/index.md
@@ -193,4 +193,4 @@ spec.containers[0].securityContext.privileged: forbidden '<*>(0xc20b222db0)true'
 
 Pod is a top-level resource in the Kubernetes REST API. More details about the
 API object can be found at: [Pod API
-object](/docs/api-reference/v1/definitions/#_v1_pod).
+object](/docs/api-reference/v1.6/#pod-v1-core).

--- a/docs/user-guide/replication-controller/index.md
+++ b/docs/user-guide/replication-controller/index.md
@@ -223,7 +223,7 @@ The ReplicationController is intended to be a composable building-block primitiv
 
 Replication controller is a top-level resource in the Kubernetes REST API. More details about the
 API object can be found at: [ReplicationController API
-object](/docs/api-reference/v1/definitions/#_v1_replicationcontroller).
+object](/docs/api-reference/v1.6/#replicationcontroller-v1-core).
 
 ## Alternatives to ReplicationController
 

--- a/docs/user-guide/security-context.md
+++ b/docs/user-guide/security-context.md
@@ -29,7 +29,7 @@ spec:
       level: "s0:c123,c456"
 ```
 
-Please refer to the [API documentation](/docs/api-reference/v1/definitions/#_v1_podsecuritycontext) for a detailed listing and
+Please refer to the [API documentation](/docs/api-reference/v1.6/#pod-v1-coresecuritycontext) for a detailed listing and
 description of all the fields available within the pod security
 context.
 
@@ -82,6 +82,6 @@ spec:
 ```
 
 Please refer to the
-[API documentation](/docs/api-reference/v1/definitions/#_v1_securitycontext) 
+[API documentation](/docs/api-reference/v1.6/#securitycontext-v1-core) 
 for a detailed listing and description of all the fields available
 within the container security context.

--- a/docs/user-guide/services/index.md
+++ b/docs/user-guide/services/index.md
@@ -594,7 +594,7 @@ through a load-balancer, though in those cases the client IP does get altered.
 
 Service is a top-level resource in the Kubernetes REST API. More details about the
 API object can be found at: [Service API
-object](/docs/api-reference/v1/definitions/#_v1_service).
+object](/docs/api-reference/v1.6/#service-v1-core).
 
 ## For More Information
 


### PR DESCRIPTION
Update api-reference URLs to new v1.6 paths

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3158)
<!-- Reviewable:end -->
