### PR TITLE
Add clearer links to Kubernetes API migration pages

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,4 +8,5 @@ title: Kubernetes API Overview
 
 {% include user-guide-content-moved.md %}
 
-[The Kubernetes API](/docs/concepts/overview/kubernetes-api/)
+  * [The Kubernetes API Overview](/docs/concepts/overview/kubernetes-api/)
+  * Kubernetes API Reference documentation for [Version 1.6](/docs/api-reference/v1.6/) and [Version 1.5](/docs/api-reference/v1.5/). 


### PR DESCRIPTION
Specified better links and added links to the actual API reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3275)
<!-- Reviewable:end -->
