### PR TITLE
Easier kubectl download for Windows

### DIFF
--- a/docs/tasks/tools/install-kubectl.md
+++ b/docs/tasks/tools/install-kubectl.md
@@ -33,8 +33,8 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s htt
 # Windows
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/windows/amd64/kubectl.exe
 ```
-To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version. For example, to download version 1.4.6 on MacOS, type:
-`curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.4.6/bin/darwin/amd64/kubectl`
+To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version. For example, to download version {{page.fullversion}} on Windows, type:
+`curl -LO https://storage.googleapis.com/kubernetes-release/release/{{page.fullversion}}/bin/windows/amd64/kubectl.exe`
 
   2. Make the kubectl binary executable.
 ```shell


### PR DESCRIPTION
Because Windows doesn't ship `curl` and doesn't process $(curl ...)
shell expansion, it is better to provide a working link for it in example
instead of OS X

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3859)
<!-- Reviewable:end -->
