### PR TITLE
Turn env variables to upper case in the example.

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -119,8 +119,8 @@ Note: This functionality is available to users running Kubernetes v1.6 and later
      name: special-config
      namespace: default
    data:
-     special_level: very
-     special_type: charm
+     SPECIAL_LEVEL: very
+     SPECIAL_TYPE: charm
    ```
 
 1. Use `env-from` to define all of the ConfigMap's data as Pod environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.


### PR DESCRIPTION
As K8s won't change the env variable from configmap(using envFrom
to upper case, so change the variable names to upper case in the
example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4447)
<!-- Reviewable:end -->
