### PR TITLE
fix robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -10,7 +10,6 @@ Disallow: /docs/user-guide/configuring-containers
 Disallow: /docs/user-guide/containers
 Disallow: /docs/user-guide/deploying-applications
 Disallow: /docs/user-guide/getting-into-containers
->>>>>>> fb2ab359... Remove from TOC/Search: pods/init-containers ...
 Disallow: /docs/user-guide/liveness/index
 Disallow: /docs/user-guide/pod-states
 Disallow: /docs/user-guide/simple-nginx


### PR DESCRIPTION
Previous merge conflict was not handled properly, so removing superfluous merge notation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3189)
<!-- Reviewable:end -->
