### PR TITLE
The link URL of [node affinity] is error

### DIFF
--- a/docs/concepts/workloads/controllers/daemonset.md
+++ b/docs/concepts/workloads/controllers/daemonset.md
@@ -75,7 +75,7 @@ a node for testing.
 If you specify a `.spec.template.spec.nodeSelector`, then the DaemonSet controller will
 create pods on nodes which match that [node
 selector](/docs/user-guide/node-selection/). Likewise if you specify a `.spec.template.spec.affinity` 
-then DaemonSet controller will create pods on nodes which match that [node affinity](../../user-guide/node-selection/index.md).
+then DaemonSet controller will create pods on nodes which match that [node affinity](/docs/user-guide/node-selection/).
 If you do not specify either, then the DaemonSet controller will create pods on all nodes.
 
 ## How Daemon Pods are Scheduled


### PR DESCRIPTION
Return 404 Error when clicking [node affinity]. The link URL of [node
affinity] should be /docs/user-guide/node-selection/ instead of
../../user-guide/node-selection/index.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3369)
<!-- Reviewable:end -->
