### PR TITLE
Fix name of ConfigMap in example

### DIFF
--- a/docs/tasks/configure-pod-container/configmap.md
+++ b/docs/tasks/configure-pod-container/configmap.md
@@ -77,7 +77,7 @@ ui.properties:          83 bytes
 The `game.properties` and `ui.properties` files in the `docs/user-guide/configmap/kubectl/` directory are represented in the `data` section of the ConfigMap.
 
 ```shell
-kubectl get configmaps game-config-2 -o yaml
+kubectl get configmaps game-config -o yaml
 ```
 
 ```yaml
@@ -99,7 +99,7 @@ data:
 kind: ConfigMap
 metadata:
   creationTimestamp: 2016-02-18T18:52:05Z
-  name: game-config-2
+  name: game-config
   namespace: default
   resourceVersion: "516"
   selfLink: /api/v1/namespaces/default/configmaps/game-config-2


### PR DESCRIPTION
The docs tell the reader to get a ConfigMap with the name `game-config-2`, but only one ConfigMap had been made in the documentation thus far, `game-config`. `game-config-2` is created in the next section. This PR simply changes the name of that ConfigMap to the only existing ConfigMap if the reader follows the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4379)
<!-- Reviewable:end -->
