### PR TITLE
Create nesting for Network Policy providers

### DIFF
--- a/_data/tasks.yml
+++ b/_data/tasks.yml
@@ -127,9 +127,11 @@ toc:
   - docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
   - docs/tasks/administer-cluster/safely-drain-node.md
   - docs/tasks/administer-cluster/declare-network-policy.md
-  - docs/tasks/administer-cluster/calico-network-policy.md
-  - docs/tasks/administer-cluster/romana-network-policy.md
-  - docs/tasks/administer-cluster/weave-network-policy.md
+  - title: Install Network Policy Provider
+    section:
+    - docs/tasks/administer-cluster/calico-network-policy.md
+    - docs/tasks/administer-cluster/romana-network-policy.md
+    - docs/tasks/administer-cluster/weave-network-policy.md
   - docs/tasks/administer-cluster/change-pv-reclaim-policy.md
   - docs/tasks/administer-cluster/configure-pod-disruption-budget.md
   - docs/tasks/administer-cluster/limit-storage-consumption.md


### PR DESCRIPTION
This helps shortening the /docs/tasks→Administer Cluster section by creating
a section for the current and future networking providers.

/cc @caseydavenport, @chrismarino, @bboreham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4300)
<!-- Reviewable:end -->
