### PR TITLE
fix broken link to concepts topic

### DIFF
--- a/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/docs/tasks/administer-cluster/declare-network-policy.md
@@ -5,7 +5,7 @@ assignees:
 title: Declare Network Policy
 ---
 {% capture overview %}
-This document helps you get started using using the Kubernetes [NetworkPolicy API](/docs/concepts/services-networking/network-policies/) to declare network policies that govern how pods communicate with each other. 
+This document helps you get started using using the Kubernetes [NetworkPolicy API](/docs/concepts/services-networking/network-policies/) to declare network policies that govern how pods communicate with each other.
 {% endcapture %}
 
 {% capture prerequisites %}

--- a/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/docs/tasks/administer-cluster/declare-network-policy.md
@@ -5,7 +5,7 @@ assignees:
 title: Declare Network Policy
 ---
 {% capture overview %}
-This document helps you get started using using the Kubernetes [NetworkPolicy API](/docs/user-guide/network-policies) to declare network policies that govern how pods communicate with each other.
+This document helps you get started using using the Kubernetes [NetworkPolicy API](/docs/concepts/services-networking/network-policies/) to declare network policies that govern how pods communicate with each other. 
 {% endcapture %}
 
 {% capture prerequisites %}


### PR DESCRIPTION
Update link to related concepts topic

Fixes issue #4456 

Q (biggish): when we're in these topics where there are redirects from the earlier docs architecture, would it be useful to update the original links? I found myself tripping a bit over some of the other redirected links in this topic (found the redirects eventually, but maybe it would help future contributors if we fixed the source as we go?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4471)
<!-- Reviewable:end -->
