### PR TITLE
Edits cpu-constraint-namespace.md

### DIFF
--- a/docs/tasks/administer-cluster/cpu-constraint-namespace.md
+++ b/docs/tasks/administer-cluster/cpu-constraint-namespace.md
@@ -195,7 +195,7 @@ resources:
 Because your Container did not specify its own CPU request and limit, it was given the
 [default CPU request and limit](/docs/tasks/administer-cluster/cpu-default-namespace/)
 from the LimitRange.
-* [Configure Memory and CPU Quotas for a Namespace](/docs/tasks/administer-cluster/quota-memory-cpu-namespace)
+
 At this point, your Container might be running or it might not be running. Recall that a prerequisite
 for this task is that your Nodes have at least 1 CPU. If each of your Nodes has only
 1 CPU, then there might not be enough allocatable CPU on any Node to accommodate a request
@@ -219,12 +219,12 @@ Pods that were created previously.
 As a cluster administrator, you might want to impose restrictions on the CPU resources that Pods can use.
 For example:
 
-* Each Node in a cluster has 2 cpu. You do not want to accept any Pod that requests
-more than 2 cpu, because no Node in the cluster can support the request.
+* Each Node in a cluster has 2 CPU. You do not want to accept any Pod that requests
+more than 2 CPU, because no Node in the cluster can support the request.
 
 * A cluster is shared by your production and development departments.
-You want to allow production workloads to consume up to 3 cpu, but you want development workloads to be limited
-to 1 cpu. You create separate namespaces for production and development, and you apply CPU constraints to
+You want to allow production workloads to consume up to 3 CPU, but you want development workloads to be limited
+to 1 CPU. You create separate namespaces for production and development, and you apply CPU constraints to
 each namespace.
 
 ## Clean up


### PR DESCRIPTION
- Removes stray link in middle of paragraph
- "cpu" becomes "CPU" throughout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5391)
<!-- Reviewable:end -->
