### PR TITLE
Add quotes to JSONPATH bash variable

### DIFF
--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -128,7 +128,7 @@ $ echo $(kubectl get pods --selector=$sel --output=jsonpath={.items..metadata.na
 
 # Check which nodes are ready
 $ JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}' \
- && kubectl get nodes -o jsonpath=$JSONPATH | grep "Ready=True"
+ && kubectl get nodes -o jsonpath="$JSONPATH" | grep "Ready=True"
 
 # List all Secrets currently in use by a pod
 $ kubectl get pods -o json | jq '.items[].spec.containers[].env[]?.valueFrom.secretKeyRef.name' | grep -v null | sort | uniq


### PR DESCRIPTION
The command was failing with

    error: error parsing jsonpath {range, unclosed action

We need to quote `$JSONPATH` so the full contents of the variable are
passed to `-o jsonpath=`.

Fixes #4258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5353)
<!-- Reviewable:end -->
