### PR TITLE
Fix spacing with shell commands

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -195,6 +195,7 @@ or pass the context on each command like this: `kubectl get pods --context=minik
 ### Dashboard
 
 To access the [Kubernetes Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/), run this command in a shell after starting minikube to get the address:
+
 ```shell
 minikube dashboard
 ```
@@ -202,6 +203,7 @@ minikube dashboard
 ### Services
 
 To access a service exposed via a node port, run this command in a shell after starting minikube to get the address:
+
 ```shell
 minikube service [-n NAMESPACE] [--url] NAME
 ```


### PR DESCRIPTION
In order to render the markdown for some of the shell commands in the Minikube getting started guide, you need an empty line above the `shell` code blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4608)
<!-- Reviewable:end -->
