### PR TITLE
Fix Reference ToC links

### DIFF
--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -12,21 +12,12 @@ toc:
 
 - title: "Kubernetes API"
   section:
+  - title: Overview
+    path: /docs/concepts/overview/kubernetes-api/
   - title: Version 1.6
     path: /docs/api-reference/v1.6/
   - title: Version 1.5
     path: /docs/api-reference/v1.5/
-
-- title: "Kubectl Commands"
-  section:
-  - title: Version 1.6
-    path: /docs/user-guide/kubectl/v1.6/
-  - title: Version 1.5
-    path: /docs/user-guide/kubectl/v1.5/
-
-- title: Kubernetes API
-  section:
-  - docs/api.md
   - title: Accessing the API
     section:
     - docs/admin/accessing-the-api.md
@@ -38,119 +29,23 @@ toc:
       - docs/admin/authorization/rbac.md
     - docs/admin/admission-controllers.md
     - docs/admin/service-accounts-admin.md
-  - docs/api-reference/v1/operations.html
-  - docs/api-reference/v1/definitions.html
   - docs/api-reference/labels-annotations-taints.md
-
-- title: Autoscaling API
-  section:
-  - docs/api-reference/autoscaling/v1/operations.html
-  - docs/api-reference/autoscaling/v1/definitions.html
-
-- title: Batch API
-  section:
-  - docs/api-reference/batch/v1/operations.html
-  - docs/api-reference/batch/v1/definitions.html
-
-- title: Apps API
-  section:
-  - title: Apps API Operations
-    path: /docs/api-reference/apps/v1beta1/operations/
-  - title: Apps API Definitions
-    path: /docs/api-reference/apps/v1beta1/definitions/
-
-- title: Extensions API
-  section:
-  - docs/api-reference/extensions/v1beta1/operations.html
   - docs/api-reference/extensions/v1beta1/definitions.html
 
 - title: kubectl CLI
   section:
-  - docs/user-guide/kubectl-overview.md
+  - title: Overview
+    path: /docs/user-guide/kubectl-overview/
+  - title: Commands
+    section:
+    - title: Version 1.6
+      path: /docs/user-guide/kubectl/v1.6/
+    - title: Version 1.5
+      path: /docs/user-guide/kubectl/v1.5/
   - docs/user-guide/docker-cli-to-kubectl.md
   - docs/user-guide/kubectl-conventions.md
   - docs/user-guide/jsonpath.md
   - docs/user-guide/kubectl-cheatsheet.md
-  - title: kubectl Commands
-    section:
-    - docs/user-guide/kubectl/index.md
-    - docs/user-guide/kubectl/kubectl_annotate.md
-    - docs/user-guide/kubectl/kubectl_api-versions.md
-    - docs/user-guide/kubectl/kubectl_apply.md
-    - docs/user-guide/kubectl/kubectl_attach.md
-    - docs/user-guide/kubectl/kubectl_autoscale.md
-    - docs/user-guide/kubectl/kubectl_certificate.md
-    - docs/user-guide/kubectl/kubectl_certificate_approve.md
-    - docs/user-guide/kubectl/kubectl_certificate_deny.md
-    - docs/user-guide/kubectl/kubectl_cluster-info.md
-    - docs/user-guide/kubectl/kubectl_cluster-info_dump.md
-    - docs/user-guide/kubectl/kubectl_completion.md
-    - docs/user-guide/kubectl/kubectl_config.md
-    - docs/user-guide/kubectl/kubectl_config_current-context.md
-    - docs/user-guide/kubectl/kubectl_config_delete-cluster.md
-    - docs/user-guide/kubectl/kubectl_config_delete-context.md
-    - docs/user-guide/kubectl/kubectl_config_get-clusters.md
-    - docs/user-guide/kubectl/kubectl_config_get-contexts.md
-    - docs/user-guide/kubectl/kubectl_config_set-cluster.md
-    - docs/user-guide/kubectl/kubectl_config_set-context.md
-    - docs/user-guide/kubectl/kubectl_config_set-credentials.md
-    - docs/user-guide/kubectl/kubectl_config_set.md
-    - docs/user-guide/kubectl/kubectl_config_unset.md
-    - docs/user-guide/kubectl/kubectl_config_use-context.md
-    - docs/user-guide/kubectl/kubectl_config_view.md
-    - docs/user-guide/kubectl/kubectl_convert.md
-    - docs/user-guide/kubectl/kubectl_cordon.md
-    - docs/user-guide/kubectl/kubectl_cp.md
-    - docs/user-guide/kubectl/kubectl_create.md
-    - docs/user-guide/kubectl/kubectl_create_configmap.md
-    - docs/user-guide/kubectl/kubectl_create_deployment.md
-    - docs/user-guide/kubectl/kubectl_create_namespace.md
-    - docs/user-guide/kubectl/kubectl_create_quota.md
-    - docs/user-guide/kubectl/kubectl_create_secret_docker-registry.md
-    - docs/user-guide/kubectl/kubectl_create_secret.md
-    - docs/user-guide/kubectl/kubectl_create_secret_generic.md
-    - docs/user-guide/kubectl/kubectl_create_secret_tls.md
-    - docs/user-guide/kubectl/kubectl_create_serviceaccount.md
-    - docs/user-guide/kubectl/kubectl_create_service_clusterip.md
-    - docs/user-guide/kubectl/kubectl_create_service_loadbalancer.md
-    - docs/user-guide/kubectl/kubectl_create_service_nodeport.md
-    - docs/user-guide/kubectl/kubectl_delete.md
-    - docs/user-guide/kubectl/kubectl_describe.md
-    - docs/user-guide/kubectl/kubectl_drain.md
-    - docs/user-guide/kubectl/kubectl_edit.md
-    - docs/user-guide/kubectl/kubectl_exec.md
-    - docs/user-guide/kubectl/kubectl_explain.md
-    - docs/user-guide/kubectl/kubectl_expose.md
-    - docs/user-guide/kubectl/kubectl_get.md
-    - docs/user-guide/kubectl/kubectl_label.md
-    - docs/user-guide/kubectl/kubectl_logs.md
-    - docs/user-guide/kubectl/kubectl_options.md
-    - docs/user-guide/kubectl/kubectl_patch.md
-    - docs/user-guide/kubectl/kubectl_port-forward.md
-    - docs/user-guide/kubectl/kubectl_proxy.md
-    - docs/user-guide/kubectl/kubectl_replace.md
-    - docs/user-guide/kubectl/kubectl_rolling-update.md
-    - docs/user-guide/kubectl/kubectl_rollout.md
-    - docs/user-guide/kubectl/kubectl_rollout_history.md
-    - docs/user-guide/kubectl/kubectl_rollout_pause.md
-    - docs/user-guide/kubectl/kubectl_rollout_resume.md
-    - docs/user-guide/kubectl/kubectl_rollout_status.md
-    - docs/user-guide/kubectl/kubectl_rollout_undo.md
-    - docs/user-guide/kubectl/kubectl_run.md
-    - docs/user-guide/kubectl/kubectl_scale.md
-    - docs/user-guide/kubectl/kubectl_set.md
-    - docs/user-guide/kubectl/kubectl_set_image.md
-    - docs/user-guide/kubectl/kubectl_set_resources.md
-    - docs/user-guide/kubectl/kubectl_taint.md
-    - docs/user-guide/kubectl/kubectl_top.md
-    - docs/user-guide/kubectl/kubectl_top_node.md
-    - docs/user-guide/kubectl/kubectl_top_pod.md
-    - docs/user-guide/kubectl/kubectl_uncordon.md
-    - docs/user-guide/kubectl/kubectl_version.md
-    - title: Superseded and Deprecated Commands
-      section:
-      - /docs/user-guide/kubectl/kubectl_namespace/
-      - docs/user-guide/kubectl/kubectl_stop.md
 
 - title: Kubernetes Components
   section:
@@ -198,13 +93,13 @@ toc:
 - title: Kubernetes Design Docs
   section:
   - title: Kubernetes Architecture
-    path: https://github.com/kubernetes/kubernetes/blob/release-1.5/docs/design/architecture.md
+    path: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture.md
   - title: Kubernetes Design Overview
-    path: https://github.com/kubernetes/kubernetes/blob/release-1.5/docs/design/
+    path: https://github.com/kubernetes/kubernetes/tree/release-1.6/docs/design
   - title: Kubernetes Identity and Access Management
-    path: https://github.com/kubernetes/kubernetes/blob/release-1.5/docs/design/access.md
+    path: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/access.md
   - docs/admin/ovs-networking.md
   - title: Security Contexts
-    path: https://github.com/kubernetes/kubernetes/blob/release-1.5/docs/design/security_context.md
+    path: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security_context.md
   - title: Security in Kubernetes
-    path: https://github.com/kubernetes/kubernetes/blob/release-1.5/docs/design/security.md
+    path: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security.md

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,12 +6,10 @@ In the reference section, you can find reference documentation for Kubernetes AP
 
 ## API References
 
-* [Kubernetes API](/docs/api/) - The core API for Kubernetes.
-* [Autoscaling API](/docs/api-reference/autoscaling/v1/operations/) - Manages autoscaling resources such as HorizontalPodAutoscalers.
-* [Batch API](/docs/api-reference/batch/v1/operations/) - Manages batch resources such as Jobs.
-* [Apps API](/docs/api-reference/apps/v1beta1/operations/) - Manages apps resources such as StatefulSets.
-* [Extensions API](/docs/api-reference/extensions/v1beta1/operations/) - Manages extensions resources such as Ingress, Deployments, and ReplicaSets.
-
+* [Kubernetes API Overview](/docs/concepts/overview/kubernetes-api/) - Conceptual overview of the API for Kubernetes.
+* Versions
+  * [1.6](/docs/api-reference/v1.6/)
+  * [1.5](/docs/api-reference/v1.5/)
 
 ## CLI References
 
@@ -19,7 +17,6 @@ In the reference section, you can find reference documentation for Kubernetes AP
     * [JSONPath](/docs/user-guide/jsonpath/) - Syntax     guide for using [JSONPath expressions](http://goessner.net/articles/JsonPath/) with kubectl.
 * [kube-apiserver](/docs/admin/kube-apiserver/) - REST API that validates and configures data for API objects such as  pods, services, replication controllers.
 * [kube-proxy](/docs/admin/kube-proxy/) - Can do simple TCP/UDP stream forwarding or round-robin TCP/UDP forwarding across a set of backends.
-* [kube-scheduler](/docs/admin/kube-scheduler/) - A policy-rich, topology-aware, workload-specific function that significantly impacts availability, performance, and capacity.
 * [kubelet](/docs/admin/kubelet/) - The primary "node agent" that runs on each node. The kubelet takes a set of PodSpecs and ensures that the described containers are running and healthy.
 
 ## Glossary


### PR DESCRIPTION
Address Issue #3269:

Autoscaling API - Manages autoscaling resources such as HorizontalPodAutoscalers.
Batch API - Manages batch resources such as Jobs.
Apps API - Manages apps resources such as StatefulSets.
Extensions API - Manages extensions resources such as Ingress, Deployments, and ReplicaSets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3270)
<!-- Reviewable:end -->
