### PR TITLE
Update extensible-admission-controllers.md

### DIFF
--- a/docs/admin/extensible-admission-controllers.md
+++ b/docs/admin/extensible-admission-controllers.md
@@ -81,7 +81,7 @@ perform its assigned task and remove its name from the list.
 *Initializers* is an alpha feature, so it is disabled by default. To turn it on,
 you need to:
 
-* Include "Initializer" in the `--admission-control` flag when starting
+* Include "Initializers" in the `--admission-control` flag when starting
   `kube-apiserver`. If you have multiple `kube-apiserver` replicas, all should
   have the same flag setting.
 


### PR DESCRIPTION
The correct name of the initializer admission controller is ```Initializers"``` (plural).

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to  
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4488)
<!-- Reviewable:end -->
