### PR TITLE
Fix invalid internal link in docs/getting-started-guides/clc.md

### DIFF
--- a/docs/getting-started-guides/clc.md
+++ b/docs/getting-started-guides/clc.md
@@ -143,7 +143,7 @@ between option name and option value.
 ## Cluster Expansion
 
 To expand an existing Kubernetes cluster, run the ```add-kube-node.sh```
-script. A complete list of script options and some examples are listed [[below]](####Cluster Expansion: Script Options).
+script. A complete list of script options and some examples are listed [below](#Cluster Expansion: Script Options).
 This script must be run from the same host that created the cluster (or a host
 that has the cluster artifact files stored in ```~/.clc_kube/$cluster_name```).
 


### PR DESCRIPTION
Link had extra # and extra [

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5210)
<!-- Reviewable:end -->
