### PR TITLE
update kubernetes.md

### DIFF
--- a/docs/getting-started-guides/kubeadm.md
+++ b/docs/getting-started-guides/kubeadm.md
@@ -109,7 +109,7 @@ For each host in turn:
   EOF
   apt-get update
   # Install docker if you don't have it already.
-  apt-get install -y docker-engine
+  apt-get install -y docker.io
   apt-get install -y kubelet kubeadm kubectl kubernetes-cni
   ```
 


### PR DESCRIPTION
Deployed in 16.04/16.10 ubuntu-server LXC template (PROXMOX)
after installing everything docker version is different depending on if you use:
apt install docker-engine
or
apt install docker.io

Different docker version will break kube-proxy after initial deployment with needed tweaks for use of Canal (cidr-range), and --skip-preflight-checks also added to init.
Without kube-proxy cluster becomes unusable after deployment, also nodes can't join.

when deployed in LXC with arguments:
lxc.aa_profile: unconfined
lxc.cgroup.devices.allow: a
lxc.cap.drop: 
lxc.cgroup.devices.deny: 
lxc.mount.auto: proc:rw sys:ro cgroup:ro
lxc.kmsg: 0
lxc.autodev: 1

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3902)
<!-- Reviewable:end -->
