### PR TITLE
Correct indent bug in httpGet liveness probe

### DIFF
--- a/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -207,8 +207,8 @@ ports:
 
 livenessProbe:
   httpGet:
-  path: /healthz
-  port: liveness-port
+    path: /healthz
+    port: liveness-port
 ```
 
 ## Define readiness probes


### PR DESCRIPTION
Fix bug in `httpGet` probe indenting in this task item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4733)
<!-- Reviewable:end -->
