### PR TITLE
Use "sudo -i" instead of "sudo su -"

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -50,7 +50,7 @@ releases](https://github.com/kubernetes/kubeadm/blob/master/CHANGELOG.md)
 For each machine:
 
 * SSH into the machine and become root if you are not already (for example,
-  run `sudo su -`).
+  run `sudo -i`).
 
 * If the machine is running Ubuntu or HypriotOS, run:
 


### PR DESCRIPTION
`sudo su -` is redundant, as you are asking the system to elevate you after you have already elevated.

If what you actually want is to get a login environment, the `sudo -i` flag is designed exactly for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4114)
<!-- Reviewable:end -->
