### PR TITLE
Update small typo in components page (#3930)

### DIFF
--- a/docs/concepts/overview/components.md
+++ b/docs/concepts/overview/components.md
@@ -15,7 +15,7 @@ deliver a functioning Kubernetes cluster.
 ## Master Components
 
 Master components provide the cluster's control plane. Master components make global decisions about the
-cluster (for example, scheduling), and detecting and responding to cluster events (starting up a new pod when a replication controller's 'replicas' field is unsatisfied. 
+cluster (for example, scheduling), and detecting and responding to cluster events (starting up a new pod when a replication controller's 'replicas' field is unsatisfied). 
 
 Master components can be run on any node in the cluster. However,
 for simplicity, set up scripts typically start all master components on


### PR DESCRIPTION
[1] page has a typo in Master Components section.
Updated the document.

[1] https://kubernetes.io/docs/concepts/overview/components/

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3931)
<!-- Reviewable:end -->
