### PR TITLE
Use correct apigroup for NetworkPolicy

### DIFF
--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -78,7 +78,7 @@ See the [NetworkPolicy getting started guide](/docs/getting-started-guides/netwo
 You can create a "default" isolation policy for a Namespace by creating a NetworkPolicy that selects all pods but does not allow any traffic:
 
 ```yaml
-apiVersion: networking/v1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-deny
@@ -91,7 +91,7 @@ This ensures that even pods that aren't selected by any other NetworkPolicy will
 Alternatively, if you want to allow all traffic for all pods in a Namespace (even if policies are added that cause some pods to be treated as "isolated"), you can create a policy that explicitly allows all traffic:
 
 ```yaml
-apiVersion: networking/v1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-all

--- a/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/docs/tasks/administer-cluster/declare-network-policy.md
@@ -73,7 +73,7 @@ Let's say you want to limit access to the `nginx` service so that only pods with
 
 ```yaml
 kind: NetworkPolicy
-apiVersion: networking/v1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: access-nginx
 spec:


### PR DESCRIPTION
Follow-up to #4225. networking &rarr; networking.k8s.io.

cc: @danwinship @thockin 
/assign chenopis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4238)
<!-- Reviewable:end -->
