### PR TITLE
correct_init_container_state

### DIFF
--- a/docs/concepts/workloads/pods/init-containers.md
+++ b/docs/concepts/workloads/pods/init-containers.md
@@ -199,7 +199,9 @@ Init Containers:
 [...]
   init-mydb:
 [...]
-    State:         Running
+    State:         Waiting
+      Reason:      PodInitializing
+    Ready:         False
 [...]
 Containers:
   myapp-container:
@@ -209,13 +211,13 @@ Containers:
     Ready:         False
 [...]
 Events:
-  FirstSeen    LastSeen    Count    From                     SubObjectPath                Type        Reason        Message
-  ---------    --------    -----    ----                     -------------                --------    ------        -------
+  FirstSeen    LastSeen    Count    From                      SubObjectPath                           Type          Reason        Message
+  ---------    --------    -----    ----                      -------------                           --------      ------        -------
   16s          16s         1        {default-scheduler }                                              Normal        Scheduled     Successfully assigned myapp-pod to 172.17.4.201
-  16s          16s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Pulling        pulling image "busybox"
+  16s          16s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Pulling       pulling image "busybox"
   13s          13s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Pulled        Successfully pulled image "busybox"
-  13s          13s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Created        Created container with docker id 5ced34a04634; Security:[seccomp=unconfined]
-  13s          13s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Started        Started container with docker id 5ced34a04634
+  13s          13s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Created       Created container with docker id 5ced34a04634; Security:[seccomp=unconfined]
+  13s          13s         1        {kubelet 172.17.4.201}    spec.initContainers{init-myservice}     Normal        Started       Started container with docker id 5ced34a04634
 $ kubectl logs myapp-pod -c init-myservice # Inspect the first init container
 $ kubectl logs myapp-pod -c init-mydb      # Inspect the second init container
 ```


### PR DESCRIPTION
init containers execute one after another.
and make output format more readable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3972)
<!-- Reviewable:end -->
