### PR TITLE
Change example PersistentVolumeClaim

### DIFF
--- a/docs/tasks/configure-pod-container/task-pv-claim.yaml
+++ b/docs/tasks/configure-pod-container/task-pv-claim.yaml
@@ -8,3 +8,4 @@ spec:
   resources:
     requests:
       storage: 3Gi
+  storageClassName: ""


### PR DESCRIPTION
If a default storage class exists, it is going to create a new persistent volume to bind to that claim instead of using our example one, which will make the tutorial fail. In particular, this happens on minikube.

Specifying an empty storageClassName will prevent the storage class to be used, and force our volume to be selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3674)
<!-- Reviewable:end -->
