### PR TITLE
Fix typo

### DIFF
--- a/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/docs/tasks/configure-pod-container/configure-service-account.md
@@ -163,7 +163,7 @@ namespace: 7 bytes
 
 ## Add ImagePullSecrets to a service account
 
-First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
+First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)
 Next, verify it has been created.  For example:
 
 ```shell

--- a/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/docs/tasks/configure-pod-container/configure-service-account.md
@@ -163,7 +163,7 @@ namespace: 7 bytes
 
 ## Add ImagePullSecrets to a service account
 
-First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)
+First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 Next, verify it has been created.  For example:
 
 ```shell

--- a/docs/tasks/configure-pod-container/security-context.md
+++ b/docs/tasks/configure-pod-container/security-context.md
@@ -334,7 +334,7 @@ need to set the `level` section. This sets the
 label given to all Containers in the Pod as well as the Volumes.
 
 **Warning**: After you specify an MCS label for a Pod, all Pods with the same
-label will able to access the Volume. So if you need inter-Pod
+label will be able to access the Volume. So if you need inter-Pod
 protection, you must ensure each Pod is assigned a unique MCS label.
 
 {% endcapture %}


### PR DESCRIPTION
Fix typos in configure-service-account.md, security-context.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4971)
<!-- Reviewable:end -->
