### PR TITLE
Updated install-kubeadm.md, removed redundant kubectl installation

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -63,7 +63,7 @@ For each machine:
   apt-get update
   # Install docker if you don't have it already.
   apt-get install -y docker-engine
-  apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+  apt-get install -y kubelet kubeadm kubernetes-cni
   ```
 
 * If the machine is running CentOS, run:
@@ -80,7 +80,7 @@ For each machine:
           https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   EOF
   setenforce 0
-  yum install -y docker kubelet kubeadm kubectl kubernetes-cni
+  yum install -y docker kubelet kubeadm kubernetes-cni
   systemctl enable docker && systemctl start docker
   systemctl enable kubelet && systemctl start kubelet
   ```


### PR DESCRIPTION
Updated install-kubeadm.md:
- Removed redundant installation of kubectl. By following instructions you were installing kubectl twice: once in separate paragraph "Installing kubectl " and then while installing kubelet and kubeadm

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4006)
<!-- Reviewable:end -->
