### PR TITLE
Small grammar change

### DIFF
--- a/docs/concepts/architecture/master-node-communication.md
+++ b/docs/concepts/architecture/master-node-communication.md
@@ -65,7 +65,7 @@ or service through the apiserver's proxy functionality.
 ### apiserver -> kubelet
 
 The connections from the apiserver to the kubelet are used for fetching logs
-for pods, attaching (through kubectl) to running pods, and using the kubelet's
+for pods, attaching (through kubectl) to running pods and the kubelet's
 port-forwarding functionality. These connections terminate at the kubelet's
 HTTPS endpoint.
 

--- a/docs/concepts/architecture/master-node-communication.md
+++ b/docs/concepts/architecture/master-node-communication.md
@@ -64,12 +64,13 @@ or service through the apiserver's proxy functionality.
 
 ### apiserver -> kubelet
 
-The connections from the apiserver to the kubelet are used for fetching logs
-for pods, attaching (through kubectl) to running pods and the kubelet's
-port-forwarding functionality. These connections terminate at the kubelet's
-HTTPS endpoint.
+The connections from the apiserver to the kubelet are used for:
+  * fetching logs for pods.
+  * attaching (through kubectl) to running pods.
+  * the kubelet's port-forwarding functionality. 
 
-By default, the apiserver does not verify the kubelet's serving certificate,
+These connections terminate at the kubelet's HTTPS endpoint. By default, 
+the apiserver does not verify the kubelet's serving certificate,
 which makes the connection subject to man-in-the-middle attacks, and
 **unsafe** to run over untrusted and/or public networks.
 


### PR DESCRIPTION
Here is the original sentence.
```
The connections from the apiserver to the kubelet are used for fetching logs for pods, 
attaching (through kubectl) to running pods, and using the kubelet's  port-forwarding functionality. 
```
If it is broken down,
```
The connections from the apiserver to the kubelet are used for
  a) fetching logs for pods
  b) attaching (through kubectl) to running pods,
  c) using the kubelet's  port-forwarding functionality
```
but actually, this sounds better

```
The connections from the apiserver to the kubelet are used for
  a) fetching logs for pods
  b) attaching (through kubectl) to running pods
  c) the kubelet's  port-forwarding functionality
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4777)
<!-- Reviewable:end -->
