### PR TITLE
Address Issue #3827: break out Configuring Redis using a ConfigMap tutorial

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -32,6 +32,9 @@ toc:
 - title: Online Training Course
   path: https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615
 - docs/tutorials/stateless-application/hello-minikube.md
+- title: Configuration
+  section:
+  - docs/tutorials/configuration/configure-redis-using-configmap.md
 - title: Object Management Using kubectl
   section:
   - docs/tutorials/object-management-kubectl/object-management.md

--- a/docs/tasks/configure-pod-container/configmap.md
+++ b/docs/tasks/configure-pod-container/configmap.md
@@ -252,6 +252,7 @@ data:
 
 {% capture whatsnext %}
 * See [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap).
+* Follow a real world example of [Configuring Redis using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -273,91 +273,6 @@ very
 You can project keys to specific paths and specific permissions on a per-file
 basis. The [Secrets](/docs/concepts/configuration/secret#using-secrets-as-files-from-a-pod) user guide explains the syntax.
 
-## Real World Example: Configuring Redis using a ConfigMap
-
-You can follow the steps below to configure a Redis cache using data stored in a ConfigMap.
-
-1. Create a ConfigMap from the `docs/user-guide/configmap/redis/redis-config` file
-
-   ```shell
-   kubectl create configmap example-redis-config --from-file=docs/user-guide/configmap/redis/redis-config
-
-   kubectl get configmap example-redis-config -o yaml
-   ```
-
-   ```yaml
-   apiVersion: v1
-   data:
-     redis-config: |
-       maxmemory 2mb
-       maxmemory-policy allkeys-lru
-   kind: ConfigMap
-   metadata:
-     creationTimestamp: 2016-03-30T18:14:41Z
-     name: example-redis-config
-     namespace: default
-     resourceVersion: "24686"
-     selfLink: /api/v1/namespaces/default/configmaps/example-redis-config
-     uid: 460a2b6e-f6a3-11e5-8ae5-42010af00002
-   ```
-
-1. Create a pod specification that uses the config data stored in the ConfigMap:
-
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: redis
-   spec:
-     containers:
-     - name: redis
-       image: kubernetes/redis:v1
-       env:
-       - name: MASTER
-         value: "true"
-       ports:
-       - containerPort: 6379
-       resources:
-         limits:
-           cpu: "0.1"
-       volumeMounts:
-       - mountPath: /redis-master-data
-         name: data
-       - mountPath: /redis-master
-         name: config
-     volumes:
-       - name: data
-         emptyDir: {}
-       - name: config
-         configMap:
-           name: example-redis-config
-           items:
-           - key: redis-config
-             path: redis.conf
-   ```
-1. Create the pod.
-
-  ```shell
-  kubectl create -f docs/user-guide/configmap/redis/redis-pod.yaml
-  ```
-
-In the example, the config volume is mounted at `/redis-master`. 
-It uses `path` to add the `redis-config` key to a file named `redis.conf`. 
-The file path for the redis config, therefore, is `/redis-master/redis.conf`.    
-This is where the image will look for the config file for the redis master.
-
-1. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to verify that the configuration was correctly applied:
-
-   ```shell
-   kubectl exec -it redis redis-cli
-   127.0.0.1:6379> CONFIG GET maxmemory
-   1) "maxmemory"
-   2) "2097152"
-   127.0.0.1:6379> CONFIG GET maxmemory-policy
-   1) "maxmemory-policy"
-   2) "allkeys-lru"
-   ```
-
 {% endcapture %}
 
 {% capture discussion %}
@@ -385,7 +300,8 @@ This is where the image will look for the config file for the redis master.
 {% endcapture %}
 
 {% capture whatsnext %}
-* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configmap.html).
+* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configmap/).
+* Follow a real world example of [Configuring Redis using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/).
 
 {% endcapture %}
 

--- a/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -1,0 +1,128 @@
+---
+assignees:
+- eparis
+- pmorie
+title: Configuring Redis using a ConfigMap
+---
+
+{% capture overview %}
+
+This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap/) and [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configmap/) tasks. 
+
+{% endcapture %}
+
+{% capture objectives %}
+
+* Create a ConfigMap.
+* Create a pod specification using the ConfigMap.
+* Create the pod.
+* Verify that the configuration was correctly applied.
+
+{% endcapture %}
+
+{% capture prerequisites %}
+
+* {% include task-tutorial-prereqs.md %}
+* Understand [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap/).
+* Understand [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configmap/).
+
+{% endcapture %}
+
+{% capture lessoncontent %}
+
+
+## Real World Example: Configuring Redis using a ConfigMap
+
+You can follow the steps below to configure a Redis cache using data stored in a ConfigMap.
+
+1. Create a ConfigMap from the `docs/user-guide/configmap/redis/redis-config` file
+
+   ```shell
+   kubectl create configmap example-redis-config --from-file=docs/user-guide/configmap/redis/redis-config
+
+   kubectl get configmap example-redis-config -o yaml
+   ```
+
+   ```yaml
+   apiVersion: v1
+   data:
+     redis-config: |
+       maxmemory 2mb
+       maxmemory-policy allkeys-lru
+   kind: ConfigMap
+   metadata:
+     creationTimestamp: 2016-03-30T18:14:41Z
+     name: example-redis-config
+     namespace: default
+     resourceVersion: "24686"
+     selfLink: /api/v1/namespaces/default/configmaps/example-redis-config
+     uid: 460a2b6e-f6a3-11e5-8ae5-42010af00002
+   ```
+
+1. Create a pod specification that uses the config data stored in the ConfigMap:
+
+   ```yaml
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: redis
+   spec:
+     containers:
+     - name: redis
+       image: kubernetes/redis:v1
+       env:
+       - name: MASTER
+         value: "true"
+       ports:
+       - containerPort: 6379
+       resources:
+         limits:
+           cpu: "0.1"
+       volumeMounts:
+       - mountPath: /redis-master-data
+         name: data
+       - mountPath: /redis-master
+         name: config
+     volumes:
+       - name: data
+         emptyDir: {}
+       - name: config
+         configMap:
+           name: example-redis-config
+           items:
+           - key: redis-config
+             path: redis.conf
+   ```
+1. Create the pod.
+
+   ```shell
+   kubectl create -f docs/user-guide/configmap/redis/redis-pod.yaml
+   ```
+
+In the example, the config volume is mounted at `/redis-master`. 
+It uses `path` to add the `redis-config` key to a file named `redis.conf`. 
+The file path for the redis config, therefore, is `/redis-master/redis.conf`.
+This is where the image will look for the config file for the redis master.
+
+1. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to verify that the configuration was correctly applied:
+
+   ```shell
+   kubectl exec -it redis redis-cli
+   127.0.0.1:6379> CONFIG GET maxmemory
+   1) "maxmemory"
+   2) "2097152"
+   127.0.0.1:6379> CONFIG GET maxmemory-policy
+   1) "maxmemory-policy"
+   2) "allkeys-lru"
+   ```
+
+{% endcapture %}
+
+{% capture whatsnext %}
+
+* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configmap/).
+* See [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap).
+
+{% endcapture %}
+
+{% include templates/tutorial.md %}

--- a/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -35,7 +35,7 @@ This page provides a real world example of how to configure Redis using a Config
 
 You can follow the steps below to configure a Redis cache using data stored in a ConfigMap.
 
-1. Create a ConfigMap from the `docs/user-guide/configmap/redis/redis-config` file
+1. Create a ConfigMap from the `docs/user-guide/configmap/redis/redis-config` file:
 
    ```shell
    kubectl create configmap example-redis-config --from-file=docs/user-guide/configmap/redis/redis-config
@@ -93,16 +93,16 @@ You can follow the steps below to configure a Redis cache using data stored in a
            - key: redis-config
              path: redis.conf
    ```
-1. Create the pod.
+1. Create the pod:
 
    ```shell
    kubectl create -f docs/user-guide/configmap/redis/redis-pod.yaml
    ```
 
-In the example, the config volume is mounted at `/redis-master`. 
-It uses `path` to add the `redis-config` key to a file named `redis.conf`. 
-The file path for the redis config, therefore, is `/redis-master/redis.conf`.
-This is where the image will look for the config file for the redis master.
+   In the example, the config volume is mounted at `/redis-master`.
+   It uses `path` to add the `redis-config` key to a file named `redis.conf`.
+   The file path for the redis config, therefore, is `/redis-master/redis.conf`.
+   This is where the image will look for the config file for the redis master.
 
 1. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to verify that the configuration was correctly applied:
 


### PR DESCRIPTION
Re: Issue #3827

Take *Real World Example: Configuring Redis using a ConfigMap* section from [Using ConfigMap Data in Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap) and create [Configuring Redis using a ConfigMap](https://github.com/kubernetes/kubernetes.github.io/tree/master/docs/tutorials/configuration/configure-redis-using-configmap.md) tutorial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3829)
<!-- Reviewable:end -->
