### PR TITLE
Clear up use of hostPort with DaemonSet

### DIFF
--- a/docs/concepts/workloads/controllers/daemonset.md
+++ b/docs/concepts/workloads/controllers/daemonset.md
@@ -106,7 +106,7 @@ Some possible patterns for communicating with pods in a DaemonSet are:
 
 - **Push**: Pods in the DaemonSet are configured to send updates to another service, such
   as a stats database.  They do not have clients.
-- **NodeIP and Known Port**: Pods in the DaemonSet use a `hostPort`, so that the pods are reachable via the node IPs.  Clients know the list of nodes ips somehow, and know the port by convention.
+- **NodeIP and Known Port**: Pods in the DaemonSet can use a `hostPort`, so that the pods are reachable via the node IPs.  Clients know the list of nodes ips somehow, and know the port by convention.
 - **DNS**: Create a [headless service](/docs/user-guide/services/#headless-services) with the same pod selector,
   and then discover DaemonSets using the `endpoints` resource or retrieve multiple A records from
   DNS.


### PR DESCRIPTION
Reading through the communication patterns it was not obvious to me that the `hostPort` option is something I have to set myself, while the **DNS** and **Service** options explicitly say one has to *create a service*.

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4265)
<!-- Reviewable:end -->
