### PR TITLE
Add documentation for podpreset opt-out annotation

### DIFF
--- a/docs/tasks/inject-data-application/podpreset.md
+++ b/docs/tasks/inject-data-application/podpreset.md
@@ -51,7 +51,7 @@ Kubernetes modifies the Pod Spec.
 
 Kubernetes annotates the resulting modified pod spec to show that it was
 modified by a `PodPreset`. The annotation is of the form
-`podpreset.admission.kubernetes.io/<pod-preset name>": "<resource version>"`.
+`podpreset.admission.kubernetes.io/podpreset-<pod-preset name>": "<resource version>"`.
 
 
 ## Enable Pod Preset
@@ -62,6 +62,12 @@ following
 1.  You have enabled the api type `settings.k8s.io/v1alpha1/podpreset`
 1.  You have enabled the admission controller `PodPreset`
 1.  You have defined your pod presets
+
+## Disable Pod Preset for a pod
+
+There may be instances where you wish for a pod to not be altered by any pod
+preset mutations. For these events, one can add an annotation in the pod spec
+of the form: `podpreset.admission.kubernetes.io/exclude: "true"`.
 
 ## Create a Pod Preset
 


### PR DESCRIPTION
The new format simply adds a prefix of "podpreset-" to the current
annotation that records what presets have acted on a pod. The new naming
makes it such that there is no chance of collision with the newly
introduced opt-out annotation (or future ones yet to be added).

Opt-out annotation PR:
kubernetes/kubernetes#44965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4067)
<!-- Reviewable:end -->
