### PR TITLE
fix typo in init-containers.md

### DIFF
--- a/docs/concepts/workloads/pods/init-containers.md
+++ b/docs/concepts/workloads/pods/init-containers.md
@@ -83,7 +83,7 @@ Here are some ideas for how to use Init Containers:
 * Wait for some time before starting the app Container with a command like `sleep 60`.
 * Clone a git repository into a volume.
 * Place values into a configuration file and run a template tool to dynamically
-  generate a configuration file for the the main app Container. For example,
+  generate a configuration file for the main app Container. For example,
   place the POD_IP value in a configuration and generate the main app
   configuration file using Jinja.
 


### PR DESCRIPTION
fix typo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4714)
<!-- Reviewable:end -->
