### PR TITLE
Clarify NetworkPolicy's "destination" podSelector a bit

### DIFF
--- a/docs/concepts/services-networking/networkpolicies.md
+++ b/docs/concepts/services-networking/networkpolicies.md
@@ -50,7 +50,7 @@ __Mandatory Fields__: As with all other Kubernetes config, a `NetworkPolicy` nee
 
 __spec__: `NetworkPolicy` [spec](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/docs/devel/api-conventions.md#spec-and-status) has all the information needed to define a particular network policy in the given namespace.
 
-__podSelector__: Each `NetworkPolicy` includes a `podSelector` which selects the grouping of pods to which the `ingress` rules in the policy apply. The example policy selects pods with the label "role=db".
+__podSelector__: Each `NetworkPolicy` includes a `podSelector` which selects the grouping of pods to which the policy applies. Since `NetworkPolicy` currently only supports definining `ingress` rules, this `podSelector` essentially defines the "destination pods" for the policy. The example policy selects pods with the label "role=db". An empty `podSelector` selects all pods in the namespace.
 
 __ingress__: Each `NetworkPolicy` includes a list of whitelist `ingress` rules.  Each rule allows traffic which matches both the `from` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port, from either of two sources, the first specified via a `namespaceSelector` and the second specified via a `podSelector`.
 


### PR DESCRIPTION
Just a minor tweak to the wording inspired by https://github.com/kubernetes/kubernetes/issues/44643.

@caseydavenport @Q-Lee

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3788)
<!-- Reviewable:end -->
