### PR TITLE
fix nine 404 page in doc

### DIFF
--- a/docs/api-reference/v1.7/index.html
+++ b/docs/api-reference/v1.7/index.html
@@ -187,7 +187,7 @@ Appears In <a href="#podspec-v1-core">PodSpec</a> </aside>
 </tr>
 <tr>
 <td>securityContext <br /> <em><a href="#securitycontext-v1-core">SecurityContext</a></em></td>
-<td>Security options the pod should run with. More info: <a href="https://kubernetes.io/docs/concepts/policy/security-context/">https://kubernetes.io/docs/concepts/policy/security-context/</a> More info: <a href="https://git.k8s.io/community/contributors/design-proposals/security_context.md">https://git.k8s.io/community/contributors/design-proposals/security_context.md</a></td>
+<td>Security options the pod should run with. More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a> More info: <a href="https://git.k8s.io/community/contributors/design-proposals/security_context.md">https://git.k8s.io/community/contributors/design-proposals/security_context.md</a></td>
 </tr>
 <tr>
 <td>stdin <br /> <em>boolean</em></td>

--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -28,7 +28,7 @@ Pods become isolated by having a NetworkPolicy that selects them. Once there is 
 
 ## The `NetworkPolicy` Resource
 
-See the [api-reference](/docs/api-reference/networking/v1/definitions/#_v1_networkpolicy) for a full definition of the resource.
+See the [api-reference](/docs/api-reference/v1.7/#networkpolicy-v1-networking) for a full definition of the resource.
 
 An example `NetworkPolicy` might look like this:
 

--- a/docs/concepts/storage/persistent-volumes.md
+++ b/docs/concepts/storage/persistent-volumes.md
@@ -563,7 +563,7 @@ parameters:
   availability: nova
 ```
 
-* `type`: [VolumeType](http://docs.openstack.org/admin-guide/dashboard-manage-volumes.html) created in Cinder. Default is empty.
+* `type`: [VolumeType](https://docs.openstack.org/user-guide/dashboard-manage-volumes.html) created in Cinder. Default is empty.
 * `availability`: Availability Zone. If not specified, volumes are generally round-robin-ed across all active zones where Kubernetes cluster has a node.
 
 #### vSphere

--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -125,7 +125,7 @@ will then download and install the cluster database and control plane
 components. This may take several minutes.
 
 You can't run `kubeadm init` twice without tearing down the cluster in between
-([unless you're upgrading from v1.6 to v1.7](/docs/tasks/administer-cluster/kubeadm-upgrade-1-7.md)),
+([unless you're upgrading from v1.6 to v1.7](/docs/tasks/administer-cluster/kubeadm-upgrade-1-7)),
 see [Tear Down](#tear-down).
 
 The output should look like:

--- a/docs/tasks/configure-pod-container/configmap.md
+++ b/docs/tasks/configure-pod-container/configmap.md
@@ -39,7 +39,7 @@ The data source corresponds to a key-value pair in the ConfigMap, where
 * key = the file name or the key you provided on the command line, and 
 * value = the file contents or the literal value you provided on the command line.
  
-You can use [`kubectl describe`](docs/user-guide/kubectl/v1.6/#describe) or [`kubectl get`](docs/user-guide/kubectl/v1.6/#get) to retrieve information about a ConfigMap. The former shows a summary of the ConfigMap, while the latter returns the full contents of the ConfigMap.
+You can use [`kubectl describe`](/docs/user-guide/kubectl/v1.6/#describe) or [`kubectl get`](/docs/user-guide/kubectl/v1.6/#get) to retrieve information about a ConfigMap. The former shows a summary of the ConfigMap, while the latter returns the full contents of the ConfigMap.
 
 ### Create ConfigMaps from directories
 

--- a/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -1014,8 +1014,7 @@ Pod.
 
 Download the example above, and save it to a file named `webp.yaml`
 
-This manifest is identical to the one you 
-[downloaded above](creating-a-statefulset) except that the `.spec.podManagementPolicy` 
+This manifest is identical to the one you downloaded above except that the `.spec.podManagementPolicy` 
 of the `web` StatefulSet is set to `Parallel`.
 
 In one terminal, watch the Pods in the StatefulSet.

--- a/docs/tutorials/stateful-application/cassandra.md
+++ b/docs/tutorials/stateful-application/cassandra.md
@@ -48,7 +48,7 @@ computer.
 
 ## Cassandra Docker
 
-The pods use the [```gcr.io/google-samples/cassandra:v12```](image/Dockerfile)
+The pods use the [```gcr.io/google-samples/cassandra:v12```](https://github.com/kubernetes/examples/blob/master/cassandra/image/Dockerfile)
 image from Google's [container registry](https://cloud.google.com/container-registry/docs/).
 The docker is based on `debian:jessie` and includes OpenJDK 8. This image
 includes a standard Cassandra installation from the Apache Debian repo.  Through the use of environment variables you are able to change values that are inserted into the `cassandra.yaml`.
@@ -835,7 +835,7 @@ via a replication control or a daemonset, you will need to use the custom seed p
 In Cassandra, a `SeedProvider` bootstraps the gossip protocol that Cassandra uses to find other
 Cassandra nodes. Seed addresses are hosts deemed as contact points. Cassandra
 instances use the seed list to find each other and learn the topology of the
-ring. The [`KubernetesSeedProvider`](java/src/main/java/io/k8s/cassandra/KubernetesSeedProvider.java)
+ring. The [`KubernetesSeedProvider`](https://github.com/kubernetes/kubernetes/blob/master/examples/storage/cassandra/java/src/main/java/io/k8s/cassandra/KubernetesSeedProvider.java)
 discovers Cassandra seeds IP addresses via the Kubernetes API, those Cassandra
 instances are defined within the Cassandra Service.
 
@@ -843,7 +843,7 @@ Refer to the custom seed provider [README](https://git.k8s.io/examples/cassandra
 `KubernetesSeedProvider` configurations. For this example you should not need
 to customize the Seed Provider configurations.
 
-See the [image](image/) directory of this example for specifics on
+See the [image](https://github.com/kubernetes/examples/tree/master/cassandra/image) directory of this example for specifics on
 how the container docker image was built and what it contains.
 
 You may also note that we are setting some Cassandra parameters (`MAX_HEAP_SIZE`

--- a/docs/tutorials/stateful-application/zookeeper.md
+++ b/docs/tutorials/stateful-application/zookeeper.md
@@ -726,7 +726,7 @@ container to rotate and ship your logs.
 The best practices with respect to allowing an application to run as a privileged 
 user inside of a container are a matter of debate. If your organization requires 
 that applications be run as a non-privileged user you can use a 
-[SecurityContext](/docs/concepts/policy/security-context/) to control the user that 
+[SecurityContext](/docs/tasks/configure-pod-container/security-context/) to control the user that 
 the entry point runs as.
 
 The `zk` StatefulSet's Pod `template` contains a SecurityContext.


### PR DESCRIPTION
I wrote a crawl to fetch all invalid herf in website: https://kubernetes.io/docs/
my crawl: http://paste.openstack.org/show/614826/
Fix nine of them first.
~~I will fix others if there are.~~ (I may fix part of them, but I need some help)

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4330)
<!-- Reviewable:end -->
