### PR TITLE
Fixed 5th step

### DIFF
--- a/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -56,7 +56,7 @@ the Pod:
 
 1. In your shell, verify that the `projected-volumes` directory contains your projected sources:
 
-        / # ls projected-volumes/
+        / # ls /projected-volume/
 {% endcapture %}
 
 {% capture whatsnext %}


### PR DESCRIPTION
volume path is /projected-volume, not projected-volumes/

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4163)
<!-- Reviewable:end -->
