### PR TITLE
Add --show-all to documentation

### DIFF
--- a/docs/tasks/job/parallel-processing-expansion.md
+++ b/docs/tasks/job/parallel-processing-expansion.md
@@ -99,7 +99,7 @@ There is not a single command to check on the output of all jobs at once,
 but looping over all the pods is pretty easy:
 
 ```shell
-$ for p in $(kubectl get pods -l jobgroup=jobexample -o name)
+$ for p in $(kubectl get pods -l jobgroup=jobexample --show-all -o name)
 do
   kubectl logs $p
 done


### PR DESCRIPTION
`kubectl get pods -l jobgroup=jobexample --show-all -o name`
will not show the completed jobs.  This caught me when running through the steps myself.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4034)
<!-- Reviewable:end -->
