### PR TITLE
Add drop-in templates

### DIFF
--- a/docs/concepts/example-concept-template.md
+++ b/docs/concepts/example-concept-template.md
@@ -1,0 +1,28 @@
+---
+title: Example Concept Template
+---
+
+{% capture overview %}
+**NOTE:** Be sure to also [create an entry in the table of contents](/docs/home/contribute/write-new-topic/#creating-an-entry-in-the-table-of-contents) for your new document.
+
+This page explains ...
+{% endcapture %}
+
+{% capture body %}
+## Understanding ...
+
+Kubernetes provides ...
+
+## Using ...
+
+To use ...
+{% endcapture %}
+
+{% capture whatsnext %}
+**[Optional Section]**
+
+* Learn more about [Writing a New Topic](/docs/home/contribute/write-new-topic/).
+* See [Using Page Templates - Concept template](/docs/home/contribute/page-templates/#concept_template) for how to use this template.
+{% endcapture %}
+
+{% include templates/concept.md %}

--- a/docs/tasks/example-task-template.md
+++ b/docs/tasks/example-task-template.md
@@ -1,0 +1,37 @@
+---
+title: Example Task Template
+---
+
+{% capture overview %}
+**NOTE:** Be sure to also [create an entry in the table of contents](/docs/home/contribute/write-new-topic/#creating-an-entry-in-the-table-of-contents) for your new document.
+
+This page shows how to ...
+{% endcapture %}
+
+{% capture prerequisites %}
+* Do this.
+* Do this too.
+{% endcapture %}
+
+{% capture steps %}
+## Doing ...
+
+1. Do this.
+1. Do this next. Possibly read this [related explanation](...).
+{% endcapture %}
+
+{% capture discussion %}
+## Understanding ...
+**[Optional Section]**
+
+Here's an interesting thing to know about the steps you just did.
+{% endcapture %}
+
+{% capture whatsnext %}
+**[Optional Section]**
+
+* Learn more about [Writing a New Topic](/docs/home/contribute/write-new-topic/).
+* See [Using Page Templates - Task template](/docs/home/contribute/page-templates/#task_template) for how to use this template.
+{% endcapture %}
+
+{% include templates/task.md %}

--- a/docs/tutorials/example-tutorial-template.md
+++ b/docs/tutorials/example-tutorial-template.md
@@ -1,0 +1,51 @@
+---
+title: Example Tutorial Template
+---
+
+{% capture overview %}
+**NOTE:** Be sure to also [create an entry in the table of contents](/docs/home/contribute/write-new-topic/#creating-an-entry-in-the-table-of-contents) for your new document.
+
+This page shows how to ...
+{% endcapture %}
+
+{% capture prerequisites %}
+* Do this.
+* Do this too.
+{% endcapture %}
+
+{% capture objectives %}
+* Learn this.
+* Build this.
+* Run this.
+{% endcapture %}
+
+{% capture lessoncontent %}
+## Building ...
+
+1. Do this.
+1. Do this next. Possibly read this [related explanation](...).
+
+## Running ...
+
+1. Do this.
+1. Do this next.
+
+## Understanding the code
+Here's something interesting about the code you ran in the preceding steps.
+{% endcapture %}
+
+{% capture cleanup %}
+**[Optional Section]**
+
+* Delete this.
+* Stop this.
+{% endcapture %}
+
+{% capture whatsnext %}
+**[Optional Section]**
+
+* Learn more about [Writing a New Topic](/docs/home/contribute/write-new-topic/).
+* See [Using Page Templates - Tutorial template](/docs/home/contribute/page-templates/#tutorial_template) for how to use this template.
+{% endcapture %}
+
+{% include templates/tutorial.md %}

--- a/skip_toc_check.txt
+++ b/skip_toc_check.txt
@@ -27,6 +27,7 @@ docs/admin/resourcequota/walkthrough.md
 docs/admin/static-pods.md
 docs/admin/sysctls.md
 docs/api-reference/labels-annotations-taints.md
+docs/concepts/example-concept-template.md
 docs/concepts/abstractions/pod-termination.md
 docs/contribute/README.md
 docs/contribute/create-pull-request.md
@@ -44,6 +45,8 @@ docs/reference/deprecation-policy.md
 docs/search.md
 docs/sitemap.md
 docs/tabs-example.md
+docs/tasks/example-task-template.md
+docs/tutorials/example-tutorial-template.md
 docs/user-guide/accessing-the-cluster.md
 docs/user-guide/annotations.md
 docs/user-guide/application-troubleshooting.md


### PR DESCRIPTION
Add markdown files using Concepts, Tasks, and Tutorial templates that contributors can copy/paste and drop in their content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3891)
<!-- Reviewable:end -->
