### PR TITLE
add links about ports and firewalls

### DIFF
--- a/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -99,11 +99,14 @@ provides load balancing for an application that has two running instances.
    see the node address by running `kubectl cluster-info`. If you are
    using Google Compute Engine instances, you can use the
    `gcloud compute instances list` command to see the public addresses of your
-   nodes.
+   nodes. For more information about this command, see the [GCE documentation](https://cloud.google.com/sdk/gcloud/reference/compute/instances/list). 
 
 1. On your chosen node, create a firewall rule that allows TCP traffic
    on your node port. For example, if your Service has a NodePort value of
-   31568, create a firewall rule that allows TCP traffic on port 31568.
+   31568, create a firewall rule that allows TCP traffic on port 31568. Different 
+   cloud providers offer different ways of configuring firewall rules. See [the 
+   GCE documentation on firewall rules](https://cloud.google.com/compute/docs/vpc/firewalls), 
+   for example.
 
 1. Use the node address and node port to access the Hello World application:
 


### PR DESCRIPTION
Links added to:
- doc for `gcloud compute instances list`
- GCE on firewall rules. This topic is GCP-specific, but also offers a nice overview of firewall rules. A better solution down the road might be to update this existing K8s topic and link to it: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
but that's a bigger fix. AWS is pretty opaque about firewall customization from what I can see, for example (mostly third-party tools?)

Fixes issue #4440

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4485)
<!-- Reviewable:end -->
