### PR TITLE
bump openstack cli tools versions to working values

### DIFF
--- a/docs/getting-started-guides/openstack-heat.md
+++ b/docs/getting-started-guides/openstack-heat.md
@@ -31,11 +31,11 @@ If you already have the required versions of the OpenStack CLI tools installed a
 #### Install OpenStack CLI tools
 
 ```sh
-sudo pip install -U --force 'python-openstackclient==2.4.0'
-sudo pip install -U --force 'python-heatclient==1.1.0'
-sudo pip install -U --force 'python-swiftclient==3.0.0'
-sudo pip install -U --force 'python-glanceclient==2.0.0'
-sudo pip install -U --force 'python-novaclient==3.4.0'
+sudo pip install -U --force 'python-openstackclient==3.11.0'
+sudo pip install -U --force 'python-heatclient==1.10.0'
+sudo pip install -U --force 'python-swiftclient==3.3.0'
+sudo pip install -U --force 'python-glanceclient==2.7.0'
+sudo pip install -U --force 'python-novaclient==9.0.1'
 ```
 
 #### Configure Openstack CLI tools
@@ -196,7 +196,7 @@ See the [OpenStack CLI Reference](http://docs.openstack.org/cli-reference/) for 
 
 ### Salt
 
-The OpenStack-Heat provider uses a [standalone Salt configuration](/docs/admin/salt/#standalone-salt-configuration-on-gce-and-others).  
+The OpenStack-Heat provider uses a [standalone Salt configuration](/docs/admin/salt/#standalone-salt-configuration-on-gce-and-others).
 It only uses Salt for bootstraping the machines and creates no salt-master and does not auto-start the salt-minion service on the nodes.
 
 ## SSHing to your nodes


### PR DESCRIPTION
Following the guide on a recent openstack deployment I was getting deprecation errors and finally the stack wasn't being created, with these versions the deployment succeeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4133)
<!-- Reviewable:end -->
