### PR TITLE
rolling-update: remove link to the doc itself

### DIFF
--- a/docs/tasks/run-application/rolling-update-replication-controller.md
+++ b/docs/tasks/run-application/rolling-update-replication-controller.md
@@ -247,8 +247,6 @@ Update succeeded. Deleting old controller: my-nginx
 replicationcontroller "my-nginx-v4" rolling updated
 ```
 
-You can also run the [update demo](/docs/tasks/run-application/rolling-update-replication-controller/) to see a visual representation of the rolling update process.
-
 ## Troubleshooting
 
 If the `timeout` duration is reached during a rolling update, the operation will


### PR DESCRIPTION
Fixes #3357. I'm removing this statement as it's not clear where it should
actually be pointing to...

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3604)
<!-- Reviewable:end -->
