### PR TITLE
Copy-to-clipboard fix

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -25,7 +25,7 @@ function copyCode(elem){
              }
              target.value = document.getElementById(elem).innerText;
          // select the content
-         target.setSelectionRange(0, target.value.length);
+         target.select();
 
          // copy the selection
          var succeed;


### PR DESCRIPTION
target.setSelectionRange(0, target.value.length); does not always seem to be
working. It doesn't work once the text is unselected. Using textarea.select()
function: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>

Fixes #3965.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4190)
<!-- Reviewable:end -->
