### PR TITLE
configure-aggregation-layer: remove proxy note

### DIFF
--- a/docs/tasks/access-kubernetes-api/configure-aggregation-layer.md
+++ b/docs/tasks/access-kubernetes-api/configure-aggregation-layer.md
@@ -34,7 +34,7 @@ Enable the aggregation layer via the following kube-apiserver flags. They may ha
     --proxy-client-cert-file=<path to aggregator proxy cert>
     --proxy-client-key-file=<path to aggregator proxy key>
 
-The [Kubernetes Architectural Roadmap](https://docs.google.com/a/google.com/document/d/1XkjVm4bOeiVkj-Xt1LgoGiqWsBfNozJ51dyI-ljzt1o/edit?usp=sharing) recommends not running kube-proxy on the master. If you follow this recommendation, then you must make sure that the system is enabled with the following apiserver flag. Again, this may have already been taken care of by your provider.
+If you are not running kube-proxy on a host running the API server then you must make sure that the system is enabled with the following apiserver flag:
 
     --enable-aggregator-routing=true
 


### PR DESCRIPTION
The referenced doc doesn't mention "kube-proxy" anywhere and I don't think this is a general best-practice in many environments. And even if it is the opinion doesn't help users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4306)
<!-- Reviewable:end -->
