### PR TITLE
`failure-domain` is no longer used in command line arg.

### DIFF
--- a/docs/concepts/configuration/assign-pod-node.md
+++ b/docs/concepts/configuration/assign-pod-node.md
@@ -183,8 +183,8 @@ flavor and the `preferredDuringSchedulingIgnoredDuringExecution` flavor.
 As with node affinity, the legal operators for pod affinity and anti-affinity are `In`, `NotIn`, `Exists`, `DoesNotExist`, `Gt`, `Lt`.
 
 In principle, the `topologyKey` can be any legal label value. However,
-for performance reasons, only a limit set of topology keys are allowed;
-they are specified in the `--failure-domain` command-line argument to the scheduler. By default the allowed topology keys are
+for performance reasons, only a limited set of topology keys are allowed.
+By default the allowed topology keys are:
 
 * `kubernetes.io/hostname`
 * `failure-domain.beta.kubernetes.io/zone`


### PR DESCRIPTION
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3352)
<!-- Reviewable:end -->
