### PR TITLE
Fix leading spaces in kubectl commands

### DIFF
--- a/docs/home/contribute/style-guide.md
+++ b/docs/home/contribute/style-guide.md
@@ -46,7 +46,7 @@ represents.
 
 1. Display information about a pod:
 
-        kubectl describe pod <pod-name>
+       kubectl describe pod <pod-name>
 
     where `<pod-name>` is the name of one of your pods.
 

--- a/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
@@ -32,11 +32,11 @@ load-balanced access to an application running in a cluster.
 
 1. Run a Hello World application in your cluster:
 
-        kubectl run hello-world --replicas=2 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+       kubectl run hello-world --replicas=2 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 
 1. List the pods that are running the Hello World application:
 
-        kubectl get pods --selector="run=load-balancer-example"
+       kubectl get pods --selector="run=load-balancer-example"
 
     The output is similar to this:
 
@@ -46,7 +46,7 @@ load-balanced access to an application running in a cluster.
 
 1. List the replica set for the two Hello World pods:
 
-        kubectl get replicasets --selector="run=load-balancer-example"
+       kubectl get replicasets --selector="run=load-balancer-example"
 
     The output is similar to this:
 
@@ -55,13 +55,13 @@ load-balanced access to an application running in a cluster.
 
 1. Create a Service object that exposes the replica set:
 
-        kubectl expose rs <your-replica-set-name> --type="LoadBalancer" --name="example-service"
+       kubectl expose rs <your-replica-set-name> --type="LoadBalancer" --name="example-service"
 
     where `<your-replica-set-name>` is the name of your replica set.
 
 1. Display the IP addresses for your service:
 
-        kubectl get services example-service
+       kubectl get services example-service
 
    The output shows the internal IP address and the external IP address of
    your service. If the external IP address shows as `<pending>`, repeat the
@@ -86,8 +86,8 @@ load-balanced access to an application running in a cluster.
 
     Note: If you are using Minikube, enter these commands:
 
-        kubectl cluster-info
-        kubectl describe services example-service
+       kubectl cluster-info
+       kubectl describe services example-service
 
     The output displays the IP address of your Minikube node and the NodePort
     value for your service. Then enter this command to access the Hello World

--- a/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -26,7 +26,7 @@ for database debugging.
 
 1. Create a pod:
 
-        kubectl create -f https://k8s.io/docs/tasks/access-application-cluster/redis-master.yaml
+       kubectl create -f https://k8s.io/docs/tasks/access-application-cluster/redis-master.yaml
 
     The output of a successful command verifies that the pod was created:
 
@@ -34,7 +34,7 @@ for database debugging.
 
 1. Check to see whether the pod is running and ready:
 
-        kubectl get pods
+       kubectl get pods
 
     When the pod is ready, the output displays a STATUS of Running:
 
@@ -44,7 +44,7 @@ for database debugging.
 1. Verify that the Redis server is running in the pod and listening on port 6379:
 
         {% raw %}
-        kubectl get pods redis-master --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+       kubectl get pods redis-master --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
         {% endraw %}
 
     The output displays the port:
@@ -55,7 +55,7 @@ for database debugging.
 
 1. Forward port 6379 on the local workstation to port 6379 of redis-master pod:
 
-        kubectl port-forward redis-master 6379:6379
+       kubectl port-forward redis-master 6379:6379
 
     The output is similar to this:
 

--- a/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -33,7 +33,7 @@ provides load balancing for an application that has two running instances.
 
 1. Run a Hello World application in your cluster:
 
-        kubectl run hello-world --replicas=2 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+       kubectl run hello-world --replicas=2 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 
     The preceding command creates a
     [Deployment](/docs/concepts/workloads/controllers/deployment/)
@@ -45,21 +45,21 @@ provides load balancing for an application that has two running instances.
 
 1. Display information about the Deployment:
 
-        kubectl get deployments hello-world
-        kubectl describe deployments hello-world
+       kubectl get deployments hello-world
+       kubectl describe deployments hello-world
 
 1. Display information about your ReplicaSet objects:
 
-        kubectl get replicasets
-        kubectl describe replicasets
+       kubectl get replicasets
+       kubectl describe replicasets
 
 1. Create a Service object that exposes the deployment:
 
-        kubectl expose deployment hello-world --type=NodePort --name=example-service
+       kubectl expose deployment hello-world --type=NodePort --name=example-service
 
 1. Display information about the Service:
 
-        kubectl describe services example-service
+       kubectl describe services example-service
 
     The output is similar to this:
 
@@ -80,7 +80,7 @@ provides load balancing for an application that has two running instances.
 
 1. List the pods that are running the Hello World application:
 
-        kubectl get pods --selector="run=load-balancer-example" --output=wide
+       kubectl get pods --selector="run=load-balancer-example" --output=wide
 
     The output is similar to this:
 

--- a/docs/tasks/access-kubernetes-api/http-proxy-access-api.md
+++ b/docs/tasks/access-kubernetes-api/http-proxy-access-api.md
@@ -13,7 +13,7 @@ This page shows how to use an HTTP proxy to access the Kubernetes API.
 * If you do not already have an application running in your cluster, start
   a Hello world application by entering this command:
 
-        kubectl run node-hello --image=gcr.io/google-samples/node-hello:1.0 --port=8080
+       kubectl run node-hello --image=gcr.io/google-samples/node-hello:1.0 --port=8080
 
 {% endcapture %}
 

--- a/docs/tasks/administer-cluster/change-default-storage-class.md
+++ b/docs/tasks/administer-cluster/change-default-storage-class.md
@@ -38,7 +38,7 @@ for details about addon manager and how to disable individual addons.
 
 1. List the StorageClasses in your cluster:
 
-        kubectl get storageclass
+       kubectl get storageclass
 
     The output is similar to this:
 
@@ -56,7 +56,7 @@ for details about addon manager and how to disable individual addons.
 
    To mark a StorageClass as non-default, you need to change its value to `false`:
 
-        kubectl patch storageclass <your-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+       kubectl patch storageclass <your-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 
     where `<your-class-name>` is the name of your chosen StorageClass.
 
@@ -65,7 +65,7 @@ for details about addon manager and how to disable individual addons.
    Similarly to the previous step, you need to add/set the annotation
    `storageclass.kubernetes.io/is-default-class=true`.
 
-        kubectl patch storageclass <your-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+       kubectl patch storageclass <your-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
    Please note that at most one StorageClass can be marked as default. If two
    or more of them are marked as default, Kubernetes ignores the annotation,
@@ -73,7 +73,7 @@ for details about addon manager and how to disable individual addons.
 
 1. Verify that your chosen StorageClass is default:
 
-        kubectl get storageclass
+       kubectl get storageclass
 
     The output is similar to this:
 

--- a/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -31,7 +31,7 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 1. List the PersistentVolumes in your cluster:
 
-        kubectl get pv
+       kubectl get pv
 
     The output is similar to this:
 
@@ -45,13 +45,13 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 1. Chose one of your PersistentVolumes and change its reclaim policy:
 
-        kubectl patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+       kubectl patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 
     where `<your-pv-name>` is the name of your chosen PersistentVolume.
 
 1. Verify that your chosen PersistentVolume has the right policy:
 
-        kubectl get pv
+       kubectl get pv
 
     The output is similar to this:
 

--- a/docs/tasks/configure-pod-container/assign-cpu-ram-container.md
+++ b/docs/tasks/configure-pod-container/assign-cpu-ram-container.md
@@ -45,11 +45,11 @@ for the `Pod`:
 
 1. Create a Pod based on the YAML configuration file:
 
-        kubectl create -f https://k8s.io/docs/tasks/configure-pod-container/cpu-ram.yaml
+       kubectl create -f https://k8s.io/docs/tasks/configure-pod-container/cpu-ram.yaml
 
 1. Display information about the pod:
 
-        kubectl describe pod cpu-ram-demo
+       kubectl describe pod cpu-ram-demo
 
     The output is similar to this:
 

--- a/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -19,7 +19,7 @@ Kubernetes cluster.
 
 1. List the nodes in your cluster:
 
-        kubectl get nodes
+       kubectl get nodes
 
     The output is similar to this:
 
@@ -30,13 +30,13 @@ Kubernetes cluster.
 
 1. Chose one of your nodes, and add a label to it:
 
-        kubectl label nodes <your-node-name> disktype=ssd
+       kubectl label nodes <your-node-name> disktype=ssd
 
     where `<your-node-name>` is the name of your chosen node.
 
 1. Verify that your chosen node has a `disktype=ssd` label:
 
-        kubectl get nodes --show-labels
+       kubectl get nodes --show-labels
 
 
     The output is similar to this:
@@ -60,11 +60,11 @@ a `disktype=ssd` label.
 1. Use the configuration file to create a pod that will get scheduled on your
    chosen node:
 
-        kubectl create -f https://k8s.io/docs/tasks/configure-pod-container/pod.yaml
+       kubectl create -f https://k8s.io/docs/tasks/configure-pod-container/pod.yaml
 
 1. Verify that the pod is running on your chosen node:
 
-        kubectl get pods --output=wide
+       kubectl get pods --output=wide
 
     The output is similar to this:
 

--- a/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -24,22 +24,22 @@ Here is the configuration file for the Pod:
 
 1. Create the Secrets:
 
-        # Create files containing the username and password:
-        echo -n "admin" > ./username.txt
-        echo -n "1f2d1e2e67df" > ./password.txt
+       # Create files containing the username and password:
+       echo -n "admin" > ./username.txt
+       echo -n "1f2d1e2e67df" > ./password.txt
 
-        # Package these files into secrets:
-        kubectl create secret generic user --from-file=./username.txt
-        kubectl create secret generic pass --from-file=./password.txt
+       # Package these files into secrets:
+       kubectl create secret generic user --from-file=./username.txt
+       kubectl create secret generic pass --from-file=./password.txt
 
 1. Create the Pod:
 
-        kubectl create -f projected-volume.yaml
+       kubectl create -f projected-volume.yaml
 
 1. Verify that the Pod's Container is running, and then watch for changes to
 the Pod:
 
-        kubectl get --watch pod test-projected-volume
+       kubectl get --watch pod test-projected-volume
 
     The output looks like this:
 
@@ -48,11 +48,11 @@ the Pod:
 
 1. In another terminal, get a shell to the running Container:
 
-        kubectl exec -it test-projected-volume -- /bin/sh
+       kubectl exec -it test-projected-volume -- /bin/sh
 
 1. In your shell, verify that the `projected-volume` directory contains your projected sources:
 
-        / # ls /projected-volume/
+       / # ls /projected-volume/
 {% endcapture %}
 
 {% capture whatsnext %}

--- a/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -45,8 +45,8 @@ case you can try several things:
     command. Here are some example command lines that extract just the necessary
     information:
 
-        kubectl get nodes -o yaml | grep '\sname\|cpu\|memory'
-        kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, cap: .status.capacity}'
+       kubectl get nodes -o yaml | grep '\sname\|cpu\|memory'
+       kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, cap: .status.capacity}'
 
   The [resource quota](/docs/concepts/policy/resource-quotas/)
   feature can be configured to limit the total amount of

--- a/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -37,7 +37,7 @@ the container starts.
 
 1. Create a Pod based on the YAML configuration file:
 
-        kubectl create -f https://k8s.io/docs/tasks/debug-application-cluster/termination.yaml
+       kubectl create -f https://k8s.io/docs/tasks/debug-application-cluster/termination.yaml
 
     In the YAML file, in the `cmd` and `args` fields, you can see that the
     container sleeps for 10 seconds and then writes "Sleep expired" to
@@ -46,13 +46,13 @@ the container starts.
 
 1. Display information about the Pod:
 
-        kubectl get pod termination-demo
+       kubectl get pod termination-demo
 
     Repeat the preceding command until the Pod is no longer running.
 
 1. Display detailed information about the Pod:
 
-        kubectl get pod --output=yaml
+       kubectl get pod --output=yaml
 
     The output includes the "Sleep expired" message:
 

--- a/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -39,11 +39,11 @@ file for the Pod defines a command and two arguments:
 
 1. Create a Pod based on the YAML configuration file:
 
-        kubectl create -f https://k8s.io/docs/tasks/inject-data-application/commands.yaml
+       kubectl create -f https://k8s.io/docs/tasks/inject-data-application/commands.yaml
 
 1. List the running Pods:
 
-        kubectl get pods
+       kubectl get pods
 
     The output shows that the container that ran in the command-demo Pod has
     completed.
@@ -51,7 +51,7 @@ file for the Pod defines a command and two arguments:
 1. To see the output of the command that ran in the container, view the logs
 from the Pod:
 
-        kubectl logs command-demo
+       kubectl logs command-demo
 
     The output shows the values of the HOSTNAME and KUBERNETES_PORT environment
     variables:

--- a/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -34,11 +34,11 @@ Pod:
 
 1. Create a Pod based on the YAML configuration file:
 
-        kubectl create -f https://k8s.io/docs/tasks/inject-data-application/envars.yaml
+       kubectl create -f https://k8s.io/docs/tasks/inject-data-application/envars.yaml
 
 1. List the running Pods:
 
-        kubectl get pods -l purpose=demonstrate-envars
+       kubectl get pods -l purpose=demonstrate-envars
 
     The output is similar to this:
 
@@ -47,7 +47,7 @@ Pod:
 
 1. Get a shell to the container running in your Pod:
 
-        kubectl exec -it envar-demo -- /bin/bash
+       kubectl exec -it envar-demo -- /bin/bash
 
 1. In your shell, run the `printenv` command to list the environment variables.
 

--- a/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -37,16 +37,16 @@ username and password:
 
 1. Create the Secret
 
-        kubectl create -f secret.yaml
+       kubectl create -f secret.yaml
 
     **Note:** If you want to skip the Base64 encoding step, you can create a Secret
     by using the `kubectl create secret` command:
 
-        kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
+       kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
 
 1. View information about the Secret:
 
-        kubectl get secret test-secret
+       kubectl get secret test-secret
 
     Output:
 
@@ -56,7 +56,7 @@ username and password:
 
 1. View more detailed information about the Secret:
 
-        kubectl describe secret test-secret
+       kubectl describe secret test-secret
 
     Output:
 
@@ -80,11 +80,11 @@ Here is a configuration file you can use to create a Pod:
 
 1. Create the Pod:
 
-        kubectl create -f secret-pod.yaml
+       kubectl create -f secret-pod.yaml
 
 1. Verify that your Pod is running:
 
-        kubectl get pod secret-test-pod
+       kubectl get pod secret-test-pod
 
     Output:
 
@@ -94,7 +94,7 @@ Here is a configuration file you can use to create a Pod:
 
 1. Get a shell into the Container that is running in your Pod:
 
-        kubectl exec -it secret-test-pod -- /bin/bash
+       kubectl exec -it secret-test-pod -- /bin/bash
 
 1. The secret data is exposed to the Container through a Volume mounted under
 `/etc/secret-volume`. In your shell, go to the directory where the secret data
@@ -127,11 +127,11 @@ Here is a configuration file you can use to create a Pod:
 
 1. Create the Pod:
 
-        kubectl create -f secret-envars-pod.yaml
+       kubectl create -f secret-envars-pod.yaml
 
 1. Verify that your Pod is running:
 
-        kubectl get pod secret-envars-test-pod
+       kubectl get pod secret-envars-test-pod
 
     Output:
 
@@ -140,7 +140,7 @@ Here is a configuration file you can use to create a Pod:
 
 1. Get a shell into the Container that is running in your Pod:
 
-        kubectl exec -it secret-envars-test-pod -- /bin/bash
+       kubectl exec -it secret-envars-test-pod -- /bin/bash
 
 1. In your shell, display the environment variables:
 

--- a/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -85,11 +85,11 @@ for a secure solution.
 
 1. Deploy the contents of the YAML file:
 
-        kubectl create -f https://k8s.io/docs/tasks/run-application/mysql-deployment.yaml
+       kubectl create -f https://k8s.io/docs/tasks/run-application/mysql-deployment.yaml
 
 1. Display information about the Deployment:
 
-        kubectl describe deployment mysql
+       kubectl describe deployment mysql
 
         Name:                 mysql
         Namespace:            default
@@ -108,14 +108,14 @@ for a secure solution.
 
 1. List the pods created by the Deployment:
 
-        kubectl get pods -l app=mysql
+       kubectl get pods -l app=mysql
 
         NAME                   READY     STATUS    RESTARTS   AGE
         mysql-63082529-2z3ki   1/1       Running   0          3m
 
 1. Inspect the Persistent Volume:
 
-        kubectl describe pv mysql-pv
+       kubectl describe pv mysql-pv
 
         Name:            mysql-pv
         Labels:          <none>
@@ -135,7 +135,7 @@ for a secure solution.
 
 1. Inspect the PersistentVolumeClaim:
 
-        kubectl describe pvc mysql-pv-claim
+       kubectl describe pvc mysql-pv-claim
 
         Name:         mysql-pv-claim
         Namespace:    default

--- a/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -38,11 +38,11 @@ a Deployment that runs the nginx:1.7.9 Docker image:
 
 1. Create a Deployment based on the YAML file:
 
-        kubectl create -f https://k8s.io/docs/tasks/run-application/deployment.yaml
+       kubectl create -f https://k8s.io/docs/tasks/run-application/deployment.yaml
 
 1. Display information about the Deployment:
 
-        kubectl describe deployment nginx-deployment
+       kubectl describe deployment nginx-deployment
 
         user@computer:~/kubernetes.github.io$ kubectl describe deployment nginx-deployment
         Name:     nginx-deployment
@@ -64,7 +64,7 @@ a Deployment that runs the nginx:1.7.9 Docker image:
 
 1. List the pods created by the deployment:
 
-        kubectl get pods -l app=nginx
+       kubectl get pods -l app=nginx
 
         NAME                                READY     STATUS    RESTARTS   AGE
         nginx-deployment-1771418926-7o5ns   1/1       Running   0          16h
@@ -72,7 +72,7 @@ a Deployment that runs the nginx:1.7.9 Docker image:
 
 1. Display information about a pod:
 
-        kubectl describe pod <pod-name>
+       kubectl describe pod <pod-name>
 
     where `<pod-name>` is the name of one of your pods.
 
@@ -85,11 +85,11 @@ specifies that the deployment should be updated to use nginx 1.8.
 
 1. Apply the new YAML file:
 
-        kubectl apply -f https://k8s.io/docs/tutorials/stateless-application/deployment-update.yaml
+       kubectl apply -f https://k8s.io/docs/tutorials/stateless-application/deployment-update.yaml
 
 1. Watch the deployment create pods with new names and delete the old pods:
 
-        kubectl get pods -l app=nginx
+       kubectl get pods -l app=nginx
 
 ## Scaling the application by increasing the replica count
 
@@ -101,11 +101,11 @@ should have four pods:
 
 1. Apply the new YAML file:
 
-        kubectl apply -f https://k8s.io/docs/tutorials/stateless-application/deployment-scale.yaml
+       kubectl apply -f https://k8s.io/docs/tutorials/stateless-application/deployment-scale.yaml
 
 1. Verify that the Deployment has four pods:
 
-        kubectl get pods -l app=nginx
+       kubectl get pods -l app=nginx
 
     The output is similar to this:
 

--- a/docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
+++ b/docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
@@ -894,7 +894,7 @@ configuration involves several manual steps:
 
 1. Export the live object to a local configuration file:
 
-        kubectl get <kind>/<name> -o yaml --export > <kind>_<name>.yaml
+       kubectl get <kind>/<name> -o yaml --export > <kind>_<name>.yaml
 
 1. Manually remove the `status` field from the configuration file.
 
@@ -903,7 +903,7 @@ configuration involves several manual steps:
 
 1. Set the `kubectl.kubernetes.io/last-applied-configuration` annotation on the object:
 
-        kubectl replace --save-config -f <kind>_<name>.yaml
+       kubectl replace --save-config -f <kind>_<name>.yaml
 
 1. Change processes to use `kubectl apply` for managing the object exclusively.
 
@@ -915,7 +915,7 @@ TODO(pwittrock): Why doesn't export remove the status field?  Seems like it shou
 
 1. Set the `kubectl.kubernetes.io/last-applied-configuration` annotation on the object:
 
-        kubectl replace --save-config -f <kind>_<name>.yaml
+       kubectl replace --save-config -f <kind>_<name>.yaml
 
 1. Change processes to use `kubectl apply` for managing the object exclusively.
 

--- a/docs/tutorials/object-management-kubectl/imperative-object-management-configuration.md
+++ b/docs/tutorials/object-management-kubectl/imperative-object-management-configuration.md
@@ -97,13 +97,13 @@ several manual steps.
 
 1. Export the live object to a local object configuration file:
 
-        kubectl get <kind>/<name> -o yaml --export > <kind>_<name>.yaml
+       kubectl get <kind>/<name> -o yaml --export > <kind>_<name>.yaml
 
 1. Manually remove the status field from the object configuration file.
 
 1. For subsequent object management, use `replace` exclusively.
 
-        kubectl replace -f <kind>_<name>.yaml
+       kubectl replace -f <kind>_<name>.yaml
 
 
 ## Defining controller selectors and PodTemplate labels

--- a/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -40,7 +40,7 @@ external IP address.
 
 1. Run a Hello World application in your cluster:
 
-        kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+       kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
 
     The preceding command creates a
     [Deployment](/docs/concepts/workloads/controllers/deployment/)
@@ -52,21 +52,21 @@ external IP address.
 
 1. Display information about the Deployment:
 
-        kubectl get deployments hello-world
-        kubectl describe deployments hello-world
+       kubectl get deployments hello-world
+       kubectl describe deployments hello-world
 
 1. Display information about your ReplicaSet objects:
 
-        kubectl get replicasets
-        kubectl describe replicasets
+       kubectl get replicasets
+       kubectl describe replicasets
 
 1. Create a Service object that exposes the deployment:
 
-        kubectl expose deployment hello-world --type=LoadBalancer --name=my-service
+       kubectl expose deployment hello-world --type=LoadBalancer --name=my-service
 
 1. Display information about the Service:
 
-        kubectl get services my-service
+       kubectl get services my-service
 
     The output is similar to this:
 
@@ -78,7 +78,7 @@ external IP address.
 
 1. Display detailed information about the Service:
 
-        kubectl describe services my-service
+       kubectl describe services my-service
 
     The output is similar to this:
 
@@ -104,7 +104,7 @@ external IP address.
    addresses of the pods that are running the Hello World application. To
    verify these are pod addresses, enter this command:
 
-        kubectl get pods --output=wide
+       kubectl get pods --output=wide
 
     The output is similar to this:
 


### PR DESCRIPTION
This is causing bash/zsh shells to not to record the executed command in the
history. See this link for details: https://unix.stackexchange.com/questions/115917/why-is-bash-not-storing-commands-that-start-with-spaces

I have not looked at every single page but this should fix at least some of the
occurences (i.e. the code blocks that occur in ordered/unordered lists).

/assign @chenopis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4656)
<!-- Reviewable:end -->
