### PR TITLE
docs(service): remove invalid `,` from example

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -489,8 +489,8 @@ In the ServiceSpec, `externalIPs` can be specified along with any of the `Servic
 In the example below, my-service can be accessed by clients on 80.11.12.10:80 (externalIP:port)
 
 ```yaml
-kind: Service,
-apiVersion: v1,
+kind: Service
+apiVersion: v1
 metadata:
   name: my-service
 spec:
@@ -498,8 +498,8 @@ spec:
     app: MyApp
   ports:
     - name: http,
-      protocol: TCP,
-      port: 80,
+      protocol: TCP
+      port: 80
       targetPort: 9376
   externalIPs: 
     - 80.11.12.10


### PR DESCRIPTION
Remove invalid `,` from the ExternalIP example YAML.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4036)
<!-- Reviewable:end -->
