### PR TITLE
Add GPU mountpath warning

### DIFF
--- a/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -109,6 +109,10 @@ The API presented here **will change** in an upcoming release to better support 
 
 As of now, CUDA libraries are expected to be pre-installed on the nodes.
 
+The NVIDIA drivers will require privileged containers due to the permissions on ``/usr/lib/nvidia-367``.
+
+To mitigate this, you can copy the libraries to a more permissive folder in ``/var/lib/`` or change the permissions directly. (Future releases will automatically perform this operation)
+
 Pods can access the libraries using `hostPath` volumes.
 
 ```yaml


### PR DESCRIPTION
The GPU path is not permissive by default and requires a bit of
additional setup if the operator does not allow for privileged
containers.

Related kubernetes/kubernetes#46007

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3870)
<!-- Reviewable:end -->
