### PR TITLE
Fix typos and syntax errors

### DIFF
--- a/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -14,7 +14,7 @@ despite bugs.
 
 The kubelet uses readiness probes to know when a Container is ready to start
 accepting traffic. A Pod is considered ready when all of its Containers are ready.
-One use of this signal is to control which Pods are used as backends for Services.
+One use of this signal is to control Pods which are used as backends for Services.
 When a Pod is not ready, it is removed from Service load balancers.
 
 {% endcapture %}
@@ -29,7 +29,7 @@ When a Pod is not ready, it is removed from Service load balancers.
 
 ## Define a liveness command
 
-Many applications running for long periods of time eventually transition to
+Many applications running for long periods of time eventually transit to
 broken states, and cannot recover except by being restarted. Kubernetes provides
 liveness probes to detect and remedy such situations.
 
@@ -180,7 +180,7 @@ can’t it is considered a failure.
 
 {% include code.html language="yaml" file="tcp-liveness-readiness.yaml" ghlink="/docs/tasks/configure-pod-container/tcp-liveness-readiness.yaml" %}
 
-As you can see, configuration for a TCP check is quite similar to a HTTP check.
+As you can see, configuration for a TCP check is quite similar to an HTTP check.
 This example uses both readiness and liveness probes. The kubelet will send the
 first readiness probe 5 seconds after the container starts. This will attempt to
 connect to the `goproxy` container on port 8080. If the probe succeeds, the pod

--- a/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/docs/tasks/configure-pod-container/configure-service-account.md
@@ -163,7 +163,7 @@ namespace: 7 bytes
 
 ## Add ImagePullSecrets to a service account
 
-First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)
+First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 Next, verify it has been created.  For example:
 
 ```shell

--- a/docs/tasks/configure-pod-container/security-context.md
+++ b/docs/tasks/configure-pod-container/security-context.md
@@ -334,7 +334,7 @@ need to set the `level` section. This sets the
 label given to all Containers in the Pod as well as the Volumes.
 
 **Warning**: After you specify an MCS label for a Pod, all Pods with the same
-label will able to access the Volume. So if you need inter-Pod
+label will be able to access the Volume. So if you need inter-Pod
 protection, you must ensure each Pod is assigned a unique MCS label.
 
 {% endcapture %}


### PR DESCRIPTION
Fix some typos and syntax errors in configure-liveness-readiness-probes.md, configure-service-account.md and security-context.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4942)
<!-- Reviewable:end -->
