### PR TITLE
[minor] grammar

### DIFF
--- a/docs/concepts/cluster-administration/federation.md
+++ b/docs/concepts/cluster-administration/federation.md
@@ -133,7 +133,7 @@ It is okay to have multiple clusters per availability zone, though on balance we
 Reasons to prefer fewer clusters are:
 
   - improved bin packing of Pods in some cases with more nodes in one cluster (less resource fragmentation).
-  - reduced operational overhead (though the advantage is diminished as ops tooling and processes matures).
+  - reduced operational overhead (though the advantage is diminished as ops tooling and processes mature).
   - reduced costs for per-cluster fixed resource costs, e.g. apiserver VMs (but small as a percentage
     of overall cluster cost for medium to large clusters).
 


### PR DESCRIPTION
in addition to the proposed change, here are few observations. 

could we re-word this in [section](https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/concepts/cluster-administration/federation.md#selecting-the-right-number-of-clusters), this is not very clear to a new user.
```
Second, decide how many clusters should be able to be unavailable at the same time, while still being available. 
```

text in [section](https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/concepts/cluster-administration/federation.md#scope-of-a-single-cluster) is also not clear to a new user, could we re-word this one too? 
```
reduced costs for per-cluster fixed resource costs, e.g. apiserver VMs (but small as a percentage of overall cluster cost for medium to large clusters).
```
could we get the technical intent of the above two sentences, please?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4781)
<!-- Reviewable:end -->
