### PR TITLE
Update GPU docs

### DIFF
--- a/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -109,8 +109,6 @@ The API presented here **will change** in an upcoming release to better support 
 
 As of now, CUDA libraries are expected to be pre-installed on the nodes.
 
-The NVIDIA drivers will require privileged containers due to the permissions on ``/usr/lib/nvidia-367``.
-
 To mitigate this, you can copy the libraries to a more permissive folder in ``/var/lib/`` or change the permissions directly. (Future releases will automatically perform this operation)
 
 Pods can access the libraries using `hostPath` volumes.
@@ -135,10 +133,10 @@ spec:
       name: lib
   volumes:
   - hostPath:
-      path: /usr/lib/nvidia-367/bin
+      path: /usr/lib/nvidia-375/bin
     name: bin
   - hostPath: 
-      path: /usr/lib/nvidia-367
+      path: /usr/lib/nvidia-375
     name: lib
 ```
 


### PR DESCRIPTION
Fix GPU docs:

- NVIDIA drivers doesn't require privileged permissions
- Update nvidia example to nvidia-375, which is part of CUDA 8.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4116)
<!-- Reviewable:end -->
