### PR TITLE
Update expose-external-ip-address.md

### DIFF
--- a/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -117,7 +117,7 @@ external IP address.
 
 1. Use the external IP address to access the Hello World application:
 
-        curl http://<external-ip>:<port>
+       curl http://<external-ip>:<port>
 
     where `<external-ip>` is the external IP address of your Service,
     and `<port>` is the value of `Port` in your Service description.


### PR DESCRIPTION
Fix leading spaces in kubectl commands and unified format.As ahmetb says,This is causing bash/zsh shells to not to record the executed command in the history. See this link for details: https://unix.stackexchange.com/questions/115917/why-is-bash-not-storing-commands-that-start-with-spaces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5032)
<!-- Reviewable:end -->
