### PR TITLE
fix example in configure-pod-configmap

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -248,7 +248,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh","-c","cat /etc/config/keys/special.level" ]
+      command: [ "/bin/sh","-c","cat /etc/config/keys" ]
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config
@@ -258,11 +258,11 @@ spec:
         name: special-config
         items:
         - key: special.level
-          path: /keys
+          path: keys
   restartPolicy: Never
 ```
 
-When the pod runs, the command (`"cat /etc/config/keys/special.level"`) produces the output below:
+When the pod runs, the command (`"cat /etc/config/keys"`) produces the output below:
 
 ```shell
 very


### PR DESCRIPTION
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

```
# kubectl create -f -
apiVersion: v1
kind: Pod
metadata:
  name: dapi-test-pod
spec:
  containers:
    - name: test-container
      image: gcr.io/google_containers/busybox
      command: [ "/bin/sh","-c","cat /etc/config/keys/special.level" ]
      volumeMounts:
      - name: config-volume
        mountPath: /etc/config
  volumes:
    - name: config-volume
      configMap:
        name: special-config
        items:
        - key: special.level
          path: /keys
  restartPolicy: Never
The Pod "dapi-test-pod" is invalid: 
* spec.volumes[0].configMap.items[0].path: Invalid value: "/keys": must be a relative path
* spec.containers[0].volumeMounts[0].name: Not found: "config-volume"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4144)
<!-- Reviewable:end -->
