### PR TITLE
fix a bug in the example initializerconfiguration

### DIFF
--- a/docs/admin/extensible-admission-controllers.md
+++ b/docs/admin/extensible-admission-controllers.md
@@ -112,19 +112,18 @@ apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: InitializerConfiguration
 metadata:
   name: example-config
-spec:
-  initializers:
-    # the name needs to be fully qualified, i.e., containing at least two "."
-    - name: podimage.example.com
-      rules:
-        # apiGroups, apiVersion, resources all support wildcard "*".
-        # "*" cannot be mixed with non-wildcard.
-        - apiGroups:
-            - ""
-          apiVersions:
-            - v1
-          resources:
-            - pods
+initializers:
+  # the name needs to be fully qualified, i.e., containing at least two "."
+  - name: podimage.example.com
+    rules:
+      # apiGroups, apiVersion, resources all support wildcard "*".
+      # "*" cannot be mixed with non-wildcard.
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods
 ```
 
 Make sure that all expansions of the `<apiGroup, apiVersions, resources>` tuple


### PR DESCRIPTION
same as #4288, but created against the 1.7 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4289)
<!-- Reviewable:end -->
