### PR TITLE
Update dns-horizontal-autoscaler.yaml

### DIFF
--- a/docs/tasks/administer-cluster/dns-horizontal-autoscaler.yaml
+++ b/docs/tasks/administer-cluster/dns-horizontal-autoscaler.yaml
@@ -22,7 +22,6 @@ spec:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system
           - --configmap=kube-dns-autoscaler
-          - --mode=linear
           - --target=<SCALE_TARGET>
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.


### PR DESCRIPTION
`mode` is deprecated in favor of dynamic switching starting from 1.1.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5070)
<!-- Reviewable:end -->
