### PR TITLE
docs: fixing a typo

### DIFF
--- a/docs/tasks/administer-cluster/cpu-default-namespace.md
+++ b/docs/tasks/administer-cluster/cpu-default-namespace.md
@@ -123,7 +123,7 @@ kubectl create -f https://k8s.io/docs/tasks/administer-cluster/cpu-defaults-pod-
 ```
 
 The output shows that the Container's CPU request is set to the value specified in the
-Container's configuration file. The Container's CPU limit is set to 1 cpu, wh70cb02113b7c7cc1604d1951ef82e1c82850eef2ich is the
+Container's configuration file. The Container's CPU limit is set to 1 cpu, which is the
 default CPU limit for the namespace.
 
 ```


### PR DESCRIPTION
Fixing a small docs typo

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5204)
<!-- Reviewable:end -->
