### PR TITLE
Prevents sweetAlert in copyCode function from being cut off on page

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -35,7 +35,7 @@ function copyCode(elem){
              sweetAlert("Oh, no...","Sorry, your browser doesn't support document.execCommand('copy'), so we can't copy this code to your clipboard.");
              succeed = false;
          }
-         if (succeed) sweetAlert("Copied to clipboard:",target.value);
+         if (succeed) sweetAlert("Copied to clipboard: ",elem);
          return succeed;
      } else {
          sweetAlert("Oops!",elem + " not found when trying to copy code");


### PR DESCRIPTION
In copyCode function, removes target.value from if (succeed) sweetAlert function. 

Sometimes target.value is too long, which causes the sweetAlert box to be cut off from the page. The confirmation button also gets cut off, which means that the user can't close the box, which means they need to refresh the page to continue.

Instead, the alert tells the user which file was copied. This is also consistent with the error presented if the file can't be found.

Example of this issue: https://kubernetes.io/docs/tasks/run-application/run-replicated-stateful-application/#statefulset

Staged version page after fix: https://deploy-preview-4201--kubernetes-io-master-staging.netlify.com/docs/tasks/run-application/run-replicated-stateful-application/#statefulset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4201)
<!-- Reviewable:end -->
