### PR TITLE
Use native patch functionality instead of JQ

### DIFF
--- a/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/docs/tasks/configure-pod-container/configure-service-account.md
@@ -175,14 +175,10 @@ NAME             TYPE                              DATA    AGE
 myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
 ```
 
-Next, read/modify/write the service account for the namespace to use this secret as an imagePullSecret.
+Next, modify the default service account for the namespace to use this secret as an imagePullSecret.
 
-Automated version using json and the jq utility:
 ```shell
-kubectl get serviceaccounts default -o json |
-     jq  'del(.metadata.resourceVersion)'|
-     jq 'setpath(["imagePullSecrets"];[{"name":"myregistrykey"}])' |
-     kubectl replace serviceaccount default -f -
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
 
 ```
 


### PR DESCRIPTION
This provides a simpler version of patching resources without the use of third party tools

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4084)
<!-- Reviewable:end -->
