### PR TITLE
Improve service type description

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -357,12 +357,12 @@ The default is `ClusterIP`.
 `Type` values and their behaviors are:
 
    * `ClusterIP`: Exposes the service on a cluster-internal IP. Choosing this value 
-     makes the service only reachable from within the cluster. This is the 
+     makes the service only reachable from within the pod. This is the 
      default `ServiceType`.
    * `NodePort`: Exposes the service on each Node's IP at a static port (the `NodePort`). 
      A `ClusterIP` service, to which the NodePort service will route, is automatically 
-     created.  You'll be able to contact the `NodePort` service, from outside the cluster, 
-     by requesting `<NodeIP>:<NodePort>`.
+     created.  You'll be able to contact the `NodePort` service, from outside the pod 
+     (but only reachable inside the cluster), by requesting `<NodeIP>:<NodePort>`.
    * `LoadBalancer`: Exposes the service externally using a cloud provider's load balancer. 
      `NodePort` and `ClusterIP` services, to which the external load balancer will route, 
      are automatically created.


### PR DESCRIPTION
**This is a...**
- [ ] Feature Request
- [x] Bug Report
 
**Problem:**

We ran into a situation where we had two pods (one running a node server and another running a redis database) and wanted to make one pod talk to each other.

Reading the service type documentation we understood that `ClusterIP` would be the configuration we should use because it says the service would be exposed inside the cluster only. But using this service type we were not able to reach the redis pod from the node pod. We then tried using the `NodePort` type (although we were concerned that the service would be exposed externally, since the documentation stated that). After deploying the application we found out that using `NodePort` didn't expose the service externally and we were able to reach the redis pod from the node pod as we expected.

**Proposed Solution:**

With this PR we want to make the documentation a little bit more clear on what to expect when using `NodePort` vs  `ClusterIP`.

Please let us know if our understanding is correct and if it this edit makes sense, thanks!

**Page to Update:**

https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4301)
<!-- Reviewable:end -->
