### PR TITLE
JSONPath: rename title

### DIFF
--- a/docs/user-guide/jsonpath.md
+++ b/docs/user-guide/jsonpath.md
@@ -1,5 +1,5 @@
 ---
-title: JSONpath Support
+title: JSONPath Support
 ---
 
 JSONPath template is composed of JSONPath expressions enclosed by {}.


### PR DESCRIPTION
`JSONPath` is how it is referenced everywhere (not `JSONpath`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4986)
<!-- Reviewable:end -->
