### PR TITLE
encrypt-data.md: update all secrets in all namespaces

### DIFF
--- a/docs/tasks/administer-cluster/encrypt-data.md
+++ b/docs/tasks/administer-cluster/encrypt-data.md
@@ -148,7 +148,7 @@ program to retrieve the contents of your secret.
 Since secrets are encrypted on write, performing an update on a secret will encrypt that content.
 
 ```
-kubectl get secrets -o json | kubectl replace -f -
+kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 ```
 
 The command above reads all secrets and then updates them to apply server side encryption.


### PR DESCRIPTION
When doc talks about "all secrets" it should update really "all secrets in all namespaces". Otherwise [it could confuse users](https://github.com/kubernetes/kubernetes/issues/49565#issuecomment-319704506).

PTAL @smarterclayton @liggitt 
CC @simo5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4620)
<!-- Reviewable:end -->
