### PR TITLE
Storageos Volume Plugin

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -120,6 +120,7 @@ to the volume sources that are defined when creating a volume:
 1. projected
 1. portworxVolume
 1. scaleIO
+1. storageos
 1. \* (allow all volumes)
 
 The recommended minimum set of allowed volumes for new PSPs are 

--- a/docs/concepts/storage/persistent-volumes.md
+++ b/docs/concepts/storage/persistent-volumes.md
@@ -127,6 +127,7 @@ However, the particular path specified in the custom recycler pod template in th
 * VMware Photon
 * Portworx Volumes
 * ScaleIO Volumes
+* StorageOS
 
 ## Persistent Volumes
 
@@ -195,6 +196,7 @@ In the CLI, the access modes are abbreviated to:
 | VsphereVolume        | &#x2713;     | -           | -            |
 | PortworxVolume       | &#x2713;     | -           | &#x2713;     |
 | ScaleIO              | &#x2713;     | &#x2713;    | -            |
+| StorageOS            | &#x2713;     | -           | -            |
 
 ### Class
 
@@ -728,6 +730,36 @@ as shown in the following command:
 ```
 $> kubectl create secret generic sio-secret --type="kubernetes.io/scaleio" --from-literal=username=sioadmin --from-literal=password=d2NABDNjMA== --namespace=default
 ```
+
+#### StorageOS
+```yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: kubernetes.io/storageos
+parameters:
+  pool: default
+  description: Kubernetes volume
+  fsType: ext4
+  adminSecretNamespace: default
+  adminSecretName: storageos-secret
+```
+
+* `pool`: The name of the StorageOS distributed capacity pool to provision the volume from.  Uses the `default` pool which is normally present if not specified.
+* `description`: The description to assign to volumes that were created dynamically.  All volume descriptions will be the same for the storage class, but different storage classes can be used to allow descriptions for different use cases.  Defaults to `Kubernetes volume`.
+* `fsType`: The default filesystem type to request.  Note that user-defined rules within StorageOS may override this value.  Defaults to `ext4`.
+* `adminSecretNamespace`: The namespace where the API configuration secret is located.  Required if adminSecretName set.
+* `adminSecretName`: The name of the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+
+The StorageOS Kubernetes volume plugin can use a Secret object to specify an endpoint and credentials to access the StorageOS API.  This is only required when the defaults have been changed.
+The secret must be created with type `kubernetes.io/storageos` as shown in the following command:
+
+```
+$ kubectl create secret generic storageos-secret --type="kubernetes.io/storageos" --from-literal=apiAddress=tcp://localhost:5705 --from-literal=apiUsername=storageos --from-literal=apiPassword=storageos --namespace=default
+```
+
+Secrets used for dynamically provisioned volumes may be created in any namespace and referenced with the `adminSecretNamespace` parameter.  Secrets used by pre-provisioned volumes must be created in the same namespace as the PVC that references it.
 
 ## Writing Portable Configuration
 

--- a/docs/concepts/storage/volumes.md
+++ b/docs/concepts/storage/volumes.md
@@ -90,6 +90,7 @@ Kubernetes supports several types of Volumes:
    * `Quobyte`
    * `PortworxVolume`
    * `ScaleIO`
+   * `StorageOS`
 
 We welcome additional contributions.
 
@@ -695,6 +696,47 @@ spec:
 ```
 
 For further detail, plese the see the [ScaleIO examples](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/volumes/scaleio).
+
+### StorageOS
+A `storageos` volume allows an existing [StorageOS](https://www.storageos.com) volume to be mounted into your pod.
+
+StorageOS runs as a container within your Kubernetes environment, making local or attached storage accessible from any node within the Kubernetes cluster.  Data can be replicated to protect against node failure.  Thin provisioning and compression can improve utilization and reduce cost.
+
+At its core, StorageOS provides block storage to containers, accessible via a file system.
+
+The StorageOS container requires 64-bit Linux and has no additional dependencies.  A free developer licence is available.
+
+__Important: You must run the StorageOS container on each node that wants to access StorageOS volumes or that will contribute storage capacity to the pool.  For installation instructions, consult the [StorageOS documentation](https://docs.storageos.com)__
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis
+    role: master
+  name: test-storageos-redis
+spec:
+  containers:
+    - name: master
+      image: kubernetes/redis:v1
+      env:
+        - name: MASTER
+          value: "true"
+      ports:
+        - containerPort: 6379
+      volumeMounts:
+        - mountPath: /redis-master-data
+          name: redis-data
+  volumes:
+    - name: redis-data
+      storageos:
+        # The `redis-vol01` volume must already exist within StorageOS in the `default` namespace.
+        volumeName: redis-vol01
+        fsType: ext4
+```
+
+For more information including Dynamic Provisioning and Persistent Volume Claims, please see the [StorageOS examples](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/examples/volumes/storageos).
 
 ## Using subPath
 


### PR DESCRIPTION
Docs for Feature: https://github.com/kubernetes/features/issues/190
PR (already merged for 1.7 release): https://github.com/kubernetes/kubernetes/pull/42156

One-line release note description: 
Volume plugin for StorageOS provides highly-available cluster-wide persistent volumes from local or attached node storage.

/cc @saad-ali

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4095)
<!-- Reviewable:end -->
