### PR TITLE
`--apiserver-advertise-address` typo

### DIFF
--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -70,7 +70,7 @@ It is usually sufficient to run `kubeadm init` without any flags, but in some
 cases you might like to override the default behaviour. Here we specify all the
 flags that can be used to customise the Kubernetes installation.
 
-- `--api-advertise-address`
+- `--apiserver-advertise-address`
 
 This is the address the API Server will advertise to other members of the
 cluster.  This is also the address used to construct the suggested `kubeadm


### PR DESCRIPTION
- Running `--api-advertise-address` returns unknown flag error
- `--apiserver-advertise-address` is the correct command, so this must have been a typo

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3445)
<!-- Reviewable:end -->
