### PR TITLE
Add fibre channel volume explanation

### DIFF
--- a/docs/concepts/storage/volumes.md
+++ b/docs/concepts/storage/volumes.md
@@ -321,9 +321,9 @@ simultaneous writers allowed.
 
 See the [iSCSI example](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/volumes/iscsi) for more details.
 
-### fc(fibre channel)
+### fc (fibre channel)
 
-A `fc` volume allows an existing fibre channel volume to be mounted into your pod.
+An `fc` volume allows an existing fibre channel volume to be mounted into your pod.
 You can specify single or multiple target World Wide Names to the parameter
 targetWWNs in your volume configuration. If multiple WWNs are specified,
 targetWWNs expects that those WWNs form multipath connection.

--- a/docs/concepts/storage/volumes.md
+++ b/docs/concepts/storage/volumes.md
@@ -74,6 +74,7 @@ Kubernetes supports several types of Volumes:
    * `awsElasticBlockStore`
    * `nfs`
    * `iscsi`
+   * `fc (fibre channel)`
    * `flocker`
    * `glusterfs`
    * `rbd`
@@ -319,6 +320,19 @@ iSCSI volumes can only be mounted by a single consumer in read-write mode - no
 simultaneous writers allowed.
 
 See the [iSCSI example](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/volumes/iscsi) for more details.
+
+### fc(fibre channel)
+
+A `fc` volume allows an existing fibre channel volume to be mounted into your pod.
+You can specify single or multiple target World Wide Names to the parameter
+targetWWNs in your volume configuration. If multiple WWNs are specified,
+targetWWNs expects that those WWNs form multipath connection.
+
+__Important: You must configure FC SAN Zoning to allocate and mask those
+LUNs (volumes) to the target WWNs beforehand so that Kubernetes hosts
+can access them__
+
+See the [FC example](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/volumes/fibre_channel) for more details.
 
 ### flocker
 


### PR DESCRIPTION
This patch adds explanation of fibre channel volume including usage of multiple WWNs.

Fix #33602
https://github.com/kubernetes/kubernetes/issues/33602

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3967)
<!-- Reviewable:end -->
