### PR TITLE
More meaningful links for the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,8 +20,8 @@
                 <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>Events Calendar</span></a>
             </div>
             <div>
-                <a href="//get.k8s.io" class="button">Download K8s</a>
-                <a href="https://github.com/kubernetes/kubernetes" class="button">Contribute to the K8s codebase</a>
+                <a href="/docs/getting-started-guides/" class="button">Get Kubernetes</a>
+                <a href="https://github.com/kubernetes/kubernetes" class="button">Contribute</a>
             </div>
         </div>
         <div id="miceType" class="center">


### PR DESCRIPTION
This replaces the two buttons on the right of the footer.

It does not seem like get.k8s.io is useful to anyone. Replacing it with the
installation guide and avoiding K8s abbreviation in these buttons.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3244)
<!-- Reviewable:end -->
