### PR TITLE
update get node ip

### DIFF
--- a/docs/tutorials/services/source-ip.md
+++ b/docs/tutorials/services/source-ip.md
@@ -118,7 +118,7 @@ $ kubectl expose deployment source-ip-app --name=nodeport --port=80 --target-por
 service "nodeport" exposed
 
 $ NODEPORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services nodeport)
-$ NODES=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="ExternalIP")].address }')
+$ NODES=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="LegacyHostIP")].address }')
 ```
 
 if you're running on a cloudprovider, you may need to open up a firewall-rule


### PR DESCRIPTION
there is not 'ExternalIP' in 'kubectl get nodes -o json',  change ExternalIP to LegacyHostIP so that get the node ip address.

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3400)
<!-- Reviewable:end -->
