### PR TITLE
Fix bin name in kubefed docs

### DIFF
--- a/docs/admin/kubefed_options.md
+++ b/docs/admin/kubefed_options.md
@@ -15,7 +15,7 @@ kubefed options
 
 ```
   # Print flags inherited by all commands
-  kubectl options
+  kubefed options
 ```
 
 ### Options inherited from parent commands

--- a/docs/admin/kubefed_version.md
+++ b/docs/admin/kubefed_version.md
@@ -15,7 +15,7 @@ kubefed version
 
 ```
   # Print the client and server versions for the current context
-  kubectl version
+  kubefed version
 ```
 
 ### Options


### PR DESCRIPTION
Observed that the bin name in the auto generated docs for kubefed is wrong in two of them (version and options). While this is the issue in how the kubefed binary code depends on some functionality from kubectl, which will need to be fixed separately; submitting a fix here, which can reflect immediately in docs. I will work on the actual fix also, later.
@chenopis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4852)
<!-- Reviewable:end -->
