### PR TITLE
Remove the alpha storage-class annotation.

### DIFF
--- a/docs/tutorials/stateful-application/zookeeper.yaml
+++ b/docs/tutorials/stateful-application/zookeeper.yaml
@@ -150,8 +150,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:


### PR DESCRIPTION
This doesn't work when run in beta storage class clusters.

Ref https://github.com/kubernetes/minikube/issues/956

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4532)
<!-- Reviewable:end -->
