### PR TITLE
Trivial typo fix

### DIFF
--- a/docs/admin/accessing-the-api.md
+++ b/docs/admin/accessing-the-api.md
@@ -61,7 +61,7 @@ After the request is authenticated as coming from a specific user, the request m
 
 A request must include the username of the requester, the requested action, and the object affected by the action. The request is authorized if an existing policy declares that the user has permissions to complete the requested action. 
 
-For example, if Bob has the policy below, then he can read pods only in the namespace `projectCarabou`:
+For example, if Bob has the policy below, then he can read pods only in the namespace `projectCaribou`:
 
 ```json
 {
@@ -83,7 +83,7 @@ If Bob makes the following request, the request is authorized because he is allo
   "kind": "SubjectAccessReview",
   "spec": {
     "resourceAttributes": {
-      "namespace": "projectCarabou",
+      "namespace": "projectCaribou",
       "verb": "get",
       "group": "unicorn.example.org",
       "resource": "pods"


### PR DESCRIPTION
s/Carabou/Caribou/ in the API access docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3874)
<!-- Reviewable:end -->
