### PR TITLE
Debugging pods

### DIFF
--- a/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -38,7 +38,7 @@ case you can try several things:
   to make room for pending pods.
 
 * Check that the pod is not larger than your nodes. For example, if all
-  nodes have a capacity of `cpu:1`, then a pod with a limit of `cpu: 1.1`
+  nodes have a capacity of `cpu:1`, then a pod with a request of `cpu: 1.1`
   will never be scheduled.
 
     You can check node capacities with the `kubectl get nodes -o <format>`


### PR DESCRIPTION
环境上实践的结果是limit超过了node的最大Capacity是可以成功创建pod的，而request中的cpu、memory是不能超过node节点上的Capacity。
kubectl describe node ：
![image2017-4-26 11-59-33](https://cloud.githubusercontent.com/assets/25783555/25421346/01d98ade-2a8f-11e7-9d00-ea81d9271e6b.png)
![2](https://cloud.githubusercontent.com/assets/25783555/25421348/07d5d8ac-2a8f-11e7-899d-e3aa386e7315.png)
![3](https://cloud.githubusercontent.com/assets/25783555/25421386/383fcf16-2a8f-11e7-8efb-070964521b11.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3541)
<!-- Reviewable:end -->
