### PR TITLE
Add description of minikube k8s dns to guestbook

### DIFF
--- a/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
@@ -20,10 +20,12 @@ spec:
         env:
         - name: GET_HOSTS_FROM
           value: dns
-          # If your cluster config does not include a dns service, then to
-          # instead access environment variables to find service host
-          # info, comment out the 'value: dns' line above, and uncomment the
-          # line below:
+          # Using `GET_HOSTS_FROM=dns` requires your cluster configuration to
+          # provide a dns service. Minikube does provide a dns service. However,
+          # if the cluster config you are using does not, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below:
           # value: env
         ports:
         - containerPort: 80

--- a/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
@@ -21,7 +21,9 @@ spec:
         env:
         - name: GET_HOSTS_FROM
           value: dns
-          # If your cluster config does not include a dns service, then to
+          # Using `GET_HOSTS_FROM=dns` requires your cluster configuration to
+          # provide a dns service. Minikube does provide a dns service. However,
+          # if the cluster config you are using does not, then to
           # instead access an environment variable to find the master
           # service's host, comment out the 'value: dns' line above, and
           # uncomment the line below:


### PR DESCRIPTION
Going through the guestbook tutorial for the first time,
the deployment configuration mentioned that whether my configuration
included a DNS service would dictate which env value I used for the
`GET_HOSTS_FROM` variable. I was using `minikube`, like I imagine many
people going through the tutorial for the first time do, and it wasn't
immediately clear to me whether minikube included a dns service (and my
intuition that it wouldn't was incorrect).

Since I imagine the majority of the people going through this tutorial
will use Minikube, specify the Minikube behavior in the comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5187)
<!-- Reviewable:end -->
