### PR TITLE
Adding Callouts to Docs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
     {% if page.case_study_styles %}<link rel="stylesheet" type="text/css" href="/css/case_study_styles.css"><!-- custom case_study_styles on -->{% else %}<link rel="stylesheet" type="text/css" href="/css/styles.css"><!-- default styles.css on -->{% endif %}
     <link rel="stylesheet" type="text/css" href="/css/jquery-ui.min.css">
     <link rel="stylesheet" type="text/css" href="/css/sweetalert.css">
-    link rel="stylesheet" type="text/css" href="/css/callouts.css">
+    <link rel="stylesheet" type="text/css" href="/css/callouts.css">
     {% if page.class == "gridPage" %}<link rel="stylesheet" type="text/css" href="/css/gridpage.css">{% endif %}
     {% if page.css %}<link rel="stylesheet" type="text/css" href="{{ page.css }}"><!-- custom css added -->{% else %}<!-- no custom css detected -->{% endif %}
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,7 @@
     {% if page.case_study_styles %}<link rel="stylesheet" type="text/css" href="/css/case_study_styles.css"><!-- custom case_study_styles on -->{% else %}<link rel="stylesheet" type="text/css" href="/css/styles.css"><!-- default styles.css on -->{% endif %}
     <link rel="stylesheet" type="text/css" href="/css/jquery-ui.min.css">
     <link rel="stylesheet" type="text/css" href="/css/sweetalert.css">
+    link rel="stylesheet" type="text/css" href="/css/callouts.css">
     {% if page.class == "gridPage" %}<link rel="stylesheet" type="text/css" href="/css/gridpage.css">{% endif %}
     {% if page.css %}<link rel="stylesheet" type="text/css" href="{{ page.css }}"><!-- custom css added -->{% else %}<!-- no custom css detected -->{% endif %}
 

--- a/css/callouts.css
+++ b/css/callouts.css
@@ -1,4 +1,4 @@
-.note, .info, .caution, .warning {
+.caution, .info, .note, .warning {
     padding: 20px;
     margin: 20px 0;
     border: 1px solid #eee;
@@ -6,16 +6,16 @@
     border-radius: 3px;
 }
 
-.note {
-    border-left-color: #428bca;
+.caution {
+    border-left-color: #f0ad4e;
 }
 
 .info {
      border-left-color: #5cb85c;
 }
 
-.caution {
-    border-left-color: #f0ad4e;
+.note {
+    border-left-color: #428bca;
 }
 
 .warning {

--- a/css/callouts.css
+++ b/css/callouts.css
@@ -1,4 +1,4 @@
-.caution, .info, .note, .warning {
+.caution, .note, .warning {
     padding: 20px;
     margin: 20px 0;
     border: 1px solid #eee;
@@ -8,10 +8,6 @@
 
 .caution {
     border-left-color: #f0ad4e;
-}
-
-.info {
-     border-left-color: #5cb85c;
 }
 
 .note {

--- a/css/callouts.css
+++ b/css/callouts.css
@@ -1,0 +1,23 @@
+.note, .info, .caution, .warning {
+    padding: 20px;
+    margin: 20px 0;
+    border: 1px solid #eee;
+    border-left-width: 5px;
+    border-radius: 3px;
+}
+
+.note {
+    border-left-color: #428bca;
+}
+
+.info {
+     border-left-color: #5cb85c;
+}
+
+.caution {
+    border-left-color: #f0ad4e;
+}
+
+.warning {
+    border-left-color: #d9534f;
+}

--- a/docs/home/contribute/style-guide.md
+++ b/docs/home/contribute/style-guide.md
@@ -137,6 +137,59 @@ A list of Kubernetes-specific terms and words to be used consistently across the
   <tr><td>TBD</td><td>TBD</td></tr>
 </table>{% endcomment %}
 
+## Callout Formatting
+Callouts help create different rhetorical appeal levels. Our documentation supports three different callouts: note, caution, and warning. 
+
+Use the following syntax to apply style:
+
+```console
+**Note:** This is my note. 
+{: .note}
+```
+
+The output is:
+
+**Note:** This is my note. 
+{: .note}
+
+Callouts should generally be single sentences but can span multiple lines if you use ```<br/>``` tags.
+
+```console
+**Note:"** This is my note. Use ```<br/>``` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
+{: .note}
+```
+
+The output is:
+
+**Note:** This is my note. Use ```<br/>``` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
+{: .note}
+
+Trying to use regular Markdown with multiple lines will **not** work.
+{: .warning}
+
+```console
+**Note:** This is my note. 
+
+I didn't read the stlye guide.
+{: .note}
+```
+
+**Note** This is my note. 
+
+I didn't read the stlye guide.
+{: .note}
+
+### Note
+
+Use {: .note} to highlight a tip or a piece of information that may be helpful to know. 
+
+### Caution
+
+Use {: .caution} to call attention to an important piece of information to avoid pitfalls.  
+
+### Warning
+
+Use {: .warning} to indicate danger or a piece of information that is crucial to follow.
 
 ## Content best practices
 

--- a/docs/home/contribute/style-guide.md
+++ b/docs/home/contribute/style-guide.md
@@ -138,58 +138,110 @@ A list of Kubernetes-specific terms and words to be used consistently across the
 </table>{% endcomment %}
 
 ## Callout Formatting
-Callouts help create different rhetorical appeal levels. Our documentation supports three different callouts: note, caution, and warning. 
+Callouts help create different rhetorical appeal levels. Our documentation supports three different callouts: note {: ,note}, caution {: .caution}, and warning {: .warning}. 
 
-Use the following syntax to apply style:
+1. Start each callout with the appropriate prefix.
+
+2. Use the following syntax to apply a style:
 
 ```console
-**Note:** This is my note. 
-{: .note}
+**Note:** The prefix you use is the same text you use in the tag. 
+{: .note} 
 ```
 
 The output is:
 
-**Note:** This is my note. 
-{: .note}
-
-Callouts should generally be single sentences but can span multiple lines if you use ```<br/>``` tags.
-
-```console
-**Note:"** This is my note. Use ```<br/>``` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
-{: .note}
-```
-
-The output is:
-
-**Note:** This is my note. Use ```<br/>``` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
-{: .note}
-
-Trying to use regular Markdown with multiple lines will **not** work.
-{: .warning}
-
-```console
-**Note:** This is my note. 
-
-I didn't read the stlye guide.
-{: .note}
-```
-
-**Note** This is my note. 
-
-I didn't read the stlye guide.
+**Note:** The prefix you choose is the same text for the tag.
 {: .note}
 
 ### Note
 
 Use {: .note} to highlight a tip or a piece of information that may be helpful to know. 
 
+For example:
+
+```console
+**Note:** You can _still_ use ~Markdown~ inside these callouts. 
+{: .note}
+```
+
+The output is:
+
+**Note:** You can _still_ use ~Markdown~ inside these callouts.
+{: .note}
+
 ### Caution
 
 Use {: .caution} to call attention to an important piece of information to avoid pitfalls.  
 
+For example:
+
+```console
+**Caution:** Each tag must be on a new line to apply the style. 
+{: .caution}
+```
+
+The output is:
+
+**Caution:** Each tag must be on a new line to apply the style. 
+{: .caution}
+
 ### Warning
 
 Use {: .warning} to indicate danger or a piece of information that is crucial to follow.
+
+For example:
+
+```console
+**Warning:** Beware. 
+{: .warning}
+```
+
+The output is:
+
+**Warning:** Beware. 
+{: .warning}
+
+## Common Callout Issues
+
+### Style Does Not Apply
+
+Callout tags must be on a new line to apply the style. Github's Preview Changes feature further obfuscates this fact by rendering the tag on the same line, but your code must match the following syntax:
+
+```console
+**Note:** Your text goes here.
+{: .note} <!-- This tag must appear on a new line. -->
+```
+
+### Multiple Lines
+
+Callouts should generally be single sentences and automatically span multiple lines. However, you can use `<br/>` tags if you need to create multiple lines.
+
+For example:
+
+```console
+**Note:"** This is my note. Use `<br/>` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
+{: .note}
+```
+
+The output is:
+
+**Note:** This is my note. Use `<br/>` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
+{: .note}
+
+Typing multiple lines does **not** work. The callout style only applies to the line directly above the tag. 
+
+```console
+**Note:** This is my note. 
+
+I didn't read the stlye guide.
+{: .note}
+```
+
+**Note:** This is my note. 
+
+I didn't read the stlye guide.
+{: .note}
 
 ## Content best practices
 

--- a/docs/home/contribute/style-guide.md
+++ b/docs/home/contribute/style-guide.md
@@ -138,7 +138,7 @@ A list of Kubernetes-specific terms and words to be used consistently across the
 </table>{% endcomment %}
 
 ## Callout Formatting
-Callouts help create different rhetorical appeal levels. Our documentation supports three different callouts: note {: ,note}, caution {: .caution}, and warning {: .warning}. 
+Callouts help create different rhetorical appeal levels. Our documentation supports three different callouts: **Note:** {: .note}, **Caution:** {: .caution}, and **Warning:** {: .warning}. 
 
 1. Start each callout with the appropriate prefix.
 
@@ -146,7 +146,7 @@ Callouts help create different rhetorical appeal levels. Our documentation suppo
 
 ```console
 **Note:** The prefix you use is the same text you use in the tag. 
-{: .note} 
+{: .note} <!-- This tag must appear on a new line. -->
 ```
 
 The output is:
@@ -161,13 +161,13 @@ Use {: .note} to highlight a tip or a piece of information that may be helpful t
 For example:
 
 ```console
-**Note:** You can _still_ use ~Markdown~ inside these callouts. 
+**Note:** You can _still_ use Markdown inside these callouts. 
 {: .note}
 ```
 
 The output is:
 
-**Note:** You can _still_ use ~Markdown~ inside these callouts.
+**Note:** You can _still_ use Markdown inside these callouts.
 {: .note}
 
 ### Caution
@@ -177,13 +177,13 @@ Use {: .caution} to call attention to an important piece of information to avoid
 For example:
 
 ```console
-**Caution:** Each tag must be on a new line to apply the style. 
+**Caution:** The callout style only applies to the line directly above the tag. 
 {: .caution}
 ```
 
 The output is:
 
-**Caution:** Each tag must be on a new line to apply the style. 
+**Caution:** The callout style only applies to the line directly above the tag. 
 {: .caution}
 
 ### Warning
@@ -220,13 +220,13 @@ Callouts should generally be single sentences and automatically span multiple li
 For example:
 
 ```console
-**Note:"** This is my note. Use `<br/>` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
+**Note:"** This is my note. Use `<br/>` to create multiple lines. <br/> <br/> You can still use _Markdown_ to **format** text!
 {: .note}
 ```
 
 The output is:
 
-**Note:** This is my note. Use `<br/>` to create multiple lines. <br/> <br/> **You** can still use _Markdown_ to ~format text~!
+**Note:** This is my note. Use `<br/>` to create multiple lines. <br/> <br/> You can still use _Markdown_ to **format** text!
 {: .note}
 
 Typing multiple lines does **not** work. The callout style only applies to the line directly above the tag. 


### PR DESCRIPTION
This uses kramdown syntax to apply a .class in Markdown. It lets us avoid using liquid tags and makes more semantic sense. For example, a note is {: .note} and a warning is {. warning}.

I removed the .note::before, etc lines to automatically insert labels that my demo included to avoid potential confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4535)
<!-- Reviewable:end -->
