### PR TITLE
Correct typo opaque-integer-resource-node.md

### DIFF
--- a/docs/tasks/administer-cluster/opaque-integer-resource-node.md
+++ b/docs/tasks/administer-cluster/opaque-integer-resource-node.md
@@ -144,7 +144,7 @@ could advertise special storage in chunks of size 1 byte. In that case, you woul
 ```yaml
 Capacity:
  ...
- pod.alpha.kubernetes.io/opaque-int-special-storage:  8Gi
+ pod.alpha.kubernetes.io/opaque-int-special-storage:  800Gi
 ```
 
 Then a Container could request any number of bytes of special storage, up to 800Gi.


### PR DESCRIPTION
correct typo acoording to context.
PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5329)
<!-- Reviewable:end -->
