### PR TITLE
fix typo:ConfigMap

### DIFF
--- a/docs/concepts/storage/volumes.md
+++ b/docs/concepts/storage/volumes.md
@@ -544,7 +544,7 @@ Each projected volume source is listed in the spec under `sources`. The
 parameters are nearly the same with two exceptions:
 
 * For secrets, the `secretName` field has been changed to `name` to be consistent
-with config maps naming.
+with ConfigMap naming.
 * The `defaultMode` can only be specified at the projected level and not for each
 volume source. However, as illustrated above, you can explicitly set the `mode`
 for each individual projection.


### PR DESCRIPTION
ConfigMap is a kind of volume. So We should use its formal name.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.8 Features: set Milestone to `1.8` and Base Branch to `release-1.8`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5237)
<!-- Reviewable:end -->
