### PR TITLE
Use right taint key in doc

### DIFF
--- a/cn/docs/concepts/workloads/controllers/daemonset.md
+++ b/cn/docs/concepts/workloads/controllers/daemonset.md
@@ -95,7 +95,7 @@ DaemonSet 也需要一个 [`.spec`](https://git.k8s.io/community/contributors/de
 
 
 
-Daemon Pod 关心 [Taint 和 Toleration](/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature)，它们会为没有指定 `tolerationSeconds` 的 `node.alpha.kubernetes.io/notReady` 和 `node.alpha.kubernetes.io/unreachable` 的 Taint，创建具有 `NoExecute` 的 Toleration。这确保了当 alpha 特性的 `TaintBasedEvictions` 被启用时，发生节点故障，比如网络分区，这时它们将不会被清除掉（当 `TaintBasedEvictions` 特性没有启用，在这些场景下也不会被清除，但会因为 NodeController 的硬编码行为而被清除，而不会因为 Toleration 导致被清除）。
+Daemon Pod 关心 [Taint 和 Toleration](/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature)，它们会为没有指定 `tolerationSeconds` 的 `node.kubernetes.io/not-ready` 和 `node.alpha.kubernetes.io/unreachable` 的 Taint，创建具有 `NoExecute` 的 Toleration。这确保了当 alpha 特性的 `TaintBasedEvictions` 被启用时，发生节点故障，比如网络分区，这时它们将不会被清除掉（当 `TaintBasedEvictions` 特性没有启用，在这些场景下也不会被清除，但会因为 NodeController 的硬编码行为而被清除，而不会因为 Toleration 导致被清除）。
 
 
 

--- a/docs/concepts/configuration/taint-and-toleration.md
+++ b/docs/concepts/configuration/taint-and-toleration.md
@@ -194,14 +194,14 @@ support for representing node problems. In other words, the node controller
 automatically taints a node when certain condition is true. The built-in taints
 currently include:
 
- * `node.alpha.kubernetes.io/notReady`: Node is not ready. This corresponds to
+ * `node.kubernetes.io/not-ready`: Node is not ready. This corresponds to
    the NodeCondition `Ready` being "`False`".
  * `node.alpha.kubernetes.io/unreachable`: Node is unreachable from the node
    controller. This corresponds to the NodeCondition `Ready` being "`Unknown`".
- * `node.kubernetes.io/outOfDisk`: Node becomes out of disk.
- * `node.kubernetes.io/memoryPressure`: Node has memory pressure.
- * `node.kubernetes.io/diskPressure`: Node has disk pressure.
- * `node.kubernetes.io/networkUnavailable`: Node's network is unavailable.
+ * `node.kubernetes.io/out-of-disk`: Node becomes out of disk.
+ * `node.kubernetes.io/memory-pressure`: Node has memory pressure.
+ * `node.kubernetes.io/disk-pressure`: Node has disk pressure.
+ * `node.kubernetes.io/network-unavailable`: Node's network is unavailable.
  * `node.cloudprovider.kubernetes.io/uninitialized`: When kubelet is started
    with "external" cloud provider, it sets this taint on a node to mark it
    as unusable. When a controller from the cloud-controller-manager initializes
@@ -233,9 +233,9 @@ tolerations:
 ```
 
 Note that Kubernetes automatically adds a toleration for
-`node.alpha.kubernetes.io/notReady` with `tolerationSeconds=300`
+`node.kubernetes.io/not-ready` with `tolerationSeconds=300`
 unless the pod configuration provided
-by the user already has a toleration for `node.alpha.kubernetes.io/notReady`.
+by the user already has a toleration for `node.kubernetes.io/not-ready`.
 Likewise it adds a toleration for
 `node.alpha.kubernetes.io/unreachable` with `tolerationSeconds=300`
 unless the pod configuration provided
@@ -251,7 +251,7 @@ admission controller](https://git.k8s.io/kubernetes/plugin/pkg/admission/default
 `NoExecute` tolerations for the following taints with no `tolerationSeconds`:
 
   * `node.alpha.kubernetes.io/unreachable`
-  * `node.alpha.kubernetes.io/notReady`
+  * `node.kubernetes.io/not-ready`
 
 This ensures that DaemonSet pods are never evicted due to these problems,
 which matches the behavior when this feature is disabled.

--- a/docs/concepts/workloads/controllers/daemonset.md
+++ b/docs/concepts/workloads/controllers/daemonset.md
@@ -113,7 +113,7 @@ when the Pod is created, so it is ignored by the scheduler).  Therefore:
 Daemon Pods do respect [taints and tolerations](/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature),
 but they are created with `NoExecute` tolerations for the following taints with no `tolerationSeconds`:
 
- - `node.alpha.kubernetes.io/notReady`
+ - `node.kubernetes.io/not-ready`
  - `node.alpha.kubernetes.io/unreachable`
 
 This ensures that when the `TaintBasedEvictions` alpha feature is enabled,


### PR DESCRIPTION
Use right taint key in kubernetes doc

Part of: https://github.com/kubernetes/kubernetes/issues/51246

~~**DO NOT MERGE** until kubernetes/kubernetes#51266 is in!~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5188)
<!-- Reviewable:end -->
