### PR TITLE
Update kubeadm.md

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -164,7 +164,7 @@ init`.
 There are pod network implementations where the master also plays a role in
 allocating a set of network address space for each node.  When using
 [flannel](https://github.com/coreos/flannel) as the [pod network](#pod-network)
-(described in step 3), specify `--pod-network-cidr 10.244.0.0/16`. _This is not
+(described in step 3), specify `--pod-network-cidr=10.244.0.0/16`. _This is not
 required for any other networks besides Flannel._
 
 Please refer to the [kubeadm reference doc](/docs/admin/kubeadm/) if you want to


### PR DESCRIPTION
Wasted hours today trying to get kubeadm working on a Ubuntu VM. The culprit is a missing = for the pod-network-cidr parameter to the kubeadm init command when using calico. Without it kube-dns refused to start, oddly enough pods had 10.244.0.0 network setup but somehow it was failing sending a request to destroy and recreate the pod.

Here's the events for the kube-dns pods if someone's interested.

Events:
  FirstSeen     LastSeen        Count   From                    SubObjectPath   Type            Reason          Message
  ---------     --------        -----   ----                    -------------   --------        ------          -------
  2m            2m              1       default-scheduler                       Normal          Scheduled       Successfully assigned kube-dns-3913472980-5xfzt to kube-master
  1m            1m              1       kubelet, kube-master                    Warning         FailedSync      Error syncing pod, skipping: failed to "CreatePodSandbox" for "kube-dns-3913472980-5xfzt_kube-system(3bd90f8c-33a8-11e7-8a23-080027ac04f3)" with CreatePodSandboxError: "CreatePodSandbox for pod \"kube-dns-3913472980-5xfzt_kube-system(3bd90f8c-33a8-11e7-8a23-080027ac04f3)\" failed: rpc error: code = 2 desc = NetworkPlugin cni failed to set up pod \"kube-dns-3913472980-5xfzt_kube-system\" network: Get https://10.96.0.1:443/api/v1/namespaces/kube-system/pods/kube-dns-3913472980-5xfzt: dial tcp 10.96.0.1:443: i/o timeout"

  1m    50s     6       kubelet, kube-master            Warning FailedSync      Error syncing pod, skipping: failed to "KillPodSandbox" for "3bd90f8c-33a8-11e7-8a23-080027ac04f3" with KillPodSandboxError: "rpc error: code = 2 desc = NetworkPlugin cni failed to teardown pod \"kube-dns-3913472980-5xfzt_kube-system\" network: connection is unauthorized"

  1m    9s      9       kubelet, kube-master            Normal  SandboxChanged  Pod sandbox changed, it will be killed and re-created.
  37s   9s      3       kubelet, kube-master            Warning FailedSync      Error syncing pod, skipping: failed to "KillPodSandbox" for "3bd90f8c-33a8-11e7-8a23-080027ac04f3" with KillPodSandboxError: "rpc error: code = 2 desc = NetworkPlugin cni failed to teardown pod \"kube-dns-3913472980-5xfzt_kube-system\" network: netplugin failed but error parsing its diagnostic message \"\": unexpected end of JSON input"

> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3672)
<!-- Reviewable:end -->
