### PR TITLE
fix header size for sub-sections under Services

### DIFF
--- a/docs/concepts/services-networking/dns-pod-service.md
+++ b/docs/concepts/services-networking/dns-pod-service.md
@@ -48,7 +48,7 @@ Services, this resolves to the set of IPs of the pods selected by the Service.
 Clients are expected to consume the set or else use standard round-robin
 selection from the set.
 
-### SRV records
+#### SRV records
 
 SRV Records are created for named ports that are part of normal or [Headless
 Services](https://kubernetes.io/docs/user-guide/services/#headless-services).
@@ -60,7 +60,7 @@ For a headless service, this resolves to multiple answers, one for each pod
 that is backing the service, and contains the port number and a CNAME of the pod
 of the form `auto-generated-name.my-svc.my-namespace.svc.cluster.local`.
 
-### Backwards compatibility
+#### Backwards compatibility
 
 Previous versions of kube-dns made names of the form
 `my-svc.my-namespace.cluster.local` (the 'svc' level was added later).  This


### PR DESCRIPTION
before:
<img width="335" alt="screen shot 2017-06-07 at 4 11 46 pm" src="https://user-images.githubusercontent.com/1469579/26905418-1a3fd51e-4b9c-11e7-8e9d-f9a9102e6e0a.png">

after:
<img width="313" alt="screen shot 2017-06-07 at 4 12 01 pm" src="https://user-images.githubusercontent.com/1469579/26905421-1c5fdbe6-4b9c-11e7-9dfe-57d99e43969d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4012)
<!-- Reviewable:end -->
