### PR TITLE
Update service-access-application-cluster.md

### DIFF
--- a/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -105,7 +105,7 @@ provides load balancing for an application that has two running instances.
 
 1. Use the node address and node port to access the Hello World application:
 
-        curl http://<public-node-ip>:<node-port>
+       curl http://<public-node-ip>:<node-port>
 
     where `<public-node-ip>` is the public IP address of your node,
     and `<node-port>` is the NodePort value for your service.


### PR DESCRIPTION
Fix leading spaces in kubectl commands and unified format.As ahmetb says,This is causing bash/zsh shells to not to record the executed command in the history. See this link for details: https://unix.stackexchange.com/questions/115917/why-is-bash-not-storing-commands-that-start-with-spaces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4748)
<!-- Reviewable:end -->
