### PR TITLE
fix wrong addresses for mysql-statefulset.yaml and gce-volume.yaml

### DIFF
--- a/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -108,7 +108,7 @@ writes.
 Finally, create the StatefulSet from the following YAML configuration file:
 
 ```shell
-kubectl create -f http://k8s.io/docs/docs/tasks/run-application/mysql-statefulset.yaml
+kubectl create -f http://k8s.io/docs/tasks/run-application/mysql-statefulset.yaml
 ```
 
 {% include code.html language="yaml" file="mysql-statefulset.yaml" ghlink="/docs/tutorials/run-application/mysql-statefulset.yaml" %}

--- a/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -54,7 +54,7 @@ Next create a PersistentVolume that points to the `mysql-disk`
 disk just created. Here is a configuration file for a PersistentVolume
 that points to the Compute Engine disk above:
 
-{% include code.html language="yaml" file="gce-volume.yaml" ghlink="/docs/docs/tasks/run-application/gce-volume.yaml" %}
+{% include code.html language="yaml" file="gce-volume.yaml" ghlink="/docs/tasks/run-application/gce-volume.yaml" %}
 
 Notice that the `pdName: mysql-disk` line matches the name of the disk
 in the Compute Engine environment. See the


### PR DESCRIPTION
the page https://kubernetes.io/docs/tasks/run-application/run-replicated-stateful-application/ has the code example 

```
kubectl create -f http://k8s.io/docs/docs/tasks/run-application/mysql-statefulset.yaml
```

but that address is wrong. Same case for gce-volume.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3652)
<!-- Reviewable:end -->
