### PR TITLE
Make caret for version drop-down more visible for v1.5

### DIFF
--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -258,6 +258,9 @@ ul.global-nav
 				left: 0
 				background: #fff
 
+			.ui-icon
+				filter: brightness(0) invert(1)
+
 		ul
 			display: none
 			position: fixed
@@ -285,6 +288,9 @@ ul.global-nav
 .flip-nav ul.global-nav li a,
 .open-nav ul.global-nav li a,
 	color: $dark-grey
+
+.flip-nav ul.global-nav li a .ui-icon
+	filter: brightness(0)
 
 .flip-nav ul.global-nav li ul li a,
 	background: #fff


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5271)
<!-- Reviewable:end -->
