### PR TITLE
Use kubectl create (without specifying namespace) for sock-shop app

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -387,8 +387,7 @@ README](https://github.com/microservices-demo/microservices-demo).
 Note that the Sock Shop demo only works on `amd64`.
 
 ``` bash
-kubectl create namespace sock-shop
-kubectl apply -n sock-shop -f "https://github.com/microservices-demo/microservices-demo/blob/master/deploy/kubernetes/complete-demo.yaml?raw=true"
+kubectl create -f "https://github.com/microservices-demo/microservices-demo/blob/master/deploy/kubernetes/complete-demo.yaml?raw=true"
 ```
 
 You can then find out the port that the [NodePort feature of


### PR DESCRIPTION
Fix error while deploying sock-shop app (#3214)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3216)
<!-- Reviewable:end -->
