### PR TITLE
Make the kubefed guide default for setting up a federation

### DIFF
--- a/docs/concepts/cluster-administration/federation.md
+++ b/docs/concepts/cluster-administration/federation.md
@@ -71,7 +71,7 @@ some caveats.
 
 To be able to federate multiple clusters, we first need to setup a federation
 control plane.
-Follow the [setup guide](/docs/tutorials/federation/set-up-cluster-federation-kubefed.md) to setup the
+Follow the [setup guide](/docs/tutorials/federation/set-up-cluster-federation-kubefed/) to setup the
 federation control plane.
 
 ## Hybrid cloud capabilities

--- a/docs/concepts/cluster-administration/federation.md
+++ b/docs/concepts/cluster-administration/federation.md
@@ -71,7 +71,7 @@ some caveats.
 
 To be able to federate multiple clusters, we first need to setup a federation
 control plane.
-Follow the [setup guide](/docs/admin/federation/) to setup the
+Follow the [setup guide](/docs/tutorials/federation/set-up-cluster-federation-kubefed.md) to setup the
 federation control plane.
 
 ## Hybrid cloud capabilities


### PR DESCRIPTION
We no longer support federation setup scripts `federation.sh` and `deploy.sh`. Update the main federation guide setup link accordingly, by making kubefed guide the way to go.

Ref. Issue: #2809

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3523)
<!-- Reviewable:end -->
