### PR TITLE
Change big to large to avoid awkward verbiage

### DIFF
--- a/docs/concepts/architecture/nodes.md
+++ b/docs/concepts/architecture/nodes.md
@@ -141,7 +141,7 @@ ConditionUnknown and 5m after that to start evicting pods.) The node controller
 checks the state of each node every `--node-monitor-period` seconds.
 
 In Kubernetes 1.4, we updated the logic of the node controller to better handle
-cases when a big number of nodes have problems with reaching the master
+cases when a large number of nodes have problems with reaching the master
 (e.g. because the master has networking problem). Starting with 1.4, the node
 controller will look at the state of all nodes in the cluster when making a
 decision about pod eviction.


### PR DESCRIPTION
In canonical American English, "large" is generally used to describe the size of a number. This is purely a style change, but "large number of" is less awkward sounding than "big number of".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4384)
<!-- Reviewable:end -->
