### PR TITLE
Add description of k8s dns to guestbook

### DIFF
--- a/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
@@ -20,10 +20,13 @@ spec:
         env:
         - name: GET_HOSTS_FROM
           value: dns
-          # If your cluster config does not include a dns service, then to
-          # instead access environment variables to find service host
-          # info, comment out the 'value: dns' line above, and uncomment the
-          # line below:
+          # Using `GET_HOSTS_FROM=dns` requires your cluster to
+          # provide a dns service. As of Kubernetes 1.3, DNS is a built-in
+          # service launched automatically. However, if the cluster you are using
+          # does not have a built-in DNS service, you can instead
+          # instead access an environment variable to find the master
+          # service's host. To do so, comment out the 'value: dns' line above, and
+          # uncomment the line below:
           # value: env
         ports:
         - containerPort: 80

--- a/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
@@ -21,9 +21,12 @@ spec:
         env:
         - name: GET_HOSTS_FROM
           value: dns
-          # If your cluster config does not include a dns service, then to
+          # Using `GET_HOSTS_FROM=dns` requires your cluster to
+          # provide a dns service. As of Kubernetes 1.3, DNS is a built-in
+          # service launched automatically. However, if the cluster you are using
+          # does not have a built-in DNS service, you can instead
           # instead access an environment variable to find the master
-          # service's host, comment out the 'value: dns' line above, and
+          # service's host. To do so, comment out the 'value: dns' line above, and
           # uncomment the line below:
           # value: env
         ports:


### PR DESCRIPTION
Going through the guestbook tutorial for the first time,
the deployment configuration mentioned that whether my configuration
included a DNS service would dictate which env value I used for the
`GET_HOSTS_FROM` variable. According to
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/,
k8s includes DNS by default starting with v1.3.

Add this additional info to help the user better understand when DNS
may/may not be enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5201)
<!-- Reviewable:end -->
