### PR TITLE
Added a prerequisite to using CoreDNS provider in federation

### DIFF
--- a/docs/tasks/federation/set-up-coredns-provider-federation.md
+++ b/docs/tasks/federation/set-up-coredns-provider-federation.md
@@ -21,12 +21,11 @@ DNS provider for Cluster Federation.
 
 {% capture prerequisites %}
 
-You need to have a running Kubernetes cluster (which is
+* You need to have a running Kubernetes cluster (which is
 referenced as host cluster). Please see one of the
 [getting started](/docs/getting-started-guides/) guides for
 installation instructions for your platform.
-
-Prerequisite: Support for `LoadBalancer` services in member clusters of federation is
+* Support for `LoadBalancer` services in member clusters of federation is
 mandatory to enable `CoreDNS` for service discovery across federated clusters.
 
 {% endcapture %}

--- a/docs/tasks/federation/set-up-coredns-provider-federation.md
+++ b/docs/tasks/federation/set-up-coredns-provider-federation.md
@@ -26,6 +26,9 @@ referenced as host cluster). Please see one of the
 [getting started](/docs/getting-started-guides/) guides for
 installation instructions for your platform.
 
+Prerequisite: Support for `LoadBalancer` services in member clusters of federation is
+mandatory to enable `CoreDNS` for service discovery across federated clusters.
+
 {% endcapture %}
 
 


### PR DESCRIPTION
We have seen many users trying to use CoreDNS DNS provider with federation of clusters in on-premise environments which do not support LoadBalancer service type, only to find later that its not working. So have added a prerequisite in the guide.

/cc @madhusudancs @kubernetes/sig-federation-pr-reviews

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5159)
<!-- Reviewable:end -->
