### PR TITLE
remove dead link

### DIFF
--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -30,7 +30,7 @@ Kubernetes reviews only the following API request attributes:
  * **group** - The list of group names to which the authenticated user belongs
  * **"extra"** - A map of arbitrary string keys to string values, provided by the authentication layer
  * **API** - Indicates whether the request is for an API resource
- * **Request path** - Path to miscellaneous non-resource endpoints like `/api` or `/healthz` (see [kubectl](#kubectl)).
+ * **Request path** - Path to miscellaneous non-resource endpoints like `/api` or `/healthz`.
  * **API request verb** - API verbs `get`, `list`, `create`, `update`, `patch`, `watch`, `proxy`, `redirect`, `delete`, and `deletecollection` are used for resource requests. To determine the request verb for a resource API endpoint, see **Determine the request verb** below.
  * **HTTP request verb** - HTTP verbs `get`, `post`, `put`, and `delete` are used for non-resource requests
  * **Resource** - The ID or name of the resource that is being accessed (for resource requests only)


### PR DESCRIPTION
There is no "kubectl" section in this page. And non-resource urls do not
have too much relationship with kubectl(At least I think so), so we
don't need "see kubectl"

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4257)
<!-- Reviewable:end -->
