### PR TITLE
fix a typo in extensible-admission-controllers

### DIFF
--- a/docs/admin/extensible-admission-controllers.md
+++ b/docs/admin/extensible-admission-controllers.md
@@ -279,5 +279,5 @@ and `Fail` policies, meaning that upon a communication error with the webhook
 admission controller, the `GenericAdmissionWebhook` can admit or reject the
 operation based on the configured policy.
 
-After you create the `initializerConfiguration`, the system will take a few
+After you create the `externalAdmissionHookConfiguration`, the system will take a few
 seconds to honor the new configuration.


### PR DESCRIPTION
Fix a copy-and-paste typo in `ExternalAdmissionHookConfiguration` section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4554)
<!-- Reviewable:end -->
