### PR TITLE
Delete swagger-ui

### DIFF
--- a/js/redirects.js
+++ b/js/redirects.js
@@ -34,6 +34,10 @@ $( document ).ready(function() {
         "to": "https://github.com/kubernetes/kubernetes/milestones/"
     },
     {
+        "from": "kubernetes/third_party/swagger-ui/",
+        "to": "/docs/reference"
+    },
+    {
         "from": "docs/user-guide/overview",
         "to": "http://kubernetes.io/docs/whatisk8s/"
     }];

--- a/kubernetes/third_party/swagger-ui/index.md
+++ b/kubernetes/third_party/swagger-ui/index.md
@@ -1,6 +1,0 @@
----
-title: Kubernetes API Swagger Spec
----
-
-Kubernetes swagger UI has now been replaced by our generated API reference docs
-which can be accessed at [http://kubernetes.io/docs/api-reference/{{page.version}}/](/docs/api-reference/{{page.version}}/).


### PR DESCRIPTION
Deleting swagger-ui and setting up a redirect to Reference section.

Closes #1924
Fixes #2220

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3259)
<!-- Reviewable:end -->
