### PR TITLE
The etcd container link is out of date in the yaml

### DIFF
--- a/docs/admin/high-availability/etcd.yaml
+++ b/docs/admin/high-availability/etcd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/etcd:2.0.9
+  - image: gcr.io/google_containers/etcd:3.0.17
     name: etcd-container
     command:
     - /usr/local/bin/etcd


### PR DESCRIPTION
The etcd container link is out of date in the  yaml file and there is something wrong when run the gcr.io/google_containers/etcd:2.0.9 container

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5129)
<!-- Reviewable:end -->
