### PR TITLE
[glossary] Glossary Template

### DIFF
--- a/_includes/glossary/README.md
+++ b/_includes/glossary/README.md
@@ -1,3 +1,0 @@
-# Instructions for Glossary snippets
-
-Markdown snippets of glossary terms to be reused throughout the documentation should be placed in this directory.

--- a/_includes/glossary/_glossary-template.md
+++ b/_includes/glossary/_glossary-template.md
@@ -5,36 +5,20 @@ formerly:
 - Slang K8s Term
 - Misnomer
 - Formerly Known as Prince
-auto_doc_path: docs/concepts/some-fancy-k8s-term.md
 related:
 - Less Fancy K8s Term
 - Tangential Term
 - Commonly Used With
 ---
 
-{% capture short %}
-Copy written here should be no more than 200 characters long. It should be short and concise, 
-yet clearly define the terminology for users. General use case would be a tooltip.
+{% capture short-description %}
+Required. One or two lines that provide a minimum definition. Do not repeat the term. Prefer fragments. Model after tooltips.
 {% endcapture %}
 
-{% capture medium %}
-Copy written here should be no more than 800 characters long.
-
-Proin convallis lacus id tortor dictum placerat. Donec et magna et tellus condimentum gravida. Curabitur lobortis arcu ut nunc sodales, eu euismod purus malesuada. Quisque sit amet magna non mi ultricies tincidunt. Etiam luctus sem id magna suscipit aliquam. Fusce tempus sem vehicula facilisis lobortis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
-
-Nam sagittis justo felis, at ornare orci tempor id. Proin mi neque, volutpat eget blandit vel, sodales ac tellus. Fusce sed interdum velit. Aenean luctus orci sed scelerisque feugiat. Etiam et ligula purus. Praesent mollis luctus diam, sit amet ultrices sapien euismod a. Fusce non ullamcorper magna.
-{% endcapture %}
-
-{% capture long %}
-Copy written here will have no specified character limit.
-
-It can be a lengthy and detailed explanation of the terminology. In fact, 
-we could use this to auto-generate docs to ensure that every Glossary entry 
-has a corresponding page.
+{% capture long-description %}
+Optional. Longer additional text to appear after (in conjunction with) short description. Provide where the short description is not sufficient as the intro paragraph to a topic. Write complete but concise sentences.
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed hendrerit dictum nisi quis posuere. Integer eleifend neque lobortis ultrices viverra. Praesent viverra placerat ex sit amet aliquet. Aliquam non ipsum ut lectus viverra pulvinar id vitae nisi. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse aliquet congue tristique. Pellentesque at condimentum orci, iaculis pellentesque urna. Aliquam ut rhoncus lorem, a tristique est. Quisque eu est sem.
 
 Suspendisse id feugiat orci. Etiam in posuere arcu, id euismod velit. Etiam pulvinar lectus at diam porta, non lobortis dolor blandit. Donec id faucibus elit. Suspendisse auctor ligula purus, id aliquam odio vehicula a. Donec pretium ligula at nulla pulvinar, sed ultrices ligula dapibus. Cras lacinia mauris ut metus rutrum volutpat. Sed fermentum lobortis ipsum, in hendrerit lectus consectetur sed. Aliquam pulvinar tortor tellus, ac luctus est euismod congue. Maecenas enim ipsum, maximus a turpis eu, blandit imperdiet lacus.
-
-Sed non lacus id arcu imperdiet iaculis. Suspendisse pharetra nisl ligula, at vehicula nulla facilisis id. Sed fringilla ligula quis augue accumsan, eu euismod tellus varius. Proin quam nisl, vehicula eget sapien quis, ultrices elementum eros. Aliquam venenatis mauris vitae nulla viverra tristique. Vestibulum sed eros sit amet lacus porta euismod in at nisl. Pellentesque sit amet varius risus, quis sodales massa. Suspendisse potenti. Etiam felis mi, tempor a pretium non, luctus at eros. Nullam egestas nulla ante, vel blandit nulla pharetra a. In ullamcorper est ut dolor malesuada, non ultrices ante efficitur. Vivamus non dignissim elit. Fusce ultricies euismod convallis. Aenean non ante enim.
 {% endcapture %}

--- a/_includes/glossary/_glossary-template.md
+++ b/_includes/glossary/_glossary-template.md
@@ -1,0 +1,40 @@
+
+---
+term: Some Fancy K8s Term
+formerly:
+- Slang K8s Term
+- Misnomer
+- Formerly Known as Prince
+auto_doc_path: docs/concepts/some-fancy-k8s-term.md
+related:
+- Less Fancy K8s Term
+- Tangential Term
+- Commonly Used With
+---
+
+{% capture short %}
+Copy written here should be no more than 200 characters long. It should be short and concise, 
+yet clearly define the terminology for users. General use case would be a tooltip.
+{% endcapture %}
+
+{% capture medium %}
+Copy written here should be no more than 800 characters long.
+
+Proin convallis lacus id tortor dictum placerat. Donec et magna et tellus condimentum gravida. Curabitur lobortis arcu ut nunc sodales, eu euismod purus malesuada. Quisque sit amet magna non mi ultricies tincidunt. Etiam luctus sem id magna suscipit aliquam. Fusce tempus sem vehicula facilisis lobortis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+
+Nam sagittis justo felis, at ornare orci tempor id. Proin mi neque, volutpat eget blandit vel, sodales ac tellus. Fusce sed interdum velit. Aenean luctus orci sed scelerisque feugiat. Etiam et ligula purus. Praesent mollis luctus diam, sit amet ultrices sapien euismod a. Fusce non ullamcorper magna.
+{% endcapture %}
+
+{% capture long %}
+Copy written here will have no specified character limit.
+
+It can be a lengthy and detailed explanation of the terminology. In fact, 
+we could use this to auto-generate docs to ensure that every Glossary entry 
+has a corresponding page.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed hendrerit dictum nisi quis posuere. Integer eleifend neque lobortis ultrices viverra. Praesent viverra placerat ex sit amet aliquet. Aliquam non ipsum ut lectus viverra pulvinar id vitae nisi. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse aliquet congue tristique. Pellentesque at condimentum orci, iaculis pellentesque urna. Aliquam ut rhoncus lorem, a tristique est. Quisque eu est sem.
+
+Suspendisse id feugiat orci. Etiam in posuere arcu, id euismod velit. Etiam pulvinar lectus at diam porta, non lobortis dolor blandit. Donec id faucibus elit. Suspendisse auctor ligula purus, id aliquam odio vehicula a. Donec pretium ligula at nulla pulvinar, sed ultrices ligula dapibus. Cras lacinia mauris ut metus rutrum volutpat. Sed fermentum lobortis ipsum, in hendrerit lectus consectetur sed. Aliquam pulvinar tortor tellus, ac luctus est euismod congue. Maecenas enim ipsum, maximus a turpis eu, blandit imperdiet lacus.
+
+Sed non lacus id arcu imperdiet iaculis. Suspendisse pharetra nisl ligula, at vehicula nulla facilisis id. Sed fringilla ligula quis augue accumsan, eu euismod tellus varius. Proin quam nisl, vehicula eget sapien quis, ultrices elementum eros. Aliquam venenatis mauris vitae nulla viverra tristique. Vestibulum sed eros sit amet lacus porta euismod in at nisl. Pellentesque sit amet varius risus, quis sodales massa. Suspendisse potenti. Etiam felis mi, tempor a pretium non, luctus at eros. Nullam egestas nulla ante, vel blandit nulla pharetra a. In ullamcorper est ut dolor malesuada, non ultrices ante efficitur. Vivamus non dignissim elit. Fusce ultricies euismod convallis. Aenean non ante enim.
+{% endcapture %}


### PR DESCRIPTION
This is still a work in progress; I'm still thinking through what we might need. Currently, I'm considering:
* `term` The canonical name of the glossary term.
* `formerly` A list of previous incarnations of the term or concept.
* `related` A list of related terms.

Addresses part of #4629.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4785)
<!-- Reviewable:end -->
