### PR TITLE
concepts/configuration/manage-compute-resources-container.md: fix a conversion (issue #4693)

### DIFF
--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -135,14 +135,12 @@ When using Docker:
   [`--cpu-shares`](https://docs.docker.com/engine/reference/run/#/cpu-share-constraint)
   flag in the `docker run` command.
 
-- The `spec.containers[].resources.limits.cpu` is converted to its millicore value,
-  multiplied by 100000, and then divided by 1000. This number is used as the value
-  of the [`--cpu-quota`](https://docs.docker.com/engine/reference/run/#/cpu-quota-constraint)
-  flag in the `docker run` command.  The [`--cpu-period`] flag is set to 100000,
-   which represents the default 100ms period for measuring quota usage. The
-   kubelet enforces cpu limits if it is started with the
-  [`--cpu-cfs-quota`] flag set to true. As of Kubernetes version 1.2, this flag
-  defaults to true.
+- The `spec.containers[].resources.limits.cpu` is converted to its millicore value and
+  multiplied by 100. The resulting value is the total amount of CPU time that a container can use
+  every 100ms. A container cannot use more than its share of CPU time during this interval.
+
+  **Note**: The default quota period is 100ms. The minimum resolution of CPU quota is 1ms.
+  {: .note}
 
 - The `spec.containers[].resources.limits.memory` is converted to an integer, and
   used as the value of the
@@ -434,4 +432,3 @@ consistency across providers and platforms.
 {% endcapture %}
 
 {% include templates/concept.md %}
-


### PR DESCRIPTION
"multiplied by 100000, and then divided by 1000" has been simplified to "multiplied by 100"
Ref: https://github.com/kubernetes/kubernetes.github.io/issues/4693

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4952)
<!-- Reviewable:end -->
