### PR TITLE
Make tables "responsive"

### DIFF
--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -864,6 +864,9 @@ dd
 		font-size: inherit
 		background-color: transparent
 
+	.includecode
+		table-layout: fixed
+
 	.includecode, .includecode th, .includecode td
 		padding: 0 !important
 


### PR DESCRIPTION
Currently if a code table has wide code, for example in [attach handler lifecycle event](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/), the table overflows the width of the page which is using `overflow: hidden`, making the edge of the code block unreadable.

It's arguable that the code is not a table of data, and therefore shouldn't be in a table (which is harder to make responsive) but this change at least sets the `table-layout` to `fixed` which restricts the table width to the parent container and allows the content to be scrollable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3286)
<!-- Reviewable:end -->
