### PR TITLE
Be more specific about cpu-shares passed to Docker

### DIFF
--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -133,8 +133,8 @@ to the container runtime.
 When using Docker:
 
 - The `spec.containers[].resources.requests.cpu` is converted to its core value,
-  which is potentially fractional, and multiplied by 1024. This number is used
-  as the value of the
+  which is potentially fractional, and multiplied by 1024. The greater of this number
+  or 2 is used as the value of the
   [`--cpu-shares`](https://docs.docker.com/engine/reference/run/#/cpu-share-constraint)
   flag in the `docker run` command.
 


### PR DESCRIPTION
Docker documentation (https://docs.docker.com/engine/reference/run/) reads:
  

> "To modify the proportion from the default of 1024, use the -c or --cpu-shares flag to set the weighting to 2 or higher. If 0 is set, the system will ignore the value and use the default of 1024."

So the Kubernetes documentation gives the impression that if requests.cpu is zero, Docker would end up applying a value of 1024, which isn't the case.

This change makes the explanation more precise, hopefully without making it much more difficult to read.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4016)
<!-- Reviewable:end -->
