### PR TITLE
Fix minor typo in Replication Controller

### DIFF
--- a/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -141,7 +141,7 @@ will have to manage the deletion yourself (see [below](#working-with-replication
 
 You can specify how many pods should run concurrently by setting `.spec.replicas` to the number
 of pods you would like to have running concurrently.  The number running at any time may be higher
-or lower, such as if the replicas was just increased or decreased, or if a pod is gracefully
+or lower, such as if the replicas were just increased or decreased, or if a pod is gracefully
 shutdown, and a replacement starts early.
 
 If you do not specify `.spec.replicas`, then it defaults to 1.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5173)
<!-- Reviewable:end -->
