### PR TITLE
Fix several typos in reference README.md file

### DIFF
--- a/docs/api-reference/v1.5/README.md
+++ b/docs/api-reference/v1.5/README.md
@@ -6,7 +6,7 @@ Static compilation of html from markdown including processing for grouping code 
 
 \> bdocs-tab:kubectl Deployment Config to run 3 nginx instances (max rollback set to 10 revisions).
 
-bdocs-tab:tab will be stripped during rendering and utilized to with CSS to show or hide the prefered tab. kubectl indicates the desired tab, since blockquotes have no specific syntax highlighting.
+bdocs-tab:tab will be stripped during rendering and utilized to with CSS to show or hide the preferred tab. kubectl indicates the desired tab, since blockquotes have no specific syntax highlighting.
 
 \`\`\`bdocs-tab:kubectl_yaml
 apiVersion: extensions/v1beta1

--- a/docs/resources-reference/v1.5/README.md
+++ b/docs/resources-reference/v1.5/README.md
@@ -6,7 +6,7 @@ Static compilation of html from markdown including processing for grouping code 
 
 \> bdocs-tab:kubectl Deployment Config to run 3 nginx instances (max rollback set to 10 revisions).
 
-bdocs-tab:tab will be stripped during rendering and utilized to with CSS to show or hide the prefered tab. kubectl indicates the desired tab, since blockquotes have no specific syntax highlighting.
+bdocs-tab:tab will be stripped during rendering and utilized to with CSS to show or hide the preferred tab. kubectl indicates the desired tab, since blockquotes have no specific syntax highlighting.
 
 \`\`\`bdocs-tab:kubectl_yaml
 apiVersion: extensions/v1beta1

--- a/docs/resources-reference/v1.6/README.md
+++ b/docs/resources-reference/v1.6/README.md
@@ -6,7 +6,7 @@ Static compilation of html from markdown including processing for grouping code 
 
 \> bdocs-tab:kubectl Deployment Config to run 3 nginx instances (max rollback set to 10 revisions).
 
-bdocs-tab:tab will be stripped during rendering and utilized to with CSS to show or hide the prefered tab. kubectl indicates the desired tab, since blockquotes have no specific syntax highlighting.
+bdocs-tab:tab will be stripped during rendering and utilized to with CSS to show or hide the preferred tab. kubectl indicates the desired tab, since blockquotes have no specific syntax highlighting.
 
 \`\`\`bdocs-tab:kubectl_yaml
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Fix several typos in reference README.md file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5065)
<!-- Reviewable:end -->
