### PR TITLE
Make issue title automatically a link

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -65,7 +65,7 @@
             (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
         </script>
         <a href="" onclick="window.open('https://github.com/kubernetes/kubernetes.github.io/issues/new?title=Issue%20with%20' +
-        window.location.pathname)" class="button issue">Create an Issue</a>
+        'k8s.io'+window.location.pathname)" class="button issue">Create an Issue</a>
         <a href="/editdocs#{{ page.path }}" class="button issue">Edit this Page</a>
     {% endif %}
     </div>


### PR DESCRIPTION
e.g. "Issue with k8s.io/docs/getting-started-guides/kubeadm/" when people
open issues on the repo. This way we can just select the text, right-click
and say Go to Link.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3995)
<!-- Reviewable:end -->
