### PR TITLE
Deprecate Kubernetes 101 and 201

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -224,8 +224,6 @@ centos-minion-3        Ready      3d      v1.6.0+fff5156
 
 **The cluster should be running! Launch a test pod.**
 
-You should have a functional cluster, check out [101](/docs/user-guide/walkthrough/)!
-
 ## Support Level
 
 

--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -188,8 +188,6 @@ kubectl delete -f ./node.json
 
 **The cluster should be running! Launch a test pod.**
 
-You should have a functional cluster, check out [101](/docs/user-guide/walkthrough/)!
-
 ## Support Level
 
 

--- a/docs/getting-started-guides/kops.md
+++ b/docs/getting-started-guides/kops.md
@@ -149,7 +149,7 @@ See the [list of add-ons](/docs/concepts/cluster-administration/addons/) to expl
 
 ## What's next
 
-* Learn more about [Kubernetes concepts and kubectl in Kubernetes 101](/docs/user-guide/walkthrough/).
+* Learn more about Kubernetes [concepts](/docs/concepts/) and [`kubectl`](/docs/user-guide/kubectl-overview/).
 * Learn about `kops` [advanced usage](https://github.com/kubernetes/kops)
 
 ## Cleanup

--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -456,8 +456,7 @@ control of your Kubernetes cluster.
 
 * Learn about kubeadm's advanced usage on the [advanced reference
   doc](/docs/admin/kubeadm/)
-* Learn more about [Kubernetes concepts and kubectl in Kubernetes
-  101](/docs/user-guide/walkthrough/).
+* Learn more about Kubernetes [concepts](/docs/concepts/) and [`kubectl`](/docs/user-guide/kubectl-overview/).
 
 ## Feedback
 

--- a/docs/getting-started-guides/mesos-docker.md
+++ b/docs/getting-started-guides/mesos-docker.md
@@ -211,10 +211,10 @@ sudo route -n add -net 172.17.0.0 $(docker-machine ip kube-dev)
 
     After deploying the cluster, `~/.kube/config` will be created or updated to configure kubectl to target the new cluster.
 
-1. Explore examples
+1. Explore tutorials
 
     To learn more about Pods, Volumes, Labels, Services, and Replication Controllers, start with the
-    [Kubernetes Walkthrough](/docs/user-guide/walkthrough/).
+    [Kubernetes Tutorials](/docs/tutorials/).
 
     To skip to a more advanced example, see the [Guestbook Example](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/guestbook/)
 

--- a/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -292,9 +292,6 @@ you should not use `host`, but rather set the `Host` header in `httpHeaders`.
 * Learn more about
 [Container Probes](/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
 
-* Learn more about
-[Health Checking](/docs/user-guide/walkthrough/k8s201/#health-checking).
-
 ### Reference
 
 * [Pod](/docs/api-reference/v1.6/#pod-v1-core)

--- a/robots.txt
+++ b/robots.txt
@@ -109,6 +109,7 @@ Disallow: /docs/user-guide/thirdpartyresources/
 Disallow: /docs/user-guide/ui/
 Disallow: /docs/user-guide/update-demo/
 Disallow: /docs/user-guide/volumes/
+Disallow: /docs/user-guide/walkthrough/
 Disallow: /docs/user-guide/working-with-resources/
 Disallow: /docs/whatisk8s/
 


### PR DESCRIPTION
Remove Kubernetes 101 and 201 pages and links

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3578)
<!-- Reviewable:end -->
