### PR TITLE
Remove link to the removed code in Kubernetes repo

### DIFF
--- a/_data/overrides.yml
+++ b/_data/overrides.yml
@@ -7,4 +7,3 @@ overrides:
 - path: docs/admin/kube-scheduler.md
 - path: docs/admin/kubelet.md
 - copypath: k8s/federation/docs/api-reference/ docs/federation/
-- copypath: k8s/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml docs/getting-started-guides/fluentd-gcp.yaml

--- a/docs/admin/cluster-large.md
+++ b/docs/admin/cluster-large.md
@@ -81,7 +81,7 @@ Note that these master node sizes are currently only set at cluster startup time
 
 To prevent memory leaks or other resource issues in [cluster addons](https://releases.k8s.io/{{page.githubbranch}}/cluster/addons) from consuming all the resources available on a node, Kubernetes sets resource limits on addon containers to limit the CPU and Memory resources they can consume (See PR [#10653](http://pr.k8s.io/10653/files) and [#10778](http://pr.k8s.io/10778/files)).
 
-For [example](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml):
+For example:
 
 ```yaml
   containers:


### PR DESCRIPTION
This code was removed in https://github.com/kubernetes/kubernetes/pull/44721 and it doesn't seem like the link is somehow useful there anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4285)
<!-- Reviewable:end -->
