### PR TITLE
Fix typo for PR #4080

### DIFF
--- a/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -13,7 +13,7 @@ redirect_from:
 
 Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable. In 1.7, users can add these custom entries with the HostAliases field in PodSpec.
 
-Modification not using HostAliases is not suggested because the file is managed by Kubetlet and can be overwritten on during Pod creation/restart.
+Modification not using HostAliases is not suggested because the file is managed by Kubelet and can be overwritten on during Pod creation/restart.
 
 ## Default Hosts File Content
 


### PR DESCRIPTION
"Kubetlet" -> "Kubelet"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4202)
<!-- Reviewable:end -->
