### PR TITLE
Fix configmaps resource name in rbac.md

### DIFF
--- a/docs/admin/authorization/rbac.md
+++ b/docs/admin/authorization/rbac.md
@@ -181,7 +181,7 @@ metadata:
   name: configmap-updater
 rules:
 - apiGroups: [""]
-  resources: ["configmap"]
+  resources: ["configmaps"]
   resourceNames: ["my-configmap"]
   verbs: ["update", "get"]
 ```


### PR DESCRIPTION
The resource is 'configmaps', not 'configmap'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5389)
<!-- Reviewable:end -->
