### PR TITLE
encrypt-data.md: make base64 command work on Linux

### DIFF
--- a/docs/tasks/administer-cluster/encrypt-data.md
+++ b/docs/tasks/administer-cluster/encrypt-data.md
@@ -104,7 +104,7 @@ To create a new secret perform the following steps:
 1. Generate a 32 byte random key and base64 encode it. If you're on Linux or Mac OS X, run the following command:
 
     ```
-    head -c 32 /dev/urandom | base64 -i - -o -
+    head -c 32 /dev/urandom | base64
     ```
 
 2. Place that value in the secret field.  


### PR DESCRIPTION
Quote from [the doc](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/):
> Generate a 32 byte random key and base64 encode it. If you’re on Linux or Mac OS X, run the following command:
> ```
> head -c 32 /dev/urandom | base64 -i - -o - 
>```

But this command fails on Fedora 25:

```console
$ head -c 32 /dev/urandom | base64 -i - -o - 
base64: invalid option -- 'o'
Try 'base64 --help' for more information.
```

Also the `-i` option behaves differently on Linux (see [`man base64`](http://man7.org/linux/man-pages/man1/base64.1.html)):

>        -i, --ignore-garbage
>              when decoding, ignore non-alphabet characters

I see that `-o` and `-i` are needed to only specify the input/output. Also the values that we specified (stdin/stdout) are being used by default (quote from [man base64](http://www.unix.com/man-page/osx/1/base64/)):

>      -i input_file
>     --input=input_file   Read input from input_file.  Default is stdin; passing - also repre-
>			  sents stdin.
>
>     -o output_file
>     --output=output_file
>			  Write output to output_file.	Default is stdout; passing - also repre-
>			  sents stdout.

So, I think that we can simplify the command and in the same time make it portable by just removing these options.

PTAL @smarterclayton 
CC @simo5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4735)
<!-- Reviewable:end -->
