### PR TITLE
The baseurl for CentOS is invalid

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -118,7 +118,7 @@ For each host in turn:
   cat <<EOF > /etc/yum.repos.d/kubernetes.repo
   [kubernetes]
   name=Kubernetes
-  baseurl=http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
+  baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
   enabled=1
   gpgcheck=1
   repo_gpgcheck=1


### PR DESCRIPTION
The baseurl for CentOS has been invalid, update it.

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3365)
<!-- Reviewable:end -->
