### PR TITLE
update zookeeper.md

### DIFF
--- a/docs/tutorials/stateful-application/zookeeper.md
+++ b/docs/tutorials/stateful-application/zookeeper.md
@@ -1000,7 +1000,7 @@ This is because the Pods in the `zk` StatefulSet have a PodAntiAffinity specifie
               topologyKey: "kubernetes.io/hostname"
 ```
 
-The `requiredDuringSchedulingRequiredDuringExecution` field tells the 
+The `requiredDuringSchedulingIgnoredDuringExecution` field tells the 
 Kubernetes Scheduler that it should never co-locate two Pods from the `zk-headless`
 Service in the domain defined by the `topologyKey`. The `topologyKey`
 `kubernetes.io/hostname` indicates that the domain is an individual node. Using 
@@ -1021,13 +1021,6 @@ Get the nodes in your cluster.
 ```shell
 kubectl get nodes
 ```
-
-Use [`kubectl cordon`](/docs/user-guide/kubectl/{{page.version}}/#cordon) to 
-cordon all but four of the nodes in your cluster.
-
-```shell{% raw %}
-kubectl cordon < node name >
-```{% endraw %}
 
 Get the `zk-budget` PodDisruptionBudget.
 
@@ -1059,6 +1052,13 @@ kubernetes-minion-group-ixsl
 kubernetes-minion-group-i4c4
 {% endraw %}
 ```
+
+Use [`kubectl cordon`](/docs/user-guide/kubectl/{{page.version}}/#cordon) to 
+cordon the three nodes that the Pods are currently scheduled on.
+
+```shell{% raw %}
+kubectl cordon < node name >
+{% endraw %}```
 
 Use [`kubectl drain`](/docs/user-guide/kubectl/{{page.version}}/#drain) to cordon and 
 drain the node on which the `zk-0` Pod is scheduled.
@@ -1095,7 +1095,8 @@ Keep watching the StatefulSet's Pods in the first terminal and drain the node on
 `zk-1` is scheduled.
 
 ```shell{% raw %}
-kubectl drain $(kubectl get pod zk-1 --template {{.spec.nodeName}}) --ignore-daemonsets --force --delete-local-data "kubernetes-minion-group-ixsl" cordoned
+kubectl drain $(kubectl get pod zk-1 --template {{.spec.nodeName}}) --ignore-daemonsets --force --delete-local-data
+node "kubernetes-minion-group-ixsl" cordoned
 WARNING: Deleting pods not managed by ReplicationController, ReplicaSet, Job, or DaemonSet: fluentd-cloud-logging-kubernetes-minion-group-ixsl, kube-proxy-kubernetes-minion-group-ixsl; Ignoring DaemonSet-managed pods: node-problem-detector-v0.1-voc74
 pod "zk-1" deleted
 node "kubernetes-minion-group-ixsl" drained


### PR DESCRIPTION
- change afinity field value to match yaml spec
- update and reorder steps for cordoning nodes to make more sense. currently says "all but four". In reality, we need to cordon the three nodes that the pods are scheduled on, not "all but four".
- add new line to code snippet for easier/correct "copy/paste"

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.8 Features: set Milestone to `1.8` and Base Branch to `release-1.8`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5184)
<!-- Reviewable:end -->
