### PR TITLE
Update configure-liveness-readiness-probes.md

### DIFF
--- a/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -136,7 +136,7 @@ Any code greater than or equal to 200 and less than 400 indicates success. Any
 other code indicates failure.
 
 You can see the source code for the server in
-[server.go](http://k8s.io/docs/user-guide/liveness/image/server.go).
+[server.go](https://github.com/kubernetes/kubernetes/blob/master/test/images/liveness/server.go).
 
 For the first 10 seconds that the Container is alive, the `/healthz` handler
 returns a status of 200. After that, the handler returns a status of 500.


### PR DESCRIPTION
Fix bad url. http://k8s.io/docs/user-guide/liveness/image/server.go is a bad url and it should be https://github.com/kubernetes/kubernetes/blob/master/test/images/liveness/server.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4707)
<!-- Reviewable:end -->
