### PR TITLE
Patch #4118 for typos

### DIFF
--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -180,7 +180,7 @@ the only other supported resource metric is memory.  These resources do not chan
 to cluster, and should always be available, as long as Heapster is deployed.
 
 You can also specify resource metrics in terms of direct values, instead of as percentages of the
-requested value.  To do so, use the `targetAverageValue` field insted of the `targetAverageUtilization`
+requested value.  To do so, use the `targetAverageValue` field instead of the `targetAverageUtilization`
 field.
 
 There are two other types of metrics, both of which are considered *custom metrics*: pod metrics and
@@ -296,7 +296,7 @@ Conditions:
   Type                  Status  Reason                  Message
   ----                  ------  ------                  -------
   AbleToScale           True    ReadyForNewScale        the last scale time was sufficiently old as to warrant a new scale
-  ScalingActive         True    ValidMetricFound        the HPA was able to succesfully calculate a replica count from pods metric http_requests
+  ScalingActive         True    ValidMetricFound        the HPA was able to successfully calculate a replica count from pods metric http_requests
   ScalingLimited        False   DesiredWithinRange      the desired replica count is within the acceptible range
 Events:
 ```
@@ -307,8 +307,8 @@ whether or not any backoff-related conditions would prevent scaling.  The second
 indicates whether or not the HPA is enabled (i.e. the replica count of the target is not zero) and
 is able to calculate desired scales. When it is `False`, it generally indicates problems with
 fetching metrics.  Finally, the last condition, `ScalingLimitted`, indicates that the desired scale
-was capped by the maximum or minimum of the HorizontalPodAutoscaler.  This is an indicatation that
-you may wish to raise or lower the mimimum or maximum replica count constrains on your
+was capped by the maximum or minimum of the HorizontalPodAutoscaler.  This is an indication that
+you may wish to raise or lower the minimum or maximum replica count constraints on your
 HorizontalPodAutoscaler.
 
 ## Appendix: Other possible scenarios


### PR DESCRIPTION
fix typos related to PR #4118 and in `/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4156)
<!-- Reviewable:end -->
