### PR TITLE
Adding back-ticks around command args

### DIFF
--- a/docs/tasks/configure-pod-container/configmap.md
+++ b/docs/tasks/configure-pod-container/configmap.md
@@ -32,7 +32,7 @@ Use the `kubectl create configmap` command to create configmaps from [directorie
 kubectl create <map-name> <data-source>
 ```
 
-where <map-name> is the name you want to assign to the ConfigMap and <data-source> is the directory, file, or literal value to draw the data from.
+where `<map-name>` is the name you want to assign to the ConfigMap and `<data-source>` is the directory, file, or literal value to draw the data from.
  
 The data source corresponds to a key-value pair in the ConfigMap, where
 


### PR DESCRIPTION
Just a minor doc correction - the existing command arguments were hidden in the text because markdown interpreted the angular brackets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3812)
<!-- Reviewable:end -->
