### PR TITLE
Create reference doc for IBM Bluemix Container Service

### DIFF
--- a/_data/setup.yml
+++ b/_data/setup.yml
@@ -17,6 +17,8 @@ toc:
     path: https://cloud.google.com/container-engine/docs/before-you-begin/
   - title: Running Kubernetes on Azure Container Service
     path: https://docs.microsoft.com/en-us/azure/container-service/container-service-kubernetes-walkthrough
+  - title: Running Kubernetes on IBM Bluemix Container Service (Beta)
+    path: https://console.ng.bluemix.net/docs/containers/container_index.html
 
 - title: Turn-key Cloud Solutions
   section:
@@ -24,7 +26,7 @@ toc:
   - docs/getting-started-guides/aws.md
   - docs/getting-started-guides/azure.md
   - docs/getting-started-guides/clc.md
-  - title: Running Kubernetes on IBM SoftLayer
+  - title: Running Kubernetes on IBM Bluemix
     path: https://github.com/patrocinio/kubernetes-softlayer
   - docs/getting-started-guides/stackpoint.md
 

--- a/docs/setup/pick-right-solution.md
+++ b/docs/setup/pick-right-solution.md
@@ -58,6 +58,8 @@ clusters.
 
 [OpenShift Dedicated](https://www.openshift.com/dedicated/) offers managed Kubernetes clusters powered by OpenShift and [OpenShift Online](https://www.openshift.com/features/) provides free hosted access for Kubernetes applications.
 
+[IBM Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/container_index.html) offers managed Kubernetes clusters (currently in beta).
+
 ### Turn-key Cloud Solutions
 
 These solutions allow you to create Kubernetes clusters on a range of Cloud IaaS providers with only a
@@ -68,7 +70,7 @@ few commands, and have active community support.
 - [Azure](/docs/getting-started-guides/azure)
 - [Tectonic by CoreOS](https://coreos.com/tectonic)
 - [CenturyLink Cloud](/docs/getting-started-guides/clc)
-- [IBM SoftLayer](https://github.com/patrocinio/kubernetes-softlayer)
+- [IBM Bluemix](https://github.com/patrocinio/kubernetes-softlayer)
 - [Stackpoint.io](/docs/getting-started-guides/stackpoint/)
 - [KUBE2GO.io](https://kube2go.io/)
 - [Madcore.Ai](https://madcore.ai/)


### PR DESCRIPTION
Create a documentation link for IBM Bluemix Container Service similar to
GCE and Azure. Also rename Softlayer references to Bluemix.

Co-Authored-By: Xavier Loup <xavier.loup@fr.ibm.com>

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3462)
<!-- Reviewable:end -->
