### PR TITLE
CronJobs aren't enabled in 1.6 by default

### DIFF
--- a/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/docs/concepts/workloads/controllers/cron-jobs.md
@@ -42,8 +42,6 @@ with batch/v2alpha1 API turned on by passing `--runtime-config=batch/v2alpha1=tr
 the API server (see [Turn on or off an API version for your cluster](/docs/admin/cluster-management/#turn-on-or-off-an-api-version-for-your-cluster)
 for more).
 
-Beginning with 1.6 series Cron Jobs are enabled by default, but note that you can not use Cron Jobs on a hosted Kubernetes provider that has disabled alpha resources.
-
 ## Creating a Cron Job
 
 Here is an example Cron Job. Every minute, it runs a simple job to print current time and then say


### PR DESCRIPTION
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4185)
<!-- Reviewable:end -->
