### PR TITLE
Fix the mistakes in the "StatefulSet Basics"

### DIFF
--- a/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -499,7 +499,7 @@ web-1   gcr.io/google_containers/nginx-slim:0.8
 web-2   gcr.io/google_containers/nginx-slim:0.8
 {% endraw %}```
 
-`web-0` has had its image updated, but `web-0` and `web-1` still have the original 
+`web-0` has had its image updated, but `web-1` and `web-2` still have the original 
 image. Complete the update by deleting the remaining Pods.
 
 ```shell


### PR DESCRIPTION
In the section "Updating StatefulSets", when the update strategy is "OnDelete" and the "web-0" pod is updated by deleting it manually.
Then the "web-1" and "web-2" should still have the original image. But in the current version, the article says that the "web-0" and "web-1" still have the original image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5324)
<!-- Reviewable:end -->
