### PR TITLE
Fix typo in cluster api docs

### DIFF
--- a/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/docs/tasks/administer-cluster/access-cluster-api.md
@@ -36,7 +36,7 @@ $ kubectl config view
 ```
 
 Many of the [examples](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/) provide an introduction to using
-kubectl.  omplete documentation is found in the [kubectl manual](/docs/user-guide/kubectl/index).
+kubectl.  Complete documentation is found in the [kubectl manual](/docs/user-guide/kubectl/index).
 
 ### Directly accessing the REST API
 


### PR DESCRIPTION
Fix type in https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/
`omplete documentation is found in the [kubectl manual](/docs/user-guide/kubectl/index).`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3937)
<!-- Reviewable:end -->
