### PR TITLE
Remove extra storageClassName

### DIFF
--- a/docs/tasks/configure-pod-container/task-pv-claim.yaml
+++ b/docs/tasks/configure-pod-container/task-pv-claim.yaml
@@ -9,4 +9,3 @@ spec:
   resources:
     requests:
       storage: 3Gi
-  storageClassName: ""


### PR DESCRIPTION
The second empty declaration for storageClassName overwrites the first.

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4248)
<!-- Reviewable:end -->
