### PR TITLE
Update distribute-credentials-secure.md

### DIFF
--- a/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -47,7 +47,7 @@ username and password:
     **Note:** If you want to skip the Base64 encoding step, you can create a Secret
     by using the `kubectl create secret` command:
 
-        kubectl create secret generic test-secret --from-literal=username='my-app',password='39528$vdg7Jb'
+        kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
 
 1. View information about the Secret:
 


### PR DESCRIPTION
Fix --from-literal cli example, existing example creates a single data element, rather than the two as-indicated.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3981)
<!-- Reviewable:end -->
