### PR TITLE
use secret to store CA certificate bundle

### DIFF
--- a/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -33,7 +33,7 @@ in the [`tls.Config`](https://godoc.org/crypto/tls#Config) struct.
 The CA certificate bundle is automatically mounted into pods using the default
 service account at the path `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
 If you are not using the default service account, ask a cluster administrator to
-build a configmap containing the certificate bundle that you have access to use.
+build a secret containing the certificate bundle that you have access to use.
 
 ## Requesting a Certificate
 


### PR DESCRIPTION
CA certificate bundle is sensitive data. It's better to store it in
secret, although secret also has risks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3499)
<!-- Reviewable:end -->
