### PR TITLE
adding explanation for product_uuid uniqueness need and how to check it

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -20,6 +20,16 @@ This page shows how to use install kubeadm.
 
 {% capture steps %}
 
+## Verify the MAC address and product_uuid are unique for every node
+
+* You can get the MAC address of the network interfaces using the command `ip link` or `ifconfig -a`
+* The product_uuid can be checked by using the command `sudo cat /sys/class/dmi/id/product_uuid`
+
+It is very likely that hardware devices will have unique addresses, although some virtual machines may have
+identical values. Kubernetes uses these values to uniquely identify the nodes in the cluster.
+If these values are not unique to each node, the installation processes
+[can fail](https://github.com/kubernetes/kubeadm/issues/31).
+
 ## Check required ports
 
 ### Master node(s)


### PR DESCRIPTION
added steps for how to verify macaddress and product_uuid with reference to the bug in github that identified this need originally (https://github.com/kubernetes/kubeadm/issues/31)

Added because I wasn't clear what product_uuid was, or how to check it - so I dug it out. Details where in the original bug (referenced). I wasn't sure if it was a good idea or not to reference the bug that caused this to be added, so I opted to include a link to it, even though it's closed. If that's not good form, I can easily remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5368)
<!-- Reviewable:end -->
