### PR TITLE
[minor] Grammar

### DIFF
--- a/docs/getting-started-guides/mesos-docker.md
+++ b/docs/getting-started-guides/mesos-docker.md
@@ -265,7 +265,7 @@ make test_e2e
 
 ## Kubernetes CLI
 
-When compiling from source, it's simplest to use the `./cluster/kubectl.sh` script, which detects your platform &
+When compiling from source, it's simpler to use the `./cluster/kubectl.sh` script, which detects your platform &
 architecture and proxies commands to the appropriate `kubectl` binary.
 
 ex: `./cluster/kubectl.sh get pods`


### PR DESCRIPTION
In this sentence `it's simplest to use the...`  it could either be `it's the simplest to use` or `it's simpler to use`.  Looking at the context it appears that the latter sounds better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4926)
<!-- Reviewable:end -->
