### PR TITLE
Fix kubeadm instructions

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -96,6 +96,7 @@ For each machine:
   EOF
   apt-get update
   apt-get install -y kubelet kubeadm
+  systemctl enable kubelet && systemctl start kubelet
   ```
 
 * If the machine is running CentOS, run:
@@ -115,6 +116,8 @@ For each machine:
   yum install -y kubelet kubeadm
   systemctl enable kubelet && systemctl start kubelet
   ```
+
+
 
   The kubelet is now restarting every few seconds, as it waits in a crashloop for
   kubeadm to tell it what to do.

--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -117,8 +117,6 @@ For each machine:
   systemctl enable kubelet && systemctl start kubelet
   ```
 
-
-
   The kubelet is now restarting every few seconds, as it waits in a crashloop for
   kubeadm to tell it what to do.
 


### PR DESCRIPTION
Update install-kubeadm.md (https://kubernetes.io/docs/setup/independent/install-kubeadm/) to include `systemctl` calls on Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5158)
<!-- Reviewable:end -->
