### PR TITLE
Fix installing autocompletion documentation

### DIFF
--- a/docs/tasks/tools/install-kubectl.md
+++ b/docs/tasks/tools/install-kubectl.md
@@ -183,12 +183,11 @@ Follow the "caveats" section of brew's output to add the appropriate bash comple
 
 If you've installed kubectl using the [Homebrew instructions](#install-with-homebrew-on-macos) then kubectl completion should start working immediately.
 
-If you have installed kubectl manually, then run: `source <(kubectl completion bash)`
-
-To add kubectl autocompletion to your profile (so it is automatically loaded in future shells):
+If you have installed kubectl manually, you need to add kubectl autocompletion to the bash-completion and add the bash-completion to your profile (so it is automatically loaded in future shells):
 
 ```shell
-echo "source <(kubectl completion bash)" >> ~/.bash_profile
+kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
+echo "source $(brew --prefix)/etc/bash_completion" >> ~/.bash_profile
 ```
 
 The Homebrew project is independent from kubernetes, so the bash-completion packages are not guaranteed to work.

--- a/docs/tasks/tools/install-kubectl.md
+++ b/docs/tasks/tools/install-kubectl.md
@@ -183,11 +183,10 @@ Follow the "caveats" section of brew's output to add the appropriate bash comple
 
 If you've installed kubectl using the [Homebrew instructions](#install-with-homebrew-on-macos) then kubectl completion should start working immediately.
 
-If you have installed kubectl manually, you need to add kubectl autocompletion to the bash-completion and add the bash-completion to your profile (so it is automatically loaded in future shells):
+If you have installed kubectl manually, you need to add kubectl autocompletion to the bash-completion:
 
 ```shell
 kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
-echo "source $(brew --prefix)/etc/bash_completion" >> ~/.bash_profile
 ```
 
 The Homebrew project is independent from kubernetes, so the bash-completion packages are not guaranteed to work.


### PR DESCRIPTION
The written solution did not work for me with the error `-bash: __git_ps1: command not found`. Since the auto-completion is already installed you can simply add the Kubernetes autocompletion to it.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4189)
<!-- Reviewable:end -->
