### PR TITLE
Patch PR #4275

### DIFF
--- a/docs/user-guide/docker-cli-to-kubectl.md
+++ b/docs/user-guide/docker-cli-to-kubectl.md
@@ -13,7 +13,7 @@ In this doc, we introduce the Kubernetes command line for interacting with the a
 
 #### docker run
 
-How do I run an nginx Deployment and expose it to the world? Checkout [kubectl run](/docs/user-guide/kubectl/v1.7/#run).
+How do I run an nginx Deployment and expose it to the world? Checkout [kubectl run](/docs/user-guide/kubectl/{{page.version}}/#run).
 
 With docker:
 
@@ -34,7 +34,7 @@ deployment "nginx-app" created
 ```
 
 `kubectl run` creates a Deployment named "nginx-app" on Kubernetes cluster >= v1.2. If you are running older versions, it creates replication controllers instead.
-If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/user-guide/kubectl/v1.7/#run) for more details. 
+If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) for more details. 
 Note that `kubectl` commands will print the type and name of the resource created or mutated, which can then be used in subsequent commands. Now, we can expose a new Service with the deployment created above:
 
 ```shell
@@ -58,7 +58,7 @@ To destroy the Deployment (and its pods) you need to run `kubectl delete deploym
 
 #### docker ps
 
-How do I list what is currently running? Checkout [kubectl get](/docs/user-guide/kubectl/v1.7/#get).
+How do I list what is currently running? Checkout [kubectl get](/docs/user-guide/kubectl/{{page.version}}/#get).
 
 With docker:
 
@@ -78,7 +78,7 @@ nginx-app-5jyvm   1/1       Running   0          1h
 
 #### docker attach
 
-How do I attach to a process that is already running in a container?  Checkout [kubectl attach](/docs/user-guide/kubectl/v1.7/#attach)
+How do I attach to a process that is already running in a container?  Checkout [kubectl attach](/docs/user-guide/kubectl/{{page.version}}/#attach)
 
 With docker:
 
@@ -102,7 +102,7 @@ $ kubectl attach -it nginx-app-5jyvm
 
 #### docker exec
 
-How do I execute a command in a container? Checkout [kubectl exec](/docs/user-guide/kubectl/v1.7/#exec).
+How do I execute a command in a container? Checkout [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
 
 With docker:
 
@@ -145,7 +145,7 @@ For more information see [Getting a Shell to a Running Container](/docs/tasks/ku
 
 #### docker logs
 
-How do I follow stdout/stderr of a running process? Checkout [kubectl logs](/docs/user-guide/kubectl/v1.7/#logs).
+How do I follow stdout/stderr of a running process? Checkout [kubectl logs](/docs/user-guide/kubectl/{{page.version}}/#logs).
 
 
 With docker:
@@ -176,7 +176,7 @@ See [Logging and Monitoring Cluster Activity](/docs/concepts/cluster-administrat
 
 #### docker stop and docker rm
 
-How do I stop and delete a running process? Checkout [kubectl delete](/docs/user-guide/kubectl/v1.7/#delete).
+How do I stop and delete a running process? Checkout [kubectl delete](/docs/user-guide/kubectl/{{page.version}}/#delete).
 
 With docker
 
@@ -213,7 +213,7 @@ There is no direct analog of `docker login` in kubectl. If you are interested in
 
 #### docker version
 
-How do I get the version of my client and server? Checkout [kubectl version](/docs/user-guide/kubectl/v1.7/#version).
+How do I get the version of my client and server? Checkout [kubectl version](/docs/user-guide/kubectl/{{page.version}}/#version).
 
 With docker:
 
@@ -241,7 +241,7 @@ Server Version: version.Info{Major:"0", Minor:"21+", GitVersion:"v0.21.1-411-g32
 
 #### docker info
 
-How do I get miscellaneous info about my environment and configuration? Checkout [kubectl cluster-info](/docs/user-guide/kubectl/v1.7/#cluster-info).
+How do I get miscellaneous info about my environment and configuration? Checkout [kubectl cluster-info](/docs/user-guide/kubectl/{{page.version}}/#cluster-info).
 
 With docker:
 


### PR DESCRIPTION
Change explicit version numbers in URLs to use {{page.version}} variable instead. Long term fix for PR #4275.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4287)
<!-- Reviewable:end -->
