### PR TITLE
Fix typo in NetworkPolicy example

### DIFF
--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -51,7 +51,7 @@ spec:
         matchLabels:
           role: frontend
     ports:
-    - protocol: tcp
+    - protocol: TCP
       port: 6379
 ```
 


### PR DESCRIPTION
The given example results in:
```
The NetworkPolicy "test-network-policy" is invalid: spec.ingress[0].ports[0].protocol: Unsupported value: "tcp": supported values: TCP, UDP
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4362)
<!-- Reviewable:end -->
