### PR TITLE
Make kubefed docs similar to rest of the docs in docs/admin

### DIFF
--- a/docs/admin/kubefed.md
+++ b/docs/admin/kubefed.md
@@ -1,3 +1,7 @@
+---
+title: kubefed
+notitle: true
+---
 ## kubefed
 
 kubefed controls a Kubernetes Cluster Federation

--- a/docs/admin/kubefed_init.md
+++ b/docs/admin/kubefed_init.md
@@ -1,3 +1,7 @@
+---
+title: kubefed init
+notitle: true
+---
 ## kubefed init
 
 Initialize a federation control plane

--- a/docs/admin/kubefed_join.md
+++ b/docs/admin/kubefed_join.md
@@ -1,3 +1,7 @@
+---
+title: kubefed join
+notitle: true
+---
 ## kubefed join
 
 Join a cluster to a federation

--- a/docs/admin/kubefed_options.md
+++ b/docs/admin/kubefed_options.md
@@ -1,3 +1,7 @@
+---
+title: kubefed options
+notitle: true
+---
 ## kubefed options
 
 Print the list of flags inherited by all commands

--- a/docs/admin/kubefed_unjoin.md
+++ b/docs/admin/kubefed_unjoin.md
@@ -1,3 +1,7 @@
+---
+title: kubefed unjoin
+notitle: true
+---
 ## kubefed unjoin
 
 Unjoin a cluster from a federation

--- a/docs/admin/kubefed_version.md
+++ b/docs/admin/kubefed_version.md
@@ -1,3 +1,7 @@
+---
+title: kubefed version
+notitle: true
+---
 ## kubefed version
 
 Print the client and server version information

--- a/skip_title_check.txt
+++ b/skip_title_check.txt
@@ -4,12 +4,6 @@ docs/getting-started-guides/docker.md
 docs/getting-started-guides/docker-multinode.md
 docs/user-guide/configmap/README.md
 docs/user-guide/downward-api/README.md
-docs/admin/kubefed_unjoin.md
-docs/admin/kubefed_init.md
-docs/admin/kubefed.md
-docs/admin/kubefed_join.md
-docs/admin/kubefed_options.md
-docs/admin/kubefed_version.md
 docs/api-reference/extensions/v1beta1/definitions.md
 docs/api-reference/extensions/v1beta1/operations.md
 docs/api-reference/v1/definitions.md

--- a/update-imported-docs.sh
+++ b/update-imported-docs.sh
@@ -136,7 +136,7 @@ done <_data/overrides.yml
 )
 
 
-BINARIES="federation-apiserver.md federation-controller-manager.md kube-apiserver.md kube-controller-manager.md kube-proxy.md kube-scheduler.md kubelet.md"
+BINARIES="federation-apiserver.md federation-controller-manager.md kube-apiserver.md kube-controller-manager.md kube-proxy.md kube-scheduler.md kubelet.md kubefed.md kubefed_init.md kubefed_join.md kubefed_options.md kubefed_unjoin.md kubefed_version.md"
 
 (
   cd docs/admin
@@ -149,6 +149,7 @@ BINARIES="federation-apiserver.md federation-controller-manager.md kube-apiserve
 ---' "$bin"
   done
 )
+
 mv -- "${APIREFDESDIR}" "${APIREFSRCDIR}"
 mv -- "${KUBECTLDESDIR}" "${KUBECTLSRCDIR}"
 rm -rf -- "${TMPDIR}" "${K8SREPO}"


### PR DESCRIPTION
The title in kubefed autogenerated docs appears twice for some reason (Probably the way, kubernetes.github.io processes the md files).
Example (https://kubernetes.io/docs/admin/kubefed/).
Align these file with other docs/admin files.
Also, update-imported-docs.sh puts only below lines at the top of all auto generated files like below:
```
---
---
```
I am assuming, there is some other post process script/tool which actually puts the two lines, for title, for example:
```
---
title: kubefed options
notitle: true
---
```
Or it is done manually.
@chenopis, please let me know if this change is ok, or something better option is there.
Actually I did ask the clarification [here](https://github.com/kubernetes/kubernetes.github.io/pull/2937#issuecomment-318920174) earlier. It appears to me, that its done manually post importing the docs. If that is indeed the case, We can update the script to update the title lines also.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4934)
<!-- Reviewable:end -->
