### PR TITLE
Fix unresolvable element

### DIFF
--- a/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -133,7 +133,7 @@ ReplicationController will think that those pods were created by it.  Kubernetes
 from doing this.
 
 If you do end up with multiple controllers that have overlapping selectors, you
-will have to manage the deletion yourself (see [below](#updating-a-replication-controller)).
+will have to manage the deletion yourself (see [below](#working-with-replicationcontrollers)).
 
 ### Multiple Replicas
 


### PR DESCRIPTION
The incorrect element pointer gives an error,
cannot resolve element with id updating-a-replication-controller, with a
broken link. Fix it.

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4365)
<!-- Reviewable:end -->
