### PR TITLE
remove Federation API from docs/reference home

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,13 +10,6 @@ assignees:
 * Kubernetes API Versions
   * [1.6](/docs/api-reference/v1.6/)
   * [1.5](/docs/api-reference/v1.5/)
-* Federation API
-  * [v1 Operations](docs/reference/federation/v1/operations.html)
-  * [v1 Model Definitions](docs/reference/federation/v1/definitions.html)
-  * [federation/v1beta1 Operations](docs/reference/federation/v1beta1/operations.html)
-  * [federation/v1beta1 Model Definitions](docs/reference/federation/v1beta1/definitions.html)
-  * [extensions/v1beta1 Operations](docs/reference/federation/extensions/v1beta1/operations.html)
-  * [extensions/v1beta1 Model Definitions](docs/reference/federation/extensions/v1beta1/definitions.html)
 
 ## CLI Reference
 


### PR DESCRIPTION
This topic is not yet important enough to list exhaustively on /docs/reference.
Also the links are broken anyway. Fixes #3535.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

cc: @chenopis 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3545)
<!-- Reviewable:end -->
