### PR TITLE
docs/concepts/policy/pod-security-policy.md: add projected to list of allowed types

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -122,7 +122,7 @@ to the volume sources that are defined when creating a volume:
 1. \* (allow all volumes)
 
 The recommended minimum set of allowed volumes for new PSPs are 
-configMap, downwardAPI, emptyDir, persistentVolumeClaim, and secret.
+configMap, downwardAPI, emptyDir, persistentVolumeClaim, secret, and projected.
 
 ### Host Network
  - *HostPorts*, default `empty`. List of `HostPortRange`, defined by `min`(inclusive) and `max`(inclusive), which define the allowed host ports.
@@ -168,7 +168,7 @@ $ kubectl get psp
 NAME        PRIV   CAPS  SELINUX   RUNASUSER         FSGROUP   SUPGROUP  READONLYROOTFS  VOLUMES
 permissive  false  []    RunAsAny  RunAsAny          RunAsAny  RunAsAny  false           [*]
 privileged  true   []    RunAsAny  RunAsAny          RunAsAny  RunAsAny  false           [*]
-restricted  false  []    RunAsAny  MustRunAsNonRoot  RunAsAny  RunAsAny  false           [emptyDir secret downwardAPI configMap persistentVolumeClaim]
+restricted  false  []    RunAsAny  MustRunAsNonRoot  RunAsAny  RunAsAny  false           [emptyDir secret downwardAPI configMap persistentVolumeClaim projected]
 ```
 
 ## Editing a Pod Security Policy


### PR DESCRIPTION
Reflects the change from https://github.com/kubernetes/kubernetes/pull/45975 to documentation.

PTAL @pweil-
CC @mfojtik

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3888)
<!-- Reviewable:end -->
