### PR TITLE
Fix on Docs "Running a Stateless Application Using a Deployment"

### DIFF
--- a/docs/tutorials/stateless-application/deployment-scale.yaml
+++ b/docs/tutorials/stateless-application/deployment-scale.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/tutorials/stateless-application/deployment-update.yaml
+++ b/docs/tutorials/stateless-application/deployment-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/tutorials/stateless-application/deployment.yaml
+++ b/docs/tutorials/stateless-application/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment


### PR DESCRIPTION
While following the current docs, the deployment e.g. states an error mentioned below.
_error: error validating "deployment.yaml": error validating data: couldn't find type: v1beta1.Deployment; if you choose to ignore these errors, turn validation off with --validate=false_

The fix was to change the apiVersion, hence correcting the docs to have the valid apiVersion.  For more details, please see the issue here
[https://github.com/kubernetes/kubernetes/issues/19515#issuecomment-292811568](url)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3299)
<!-- Reviewable:end -->
