### PR TITLE
rbac: document resourceNames and note they can't be used for creates

### DIFF
--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -54,6 +54,7 @@ A request has the following attributes that can be considered for authorization:
   - what subresource is being accessed (for resource requests only)
   - the namespace of the object being accessed (for namespaced resource requests only)
   - the API group being accessed (for resource requests only); an empty string designates the [core API group](/docs/api/)
+  - the name of the resource being accessed (only for resource requests using `get`, `update`, `patch`, and `delete` verbs)
 
 The request verb for a resource API endpoint can be determined by the HTTP verb used and whether or not the request acts on an individual resource or a collection of resources:
 

--- a/docs/admin/authorization/rbac.md
+++ b/docs/admin/authorization/rbac.md
@@ -168,6 +168,28 @@ rules:
   verbs: ["get", "list"]
 ```
 
+Resources can also be referred to by name for certain requests through the `resourceNames` list.
+When specified, requests using the "get", "delete", "update", and "patch" verbs can be restricted
+to individual instances of a resource. To restrict a subject to only "get" and "update" a single
+configmap, you would write:
+
+```yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: configmap-updater
+rules:
+- apiGroups: [""]
+  resources: ["configmap"]
+  resourceNames: ["my-configmap"]
+  verbs: ["update", "get"]
+```
+
+Notably, `resourceNames` can NOT be used to limit requests using the "create" verb because
+authorizers only have access to information that can be obtained from the request URL, method,
+and headers (resource names in a "create" request are part of the request body).
+
 #### Role Examples
 
 Only the `rules` section is shown in the following examples.


### PR DESCRIPTION
closes https://github.com/kubernetes/kubernetes/issues/44978

cc @kubernetes/sig-auth-pr-reviews 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3555)
<!-- Reviewable:end -->
