### PR TITLE
Clarify the required uniqueness of Label Key

### DIFF
--- a/docs/concepts/overview/working-with-objects/labels.md
+++ b/docs/concepts/overview/working-with-objects/labels.md
@@ -38,7 +38,7 @@ Example labels:
    * `"partition" : "customerA"`, `"partition" : "customerB"`
    * `"track" : "daily"`, `"track" : "weekly"`
 
-These are just examples; you are free to develop your own conventions.
+These are just examples of commonly used labels; you are free to develop your own conventions. Keep in mind that label Key must be unique for a given object.
 
 ## Syntax and character set
 


### PR DESCRIPTION
fixes #16812 
https://github.com/kubernetes/kubernetes/issues/16812
The issue is about having the example labels with multiple usage of keys (e.g. 'release', 'environment' used in examples) gives a wrong impression to reader that keys doesn't need to be unique. The concerned was shared by an active developer as well so this PR is trying remove such a confusion.
The issue was opened year back against Kubernetes, not moving it to k8s.
github.io issues but I will close the issue once these changes merge.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4020)
<!-- Reviewable:end -->
