### PR TITLE
Updating vSphere Cloud Provider Documentation

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -12,24 +12,24 @@ This page covers how to get started with deploying Kubernetes on vSphere and det
 
 ### Getting started with the vSphere Cloud Provider
 
-Kubernetes comes with a cloud provider for vSphere. A quick and easy way to try out the cloud provider is to deploy Kubernetes using [Kubernetes-Anywhere](https://github.com/kubernetes/kubernetes-anywhere).
-
-This page also describes how to configure and get started with the cloud provider if deploying using custom install scripts.
+Kubernetes comes with a cloud provider for vSphere. 
+vSphere Cloud Provider for Kubernetes allows Kubernetes Pods to use enterprise grade vSphere Storage.
 
 ### Deploy Kubernetes on vSphere
 
-To start using Kubernetes on top of vSphere and use the vSphere Cloud Provider use Kubernetes-Anywhere. Kubernetes-Anywhere will deploy and configure a cluster from scratch.
+To start using Kubernetes on top of vSphere and use the vSphere Cloud Provider use [Kubernetes-Anywhere](https://github.com/kubernetes/kubernetes-anywhere).
 
 Detailed steps can be found at the [getting started with Kubernetes-Anywhere on vSphere](https://git.k8s.io/kubernetes-anywhere/phase1/vsphere/README.md) page.
 
 ### vSphere Cloud Provider
 
-vSphere Cloud Provider allows using vSphere managed storage within Kubernetes. It supports:
+vSphere Cloud Provider allows using vSphere managed enterprise grade storage within Kubernetes. It supports:
 
-1. Volumes
-2. Persistent Volumes
-3. Storage Classes and provisioning of volumes.
-4. vSphere Storage Policy Based Management for Containers orchestrated by Kubernetes.
+- Enterprise class services such as de-duplication and encryption with vSAN, QoS, high availability and data reliability
+- Policy based management at granularity of container volumes
+- Volumes, Persistent Volumes, Storage Classes,  dynamic provisioning of volumes and scalable deployment of Stateful Apps with StatefulSets
+
+For more detail visit [vSphere Storage for Kubernetes Documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html)
 
 Documentation for how to use vSphere managed storage can be found in the [persistent volumes user guide](/docs/concepts/storage/persistent-volumes/#vsphere) and the [volumes user guide](/docs/concepts/storage/volumes/#vspherevolume).
 
@@ -184,7 +184,7 @@ Below is summary of supported parameters in the `vsphere.conf` file
 --cloud-config=<Path of the vsphere.conf file>
 ```
 
-Manifest files for API server and controller-manager are generally located at `/etc/kubernetes`.
+Manifest files for API server and controller-manager are generally located at `/etc/kubernetes/manifests`.
 
 **Step-7** Restart Kubelet on all nodes.
 
@@ -194,16 +194,17 @@ Manifest files for API server and controller-manager are generally located at `/
 Note: After enabling the vSphere Cloud Provider, Node names will be set to the VM names from the vCenter Inventory.
 
 #### Known issues
-[vmware#220](https://github.com/vmware/kubernetes/issues/220) :
-vSphere Cloud Provider can not be used on the Kubernetes Cluster when vCenter port is configured other than the default port 443. Fix for this issue is already out (Kubernetes PR# [49689](https://github.com/kubernetes/kubernetes/pull/49689)). We will make sure that, PR 49689 is cherry picked to 1.7, 1.6 and 1.5 branches. 
+Please visit this [link](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/known-issues.html) for the list of major known issues with Kubernetes vSphere Cloud Provider
 
 ## Support Level
 
+For quick support please join VMware Code Slack ([#kubernetes](https://vmwarecode.slack.com/messages/kubernetes/)) and post your question.
 
 IaaS Provider        | Config. Mgmt | OS     | Networking | Docs                                          | Conforms  | Support Level
 -------------------- | ------------ | ------ | ---------- | --------------------------------------------- | --------- | ----------------------------
 Vmware vSphere       | Kube-anywhere    | Photon OS | Flannel         | [docs](/docs/getting-started-guides/vsphere)                                |                | Community  ([@abrarshivani](https://github.com/abrarshivani)), ([@kerneltime](https://github.com/kerneltime)), ([@BaluDontu](https://github.com/BaluDontu)), ([@luomiao](https://github.com/luomiao)), ([@divyenpatel](https://github.com/divyenpatel))
 
 If you identify any issues/problems using the vSphere cloud provider, you can create an issue in our repo - [VMware Kubernetes](https://github.com/vmware/kubernetes).
+
 
 For support level information on all solutions, see the [Table of solutions](/docs/getting-started-guides/#table-of-solutions) chart.

--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -12,24 +12,23 @@ This page covers how to get started with deploying Kubernetes on vSphere and det
 
 ### Getting started with the vSphere Cloud Provider
 
-Kubernetes comes with a cloud provider for vSphere. 
-vSphere Cloud Provider for Kubernetes allows Kubernetes Pods to use enterprise grade vSphere Storage.
+Kubernetes comes with *vSphere Cloud Provider*, a cloud provider for vSphere that allows Kubernetes Pods to use enterprise grade vSphere Storage.
 
 ### Deploy Kubernetes on vSphere
 
-To start using Kubernetes on top of vSphere and use the vSphere Cloud Provider use [Kubernetes-Anywhere](https://github.com/kubernetes/kubernetes-anywhere).
+To deploy Kubernetes on vSphere and use the vSphere Cloud Provider, see [Kubernetes-Anywhere](https://github.com/kubernetes/kubernetes-anywhere). 
 
 Detailed steps can be found at the [getting started with Kubernetes-Anywhere on vSphere](https://git.k8s.io/kubernetes-anywhere/phase1/vsphere/README.md) page.
 
 ### vSphere Cloud Provider
 
-vSphere Cloud Provider allows using vSphere managed enterprise grade storage within Kubernetes. It supports:
+vSphere Cloud Provider allows Kubernetes to use vSphere managed enterprise grade storage. It supports:
 
-- Enterprise class services such as de-duplication and encryption with vSAN, QoS, high availability and data reliability
-- Policy based management at granularity of container volumes
-- Volumes, Persistent Volumes, Storage Classes,  dynamic provisioning of volumes and scalable deployment of Stateful Apps with StatefulSets
+- Enterprise class services such as de-duplication and encryption with vSAN, QoS, high availability and data reliability.
+- Policy based management at granularity of container volumes.
+- Volumes, Persistent Volumes, Storage Classes, dynamic provisioning of volumes, and scalable deployment of Stateful Apps with StatefulSets.
 
-For more detail visit [vSphere Storage for Kubernetes Documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html)
+For more detail visit [vSphere Storage for Kubernetes Documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html).
 
 Documentation for how to use vSphere managed storage can be found in the [persistent volumes user guide](/docs/concepts/storage/persistent-volumes/#vsphere) and the [volumes user guide](/docs/concepts/storage/volumes/#vspherevolume).
 
@@ -194,7 +193,7 @@ Manifest files for API server and controller-manager are generally located at `/
 Note: After enabling the vSphere Cloud Provider, Node names will be set to the VM names from the vCenter Inventory.
 
 #### Known issues
-Please visit this [link](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/known-issues.html) for the list of major known issues with Kubernetes vSphere Cloud Provider
+Please visit [known issues](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/known-issues.html) for the list of major known issues with Kubernetes vSphere Cloud Provider.
 
 ## Support Level
 


### PR DESCRIPTION
Summary of Change.

- Updated Introduction for vSphere Cloud Provider.
- Added link to vSphere Storage for Kubernetes Documentation.
- Added Slack Support Channel
- Removed resolved known issues, and added link to the list of known issues posted on vSphere Cloud Provider documentation site.
 

Preview - https://deploy-preview-5241--kubernetes-io-master-staging.netlify.com/docs/getting-started-guides/vsphere/

Please review: @BaluDontu @tusharnt @pdhamdhere

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5241)
<!-- Reviewable:end -->
