### PR TITLE
Link to individual concepts on concept overview

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -21,18 +21,18 @@ Kubernetes contains a number of abstractions that represent the state of your sy
 
 The basic Kubernetes objects include:
 
-* [Pod](/docs/concepts/abstractions/pod/)
-* Service
-* Volume
-* Namespace
+* [Pod](/docs/concepts/workload/pods/pod-overview/)
+* [Service](/docs/concepts/services-networking/service/)
+* [Volume](/docs/concepts/storage/volumes/)
+* [Namespace](/docs/concepts/overview/working-with-objects/namespaces/)
 
 In addition, Kubernetes contains a number of higher-level abstractions called Controllers. Controllers build upon the basic objects, and provide additional functionality and convenience features. They include:
 
-* ReplicaSet
-* Deployment
-* [StatefulSet](/docs/concepts/abstractions/controllers/statefulsets/)
-* DaemonSet
-* Job
+* [ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)
+* [Deployment](/docs/concepts/workloads/controllers/deployment/)
+* [StatefulSet](/docs/concepts/workloads/controllers/statefulsets/)
+* [DaemonSet](/docs/concepts/workloads/controllers/daemonset/)
+* [Job](/docs/concepts/workloads/controllers/jobs-run-to-completion/)
 
 ## Kubernetes Control Plane
 


### PR DESCRIPTION
On the concept overview page there are lists of example concepts.
Currently only two are linked to (and one of those to an old location).
This change adds links to all of the concepts so that a new user quickly
see some exaple concepts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5202)
<!-- Reviewable:end -->
