### PR TITLE
Update port-forward-access-application-cluster.md

### DIFF
--- a/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -64,11 +64,11 @@ for database debugging.
 
 1. Start the Redis command line interface:
 
-        redis-cli
+       redis-cli
 
 1. At the Redis command line prompt, enter the `ping` command:
 
-        127.0.0.1:6379>ping
+       127.0.0.1:6379>ping
 
     A successful ping request returns PONG.
 


### PR DESCRIPTION
Fix leading spaces in commands

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4767)
<!-- Reviewable:end -->
