### PR TITLE
add small blurb about reclaim policies and SCs

### DIFF
--- a/docs/concepts/storage/persistent-volumes.md
+++ b/docs/concepts/storage/persistent-volumes.md
@@ -447,6 +447,14 @@ can be used. Some external provisioners are listed under the repository [kuberne
 There are also cases when 3rd party storage vendors provide their own external
 provisioner.
 
+### Reclaim Policy
+Persistent Volumes that are dynamically created by a storage class will have a reclaim
+policy of `delete`.  If that is not desired, the only current option is to edit the
+PV after it is created.
+
+Persistent Volumes that are created manually and managed via a storage class will have
+whatever reclaim policy they were assigned at creation.
+
 ### Parameters
 Storage classes have parameters that describe volumes belonging to the storage
 class. Different parameters may be accepted depending on the `provisioner`. For


### PR DESCRIPTION
The reclaim policy for dynamically created persistent volumes is always delete.  This is only mentioned in a blog post.  It should be on this page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4125)
<!-- Reviewable:end -->
