### PR TITLE
Updated doc for critical pod.

### DIFF
--- a/docs/concepts/cluster-administration/guaranteed-scheduling-critical-addon-pods.md
+++ b/docs/concepts/cluster-administration/guaranteed-scheduling-critical-addon-pods.md
@@ -39,8 +39,8 @@ killed for this purpose.
 
 ## Config
 
-Rescheduler doesn't have any user facing configuration (component config) or API.
-It's enabled by default. It can be disabled:
+Rescheduler should be [enabled by default as a static pod](https://github.com/kubernetes/kubernetes/blob/master/cluster/saltbase/salt/rescheduler/rescheduler.manifest).
+It doesn't have any user facing configuration (component config) or API and can be disabled:
 
 * during cluster setup by setting `ENABLE_RESCHEDULER` flag to `false`
 * on running cluster by deleting its manifest from master node


### PR DESCRIPTION
Clarified that the rescheduler should be enabled by default as a
static pod for critical pod.

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3315)
<!-- Reviewable:end -->
