### PR TITLE
Update kubectl patch doc to use apps/v1beta2 APIs

### DIFF
--- a/cn/docs/tasks/run-application/deployment-patch-demo.yaml
+++ b/cn/docs/tasks/run-application/deployment-patch-demo.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: patch-demo
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/docs/tasks/run-application/deployment-patch-demo.yaml
+++ b/docs/tasks/run-application/deployment-patch-demo.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: patch-demo
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -81,13 +81,13 @@ The output shows that the PodSpec in the Deployment has two Containers:
 
 ```shell
 containers:
-- image: nginx
-  imagePullPolicy: Always
-  name: patch-demo-ctr
-  ...
 - image: redis
   imagePullPolicy: Always
   name: patch-demo-ctr-2
+  ...
+- image: nginx
+  imagePullPolicy: Always
+  name: patch-demo-ctr
   ...
 ```
 
@@ -118,9 +118,9 @@ The output shows that the Pod has two Containers: one running nginx and one runn
 
 ```
 containers:
-- image: nginx
-  ...
 - image: redis
+  ...
+- image: nginx
   ...
 ```
 


### PR DESCRIPTION
This PR updates YAML file of kubectl patch doc to use apps/v1beta2 APIs, and changes some sentences and order of terminal outputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5422)
<!-- Reviewable:end -->
