### PR TITLE
NetworkPolicy updates for v1

### DIFF
--- a/docs/concepts/services-networking/networkpolicies.md
+++ b/docs/concepts/services-networking/networkpolicies.md
@@ -2,6 +2,7 @@
 assignees:
 - thockin
 - caseydavenport
+- danwinship
 title: Network Policies
 redirect_from:
 - "/docs/user-guide/networkpolicies/"
@@ -17,11 +18,7 @@ A network policy is a specification of how groups of pods are allowed to communi
 
 ## Prerequisites
 
-You must enable the `extensions/v1beta1/networkpolicies` runtime config in your apiserver to enable this resource.
-
-You must also be using a networking solution which supports `NetworkPolicy` - simply creating the
-resource without a controller to implement it will have no effect.
-
+Network policies are implemented by the network plugin, so you must be using a networking solution which supports `NetworkPolicy` - simply creating the resource without a controller to implement it will have no effect.
 
 ## Configuring Namespace Isolation
 
@@ -29,22 +26,23 @@ By default, all traffic is allowed between all pods (and `NetworkPolicy` resourc
 
 Isolation can be configured on a per-namespace basis. Currently, only isolation on inbound traffic (ingress) can be defined. When a namespace has been configured to isolate inbound traffic, all traffic to pods in that namespace (even from other pods in the same namespace) will be blocked. `NetworkPolicy` objects can then be added to the isolated namespace to specify what traffic should be allowed.
 
-Ingress isolation can be enabled using an annotation on the Namespace.
+Isolation is enabled via the `NetworkPolicy` field of the `Namespace` object. To enable isolation via `kubectl`:
 
-```yaml
-kind: Namespace
-apiVersion: v1
-metadata:
-  annotations:
-    net.beta.kubernetes.io/network-policy: |
-      {
-        "ingress": {
-          "isolation": "DefaultDeny"
-        }
-      }
+```shell
+{% raw %}
+kubectl patch ns <namespace> -p '{"spec": {"networkPolicy": {"ingress": {"isolation": "DefaultDeny"}}}}'
+{% endraw %}
 ```
 
-To configure the annotation via `kubectl`:
+To disable it:
+
+```shell
+{% raw %}
+kubectl patch ns <namespace> -p '{"spec": {"networkPolicy": null}}'
+{% endraw %}
+```
+
+NOTE: older network plugins may instead require the v1beta1 syntax, using an annotation:
 
 ```shell
 {% raw %}
@@ -54,12 +52,12 @@ kubectl annotate ns <namespace> "net.beta.kubernetes.io/network-policy={\"ingres
 
 ## The `NetworkPolicy` Resource
 
-See the [api-reference](/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy) for a full definition of the resource.
+See the [api-reference](/docs/api-reference/networking/v1/definitions/#_v1_networkpolicy) for a full definition of the resource.
 
 An example `NetworkPolicy` might look like this:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking/v1
 kind: NetworkPolicy
 metadata:
   name: test-network-policy

--- a/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/docs/tasks/administer-cluster/declare-network-policy.md
@@ -1,6 +1,7 @@
 ---
 assignees:
 - caseydavenport
+- danwinship
 title: Declaring Network Policy
 redirect_from:
 - "/docs/getting-started-guides/network-policy/walkthrough/"
@@ -64,7 +65,7 @@ Let's say we want to limit access to our nginx Service so that only pods with th
 enable ingress isolation on the `default` Namespace.  This will prevent _any_ pods from accessing the nginx Service.
 
 ```console
-$ kubectl annotate ns default "net.beta.kubernetes.io/network-policy={\"ingress\": {\"isolation\": \"DefaultDeny\"}}"
+$ kubectl patch ns default -p '{"spec": {"networkPolicy": {"ingress": {"isolation": "DefaultDeny"}}}}'
 ```
 
 With ingress isolation in place, we should no longer be able to access the nginx Service like we were able to before:
@@ -85,7 +86,7 @@ Let's now create a `NetworkPolicy` which allows connections from pods with the l
 
 ```yaml
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking/v1
 metadata:
   name: access-nginx
 spec:


### PR DESCRIPTION
First commit does some miscellaneous rewriting (see commit message), second commit just updates things to use the v1 API stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3721)
<!-- Reviewable:end -->
