### PR TITLE
Kuberenetes on DC/OS teaser & warning about legacy guide

### DIFF
--- a/docs/getting-started-guides/dcos.md
+++ b/docs/getting-started-guides/dcos.md
@@ -6,6 +6,10 @@ title: DCOS
 
 {% assign for_k8s_version="1.6" %}{% include feature-state-deprecated.md %}
 
+**[Kuberenetes on DC/OS](https://mesosphere.com/blog/kubernetes-dcos/) is coming soon!**
+
+**WARNING**: This legacy guide requires DCOS v1.6 and installs Kubernetes v1.1.5.
+
 This guide will walk you through installing [Kubernetes-Mesos](https://github.com/mesosphere/kubernetes-mesos) on [Datacenter Operating System (DCOS)](https://mesosphere.com/product/) with the [DCOS CLI](https://github.com/mesosphere/dcos-cli) and operating Kubernetes with the [DCOS Kubectl plugin](https://github.com/mesosphere/dcos-kubectl).
 
 * TOC


### PR DESCRIPTION
This guide doesn't work with recent versions of either DC/OS or Kubernetes. It's marked as deprecated, but really it's just dead.

[A new Kuberenetes on DC/OS project has been announced](https://mesosphere.com/blog/kubernetes-dcos/) but is not available yet. The new project is not based on the old kubernetes-mesos project and has no relation to [kubernetes-incubator/kube-mesos-framework](https://github.com/kubernetes-incubator/kube-mesos-framework). When the new project is ready, this page will probably be replaced with a stub pointing to a new guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5340)
<!-- Reviewable:end -->
