### PR TITLE
Move media query to right before next one, remove padding on margin

### DIFF
--- a/docs/tutorials/kubernetes-basics/public/css/styles.css
+++ b/docs/tutorials/kubernetes-basics/public/css/styles.css
@@ -8788,10 +8788,11 @@ button.close
     -ms-flex: 1 1 auto;
         flex: 1 1 auto;
 }
-@media screen and (max-width: 992px)
+@media screen and (max-width: 998px)
 {
     .content
     {
+        margin-left: 0px;
         padding-right: 20px;
         padding-left: 20px;
     }


### PR DESCRIPTION
When the size of the window was decreased below 999px to whenever phone size takes over, the content would be shifted by -200px.  This was to compensate for the menu on the size trying to bump things over, but didn't work because the menu disappeared at 999px.  This fixes it and bumps the media query up against the other one: 992px to 998px.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4251)
<!-- Reviewable:end -->
