### PR TITLE
fix wildcard in authorization

### DIFF
--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -106,7 +106,7 @@ properties:
         - Ex: `/version` or `/apis`
         - Wildcard: 
           - `*` matches all non-resource requests.
-          - `/foo/*` matches `/foo/` and all of its subpaths.
+          - `/foo/*` matches all subpaths of `/foo/`.
     - `readonly`, type boolean, when true, means that the policy only applies to get, list, and watch operations.
 
 **NOTES:** An unset property is the same as a property set to the zero value for its type


### PR DESCRIPTION
see https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/rbac/validation/policy_comparator_test.go#L421
`/foo/*` doesn't match `/foo/`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3503)
<!-- Reviewable:end -->
