### PR TITLE
Fix indentation in ConfigMap usage example

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -209,22 +209,22 @@ The `command` section references the `special.level` item stored in the ConfigMa
 apiVersion: v1
 kind: Pod
 metadata:
-name: dapi-test-pod
+  name: dapi-test-pod
 spec:
-containers:
-  - name: test-container
-    image: gcr.io/google_containers/busybox
-    command: [ "/bin/sh", "-c", "ls /etc/config/" ]
-    volumeMounts:
+  containers:
+    - name: test-container
+      image: gcr.io/google_containers/busybox
+      command: [ "/bin/sh", "-c", "ls /etc/config/" ]
+      volumeMounts:
+      - name: config-volume
+        mountPath: /etc/config
+  volumes:
     - name: config-volume
-      mountPath: /etc/config
-volumes:
-  - name: config-volume
-    configMap:
-      # Provide the name of the ConfigMap containing the files you want 
-      # to add to the container
-      name: special-config
-restartPolicy: Never
+      configMap:
+        # Provide the name of the ConfigMap containing the files you want
+        # to add to the container
+        name: special-config
+  restartPolicy: Never
 ```
 
 When the pod runs, the command (`"ls /etc/config/"`) produces the output below:

--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -243,23 +243,23 @@ In this case, the `special.key` item will be mounted in the `config-volume` volu
 apiVersion: v1
 kind: Pod
 metadata:
-name: dapi-test-pod
+  name: dapi-test-pod
 spec:
-containers:
-  - name: test-container
-    image: gcr.io/google_containers/busybox
-    command: [ "/bin/sh","-c","cat /etc/config/keys/special.level" ]
-    volumeMounts:
+  containers:
+    - name: test-container
+      image: gcr.io/google_containers/busybox
+      command: [ "/bin/sh","-c","cat /etc/config/keys/special.level" ]
+      volumeMounts:
+      - name: config-volume
+        mountPath: /etc/config
+  volumes:
     - name: config-volume
-      mountPath: /etc/config
-volumes:
-  - name: config-volume
-    configMap:
-      name: special-config
-      items:
-      - key: special.level
-        path: /keys
-restartPolicy: Never
+      configMap:
+        name: special-config
+        items:
+        - key: special.level
+          path: /keys
+  restartPolicy: Never
 ```
 
 When the pod runs, the command (`"cat /etc/config/keys/special.level"`) produces the output below:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3867)
<!-- Reviewable:end -->
