### PR TITLE
Add missing link to multi-zones

### DIFF
--- a/_data/tasks.yml
+++ b/_data/tasks.yml
@@ -153,6 +153,7 @@ toc:
   - docs/tasks/administer-cluster/share-configuration.md
   - docs/tasks/administer-cluster/running-cloud-controller.md
   - docs/tasks/administer-cluster/highly-available-master.md
+  - docs/tasks/administer-cluster/multiple-zones.md
   - docs/tasks/administer-cluster/configure-multiple-schedulers.md
   - docs/tasks/administer-cluster/ip-masq-agent.md
   - docs/tasks/administer-cluster/dns-custom-nameservers.md


### PR DESCRIPTION
Add missing link to multiple-zones in TOC data

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4710)
<!-- Reviewable:end -->
