### PR TITLE
Add CRI runtime support

### DIFF
--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -409,6 +409,31 @@ export no_proxy="localhost,127.0.0.1,localaddress,.localdomain.com,example.com,1
 Remember to change `proxy_ip` and add a kube master node IP address to
 `no_proxy`.
 
+## Use Kubeadm with other CRI runtimes
+
+Since [Kubernetes 1.6 release](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#node-components-1), Kubernetes container runtimes have been transferred to using CRI by default. Currently, the build-in container runtime is Docker which is enabled by build-in `dockershim` in `kubelet`.
+
+Using other CRI based runtimes with kubeadm is very simple, and currently supported runtimes are:
+
+- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [frakti](https://github.com/kubernetes/frakti)
+- [rkt](https://github.com/kubernetes-incubator/rktlet)
+
+After you have successfully installed `kubeadm` and `kubelet`, please follow these two steps:
+
+1. Install runtime shim on every node. You will need to follow the installation document in the runtime shim project listing above. 
+
+2. Configure kubelet to use remote CRI runtime. Please remember to change `RUNTIME_ENDPOINT` to your own value like `/var/run/{your_runtime}.sock`:
+
+```shell
+  $ cat > /etc/systemd/system/kubelet.service.d/20-cri.conf <<EOF
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=$RUNTIME_ENDPOINT --feature-gates=AllAlpha=true"
+EOF
+  $ systemctl daemon-reload
+```
+
+Now `kubelet` is ready to use the specified CRI runtime, and you can continue with `kubeadm init` and `kubeadm join` workflow to deploy Kubernetes cluster.
+
 ## Releases and release notes
 
 If you already have kubeadm installed and want to upgrade, run `apt-get update


### PR DESCRIPTION
Add a doc for other CRI runtimes, fixes: https://github.com/kubernetes/kubeadm/issues/82

I also suggest do not include service files for these alternative CRI runtimes unless they become GA in next 2 releases. WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3941)
<!-- Reviewable:end -->
