### PR TITLE
Downward API supports pod's UID

### DIFF
--- a/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -199,6 +199,7 @@ variables and DownwardAPIVolumeFiles:
 * The Pod’s namespace
 * The Pod’s IP address
 * The Pod’s service account name
+* The Pod’s UID
 * A Container’s CPU limit
 * A container’s CPU request
 * A Container’s memory limit


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/48125 supports pod's UID through Downward API. Update the doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4268)
<!-- Reviewable:end -->
