### PR TITLE
Address issue #3072 for apps

### DIFF
--- a/redirects.rb
+++ b/redirects.rb
@@ -56,7 +56,14 @@ fixed_redirects = """# 301 redirects (301 is the default status when no other on
 /docs/user-guide/overview	/docs/whatisk8s/
 /docs/roadmap			https://github.com/kubernetes/kubernetes/milestones/
 /api-ref			https://github.com/kubernetes/kubernetes/milestones/
+#Apps API
 /docs/api-reference/apps/v1beta1/definitions/	/docs/api-reference/v1.6/#deployment-v1beta1-apps
+#Autoscaling API
+/docs/api-reference/autoscaling/v1/operations/	/docs/api-reference/v1.6/#horizontalpodautoscaler-v1-autoscaling
+#Batch API
+/docs/api-reference/batch/v1/operations/	/docs/api-reference/v1.6/#job-v1-batch
+#Extensions API
+/docs/api-reference/extensions/v1beta1/operations/	/docs/api-reference/extensions/v1beta1/definitions/
 """
 
 branch_redirects = ["examples" , "cluster", "docs/devel", "docs/design"]

--- a/redirects.rb
+++ b/redirects.rb
@@ -56,6 +56,7 @@ fixed_redirects = """# 301 redirects (301 is the default status when no other on
 /docs/user-guide/overview	/docs/whatisk8s/
 /docs/roadmap			https://github.com/kubernetes/kubernetes/milestones/
 /api-ref			https://github.com/kubernetes/kubernetes/milestones/
+/docs/api-reference/apps/v1beta1/definitions/	/docs/api-reference/v1.6/#deployment-v1beta1-apps
 """
 
 branch_redirects = ["examples" , "cluster", "docs/devel", "docs/design"]


### PR DESCRIPTION
Redirect https://kubernetes.io/docs/api-reference/apps/v1beta1/definitions/ to https://kubernetes.io/docs/api-reference/v1.6/#deployment-v1beta1-apps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3228)
<!-- Reviewable:end -->
