### PR TITLE
Remove CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-kubernetes.io


### PR DESCRIPTION
Removing CNAME file to avoid the following GitHub error message:

>The page build completed successfully, but returned the following
warning for the `master` branch:
>
>The CNAME `kubernetes.io` is already taken. Check out
https://help.github.com/articles/troubleshooting-custom-domains/#cname-already-taken
for more information.

cc @thockin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5180)
<!-- Reviewable:end -->
