### PR TITLE
Replace with new service url

### DIFF
--- a/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -23,7 +23,7 @@ following Kubernetes concepts.
 
 * [Pods](/docs/user-guide/pods/single-container/)
 * [Cluster DNS](/docs/concepts/services-networking/dns-pod-service/)
-* [Headless Services](/docs/user-guide/services/#headless-services)
+* [Headless Services](/docs/concepts/services-networking/service/#headless-services)
 * [PersistentVolumes](/docs/concepts/storage/volumes/)
 * [PersistentVolume Provisioning](http://releases.k8s.io/{{page.githubbranch}}/examples/persistent-volume-provisioning/)
 * [StatefulSets](/docs/concepts/abstractions/controllers/statefulsets/)


### PR DESCRIPTION
The headless service page url has moved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3473)
<!-- Reviewable:end -->
