### PR TITLE
Fix api version for deployment

### DIFF
--- a/docs/concepts/workloads/controllers/nginx-deployment.yaml
+++ b/docs/concepts/workloads/controllers/nginx-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment


### PR DESCRIPTION
I am not 100% sure this was a mistake, but I'm pretty sure it is, with `apps/v1beta1` (which I don't see in other docs or examples) I get 

error: error validating "test.yaml": error validating data: couldn't find type: v1beta1.Deployment; if you choose to ignore these errors, turn validation off with --validate=false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3229)
<!-- Reviewable:end -->
