### PR TITLE
Update debug-pod-replication-controller.md

### DIFF
--- a/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -45,8 +45,8 @@ case you can try several things:
     command. Here are some example command lines that extract just the necessary
     information:
 
-       kubectl get nodes -o yaml | grep '\sname\|cpu\|memory'
-       kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, cap: .status.capacity}'
+      kubectl get nodes -o yaml | grep '\sname\|cpu\|memory'
+      kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, cap: .status.capacity}'
 
   The [resource quota](/docs/concepts/policy/resource-quotas/)
   feature can be configured to limit the total amount of


### PR DESCRIPTION
Fix leading spaces in kubectl commands and unified format.This is causing bash/zsh shells to not to record the executed command in the history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5100)
<!-- Reviewable:end -->
