### PR TITLE
Update guestbook tutorial for k8s-1.8

### DIFF
--- a/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: frontend
 spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   replicas: 3
   template:
     metadata:

--- a/docs/tutorials/stateless-application/guestbook/redis-master-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/redis-master-deployment.yaml
@@ -1,8 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: redis-master
 spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
   replicas: 1
   template:
     metadata:

--- a/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
@@ -1,8 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: redis-slave
 spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   replicas: 2
   template:
     metadata:


### PR DESCRIPTION
Update to use apps/v1beta2
Update spec.selector which is now required
The rest of the tutorial is up-to-date.

cc @kubernetes/sig-apps-pr-reviews @kow3ns

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5421)
<!-- Reviewable:end -->
