### PR TITLE
Added references to logging daemonsets

### DIFF
--- a/docs/concepts/workloads/controllers/daemonset.md
+++ b/docs/concepts/workloads/controllers/daemonset.md
@@ -19,7 +19,7 @@ collected.  Deleting a DaemonSet will clean up the pods it created.
 Some typical uses of a DaemonSet are:
 
 - running a cluster storage daemon, such as `glusterd`, `ceph`, on each node.
-- running a logs collection daemon on every node, such as `fluentd` or `logstash`.
+- running a logs collection daemon on every node, such as (`fluentd`)[http://www.fluentd.org], (`fluent-bit`)[http://fluentbit.io/documentation/current/kubernetes/], (`fluentd-enterprise`)[http://fluentd.treasuredata.com] or `logstash`.
 - running a node monitoring daemon on every node, such as [Prometheus Node Exporter](
   https://github.com/prometheus/node_exporter), `collectd`, New Relic agent, or Ganglia `gmond`.
 


### PR DESCRIPTION
Added Fluent-bit, Fluentd Enterprise as well as references to the website links

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4254)
<!-- Reviewable:end -->
