### PR TITLE
Revert "add host paths to psp (#3971)"

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -35,7 +35,6 @@ administrator to control the following:
 | The use of host ports                                         | `hostPorts`                       |
 | The use of host's PID namespace                               | `hostPID`                         |
 | The use of host's IPC namespace                               | `hostIPC`                         |
-| The use of host paths                                         | [`allowedHostPaths`](#allowed-host-paths)    |
 | The SELinux context of the container                          | [`seLinux`](#selinux)             |
 | The user ID                                                   | [`runAsUser`](#runasuser)         |
 | Configuring allowable supplemental groups                     | [`supplementalGroups`](#supplementalgroups) |
@@ -128,10 +127,7 @@ configMap, downwardAPI, emptyDir, persistentVolumeClaim, secret, and projected.
 
 ### Host Network
  - *HostPorts*, default `empty`. List of `HostPortRange`, defined by `min`(inclusive) and `max`(inclusive), which define the allowed host ports.
-
-### Allowed Host Paths
- - *AllowedHostPaths* is a white list of allowed host path prefixes. Empty indicates that all host paths may be used.
-
+ 
 ## Admission
 
 _Admission control_ with `PodSecurityPolicy` allows for control over the


### PR DESCRIPTION
This reverts the changes from https://github.com/kubernetes/kubernetes.github.io/pull/3971 because support of `allowedHostPaths` field was also reverted from the Kubernetes (see https://github.com/kubernetes/kubernetes/pull/47851).

PTAL @pweil- @liggitt 
CC @simo5
@jhorwit2 @xilabao JFYI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4420)
<!-- Reviewable:end -->
