### PR TITLE
Fix wrong link to create a ConfigMap

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -8,7 +8,7 @@ This page provides a series of usage examples demonstrating how to configure Pod
 
 {% capture prerequisites %}
 * {% include task-tutorial-prereqs.md %}
-* [Create a ConfigMap](/docs/tasks/configure-pod-container/configmap.html)
+* [Create a ConfigMap](/docs/tasks/configure-pod-container/configmap/)
 {% endcapture %}
 
 {% capture steps %}


### PR DESCRIPTION
This PR fix the issue described at https://github.com/kubernetes/kubernetes.github.io/issues/4039

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4043)
<!-- Reviewable:end -->
