### PR TITLE
Fix ScheduledJobs to CronJobs

### DIFF
--- a/docs/user-guide/kubectl/v1.5/index.html
+++ b/docs/user-guide/kubectl/v1.5/index.html
@@ -232,7 +232,7 @@ inspect them.</p>
 <td>restart</td>
 <td></td>
 <td>Always</td>
-<td>The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  If set to &#39;Always&#39; a deployment is created, if set to &#39;OnFailure&#39; a job is created, if set to &#39;Never&#39;, a regular pod is created. For the latter two --replicas must be 1.  Default &#39;Always&#39;, for ScheduledJobs <code>Never</code>. </td>
+<td>The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  If set to &#39;Always&#39; a deployment is created, if set to &#39;OnFailure&#39; a job is created, if set to &#39;Never&#39;, a regular pod is created. For the latter two --replicas must be 1.  Default &#39;Always&#39;, for CronJobs <code>Never</code>. </td>
 </tr>
 <tr>
 <td>rm</td>


### PR DESCRIPTION
ScheduledJobs has already been renamed to CronJobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3193)
<!-- Reviewable:end -->
