### PR TITLE
Remove swagger-ui from search index

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -43,6 +43,8 @@ Disallow: /docs/admin/sysctls/
 Disallow: /docs/admin/upgrade-1-6/
 Disallow: /docs/api/
 Disallow: /docs/contribute/
+Disallow: /kubernetes/swagger-spec/
+Disallow: /kubernetes/third_party/swagger-ui/
 Disallow: /docs/getting-started-guides/kubectl/
 Disallow: /docs/getting-started-guides/network-policy/
 Disallow: /docs/getting-started-guides/running-cloud-controller/


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3582)
<!-- Reviewable:end -->
