### PR TITLE
Minor fix in example resource limit policy

### DIFF
--- a/docs/tasks/administer-cluster/cpu-memory-limit.md
+++ b/docs/tasks/administer-cluster/cpu-memory-limit.md
@@ -210,8 +210,8 @@ to 512MB of memory.  The cluster operator creates a separate namespace for each 
 each namespace.
 3. Users may create a pod which consumes resources just below the capacity of a machine.  The left over space
 may be too small to be useful, but big enough for the waste to be costly over the entire cluster.  As a result,
-the cluster operator may want to set limits that a pod must consume at least 20% of the memory and CPU of their
-average node size in order to provide for more uniform scheduling and limit waste.
+the cluster operator may want to set limits that a pod must consume no more than 20% of the memory and CPU of
+their average node size in order to provide for more uniform scheduling and limit waste.
 
 ## Summary
 


### PR DESCRIPTION
Looks like 

```
the cluster operator may want to set limits that a pod must consume at least 20% of the memory and CPU
```

was meant to be 

```
the cluster operator may want to set limits that a pod must consume no more than 20% of the memory and CPU
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4543)
<!-- Reviewable:end -->
