### PR TITLE
Fix example in the "Adding ConfigMap data to a Volume" section

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -237,7 +237,7 @@ special.type
 ### Add ConfigMap data to a specific path in the Volume:
 
 Use the `path` field to specify the desired file path for specific ConfigMap items. 
-In this case, the `special.key` item will be mounted in the `config-volume` volume at `/etc/config/keys`.
+In this case, the `special.level` item will be mounted in the `config-volume` volume at `/etc/config/keys`.
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
"special.key" does not exist in the given ConfigMap example. It should
be "special.level" instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3961)
<!-- Reviewable:end -->
