### PR TITLE
the proposal and api link should be updated

### DIFF
--- a/docs/concepts/policy/security-context.md
+++ b/docs/concepts/policy/security-context.md
@@ -9,7 +9,7 @@ redirect_from:
 - "/docs/user-guide/security-context.html"
 ---
 
-A security context defines the operating system security settings (uid, gid, capabilities, SELinux role, etc..) applied to a container. See [security context design](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security-context-constraints.md) for more details.
+A security context defines the operating system security settings (uid, gid, capabilities, SELinux role, etc..) applied to a container. See [security context design](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security_context.md) for more details.
 
 There are two levels of security context: pod level security context, and container level security context.
 
@@ -32,7 +32,7 @@ spec:
       level: "s0:c123,c456"
 ```
 
-Please refer to the [API documentation](/docs/api-reference/v1.6/#pod-v1-coresecuritycontext) for a detailed listing and
+Please refer to the [API documentation](https://kubernetes.io/docs/api-reference/v1.6/#podsecuritycontext-v1-core) for a detailed listing and
 description of all the fields available within the pod security
 context.
 


### PR DESCRIPTION
I was trying out Security Context, I found some information should be updated:

1. the proposal link should be use security-context, not security-context-constraints.
2. and the api doc link for pod security context should be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3558)
<!-- Reviewable:end -->
