### PR TITLE
fix memorypressue and diskpressure descriptions

### DIFF
--- a/docs/concepts/architecture/nodes.md
+++ b/docs/concepts/architecture/nodes.md
@@ -54,8 +54,8 @@ The `conditions` field describes the status of all `Running` nodes.
 |----------------|-------------|
 | `OutOfDisk`    | `True` if there is insufficient free space on the node for adding new pods, otherwise `False` |
 | `Ready`        | `True` if the node is healthy and ready to accept pods, `False` if the node is not healthy and is not accepting pods, and `Unknown` if the node controller has not heard from the node in the last 40 seconds |
-| `MemoryPressure`    | `True` if node has no memory pressure, otherwise `False` |
-| `DiskPressure`    | `True` if node has no disk pressure, otherwise `False` |
+| `MemoryPressure`    | `True` if pressure exists on the node memory -- that is, if the node memory is low; otherwise `False` |
+| `DiskPressure`    | `True` if pressure exists on the disk size -- that is, if the disk capacity is low; otherwise `False` |
 
 The node condition is represented as a JSON object. For example, the following response describes a healthy node.
 


### PR DESCRIPTION
Clarified descriptions for node conditions.

Fixes issue #4357 

Additional Q: would it be useful to link from this location in the doc to this? https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/#kubelet-may-not-observe-memory-pressure-right-away

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4455)
<!-- Reviewable:end -->
