### PR TITLE
Remove beta warning about Jobs.

### DIFF
--- a/docs/concepts/configuration/overview.md
+++ b/docs/concepts/configuration/overview.md
@@ -37,7 +37,7 @@ This document is meant to highlight and consolidate in one place configuration b
 
   Replication controllers are almost always preferable to creating pods, except for some explicit
   [`restartPolicy: Never`](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy) scenarios.  A
-  [Job](/docs/concepts/jobs/run-to-completion-finite-workloads/) object (currently in Beta), may also be appropriate.
+  [Job](/docs/concepts/jobs/run-to-completion-finite-workloads/) object may also be appropriate.
 
 
 ## Services


### PR DESCRIPTION
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

I feel like it would be better to remove the `restartPolicy: Never` from this entirely in favor of pointing to Jobs, but I don't know if there are other uses of `Never` that a Job wouldn't work for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3798)
<!-- Reviewable:end -->
