### PR TITLE
HPA autoscaling/v2alpha1 status conditions

### DIFF
--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -269,6 +269,48 @@ Then, your HorizontalPodAutoscaler would attempt to ensure that each pod was con
 50% of its requested CPU, serving 1000 packets per second, and that all pods behind the main-route
 Ingress were serving a total of 10000 requests per second.
 
+## Appendix: Horizontal Pod Autoscaler Status Conditions
+
+When using the `autoscaling/v2alpha1` form of the HorizontalPodAutoscaler, you will be able to see
+*status conditions* set by Kubernetes on the HorizontalPodAutoscaler.  These status conditions indicate
+whether or not the HorizontalPodAutoscaler is able to scale, and whether or not it is currently restricted
+in any way.
+
+The conditions appear in the `status.conditions` field.  To see the conditions affecting a HorizontalPodAutoscaler,
+we can use `kubectl describe hpa`:
+
+```shell
+$ kubectl describe hpa cm-test
+Name:                           cm-test
+Namespace:                      prom
+Labels:                         <none>
+Annotations:                    <none>
+CreationTimestamp:              Fri, 16 Jun 2017 18:09:22 +0000
+Reference:                      ReplicationController/cm-test
+Metrics:                        ( current / target )
+  "http_requests" on pods:      66m / 500m
+Min replicas:                   1
+Max replicas:                   4
+ReplicationController pods:     1 current / 1 desired
+Conditions:
+  Type                  Status  Reason                  Message
+  ----                  ------  ------                  -------
+  AbleToScale           True    ReadyForNewScale        the last scale time was sufficiently old as to warrant a new scale
+  ScalingActive         True    ValidMetricFound        the HPA was able to succesfully calculate a replica count from pods metric http_requests
+  ScalingLimited        False   DesiredWithinRange      the desired replica count is within the acceptible range
+Events:
+```
+
+For this HorizontalPodAutoscaler, we can see several conditions in a healthy state.  The first,
+`AbleToScale`, indicates whether or not the HPA is able to fetch and update scales, as well as
+whether or not any backoff-related conditions would prevent scaling.  The second, `ScalingActive`,
+indicates whether or not the HPA is enabled (i.e. the replica count of the target is not zero) and
+is able to calculate desired scales. When it is `False`, it generally indicates problems with
+fetching metrics.  Finally, the last condition, `ScalingLimitted`, indicates that the desired scale
+was capped by the maximum or minimum of the HorizontalPodAutoscaler.  This is an indicatation that
+you may wish to raise or lower the mimimum or maximum replica count constrains on your
+HorizontalPodAutoscaler.
+
 ## Appendix: Other possible scenarios
 
 ### Creating the autoscaler from a .yaml file


### PR DESCRIPTION
This commit documents the new status conditions feature for HPA
autoscaling/v2alpha1.  It demonstrates how to get the status conditions
using `kubectl describe`, and how to interpret them.

Documents kubernetes/features#264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4118)
<!-- Reviewable:end -->
