### PR TITLE
Move cron jobs to keep glossary in alphabetical order

### DIFF
--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -168,6 +168,7 @@ toc:
 - title: Glossary
   section:
   - docs/user-guide/annotations.md
+  - docs/user-guide/cron-jobs.md
   - docs/admin/daemons.md
   - docs/user-guide/deployments.md
   - docs/user-guide/horizontal-pod-autoscaling/index.md
@@ -187,7 +188,6 @@ toc:
   - docs/user-guide/replicasets.md
   - docs/user-guide/replication-controller/index.md
   - docs/admin/resourcequota/index.md
-  - docs/user-guide/cron-jobs.md
   - docs/user-guide/secrets/index.md
   - docs/user-guide/security-context.md
   - docs/user-guide/services/index.md


### PR DESCRIPTION
After ScheduledJobs being renamed to CronJobs, the Glossary should be modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3234)
<!-- Reviewable:end -->
