### PR TITLE
Add an annotation for ingress path

### DIFF
--- a/docs/concepts/services-networking/ingress.md
+++ b/docs/concepts/services-networking/ingress.md
@@ -60,6 +60,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - http:
@@ -124,6 +126,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: test
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - host: foo.bar.com


### PR DESCRIPTION
The path of ingress do not work without the following annotations:
annotations:
  ingress.kubernetes.io/rewrite-target: /
https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md#rewrite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/3998)
<!-- Reviewable:end -->
