### PR TITLE
selector does not need to match metadata.labels

### DIFF
--- a/docs/concepts/workloads/controllers/deployment.md
+++ b/docs/concepts/workloads/controllers/deployment.md
@@ -799,8 +799,7 @@ allowed, which is the default if not specified.
 `.spec.selector` is an optional field that specifies a [label selector](/docs/concepts/overview/working-with-objects/labels/)
 for the Pods targeted by this deployment.
 
-If specified, `.spec.selector` must match `.spec.template.metadata.labels`, or it will be rejected by
-the API.  If `.spec.selector` is unspecified, `.spec.selector.matchLabels` will be defaulted to
+If `.spec.selector` is unspecified, `.spec.selector.matchLabels` will be defaulted to
 `.spec.template.metadata.labels`.
 
 Deployment may kill Pods whose labels match the selector, in the case that their template is different


### PR DESCRIPTION
I don't think it's the case that if specified, `.spec.selector` must match `.spec.template.metadata.labels`, or it will be rejected by the API.

This stackoverflow question is a good example of why you might want them different: https://stackoverflow.com/a/39474037/42754

----

Fixes https://github.com/kubernetes/kubernetes.github.io/issues/4346

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4348)
<!-- Reviewable:end -->
