### PR TITLE
Update json gem and use bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.11.1)
     liquid (3.0.6)
     listen (3.0.6)
@@ -200,4 +200,4 @@ DEPENDENCIES
   jekyll-include-cache (~> 0.1)
 
 BUNDLED WITH
-   1.13.6
+   1.15.2

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ help: ## Show this help.
 all: build ## Build site with production settings and put deliverables in _site.
 
 build: ## Build site with production settings and put deliverables in _site.
-	jekyll build
+	bundle exec jekyll build
 
 build-preview: ## Build site with drafts and future posts enabled.
-	jekyll build --drafts --future
+	bundle exec jekyll build --drafts --future
 
 serve: ## Boot the development server.
-	jekyll serve
+	bundle exec jekyll serve
 
 stage: ## Run the Jekyll staging container.
 	docker run -ti --rm -v "${PWD}":/k8sdocs -p 4000:4000 gcr.io/google-samples/k8sdocs:1.1


### PR DESCRIPTION
- json 1.8.3 was failing to install on Mac. Upgrading has fixed this.
- Call jekyll through bundler so that Gemfile versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5199)
<!-- Reviewable:end -->
