### PR TITLE
Typo in storage docs

### DIFF
--- a/docs/concepts/storage/persistent-volumes.md
+++ b/docs/concepts/storage/persistent-volumes.md
@@ -318,7 +318,7 @@ A claim can request a particular class by specifying the name of a
 Only PVs of the requested class, ones with the same `storageClassName` as the PVC, can
 be bound to the PVC.
 
-PVCs don't necessarily have to request a class. A PVC with its `storageClasName` set
+PVCs don't necessarily have to request a class. A PVC with its `storageClassName` set
 equal to `""` is always interpreted to be requesting a PV with no class, so it
 can only be bound to PVs with no class (no annotation or one set equal to
 `""`). A PVC with no `storageClassName` is not quite the same and is treated differently


### PR DESCRIPTION
Fix typo in  storage docs storageClasName -> storageClassName

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3263)
<!-- Reviewable:end -->
