### PR TITLE
Update docs/admin/kubeadm.md for 1.8

### DIFF
--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -65,10 +65,8 @@ toc:
 
 - title: Setup Tools
   section:
-  - title: Kubeadm
-    path: /docs/admin/kubeadm/
+  - docs/admin/kubeadm.md
   - title: Kubefed
-    path: /docs/admin/kubefed/
     section:
     - docs/admin/kubefed.md
     - docs/admin/kubefed_options.md


### PR DESCRIPTION
 - Made a couple of minor wording changes (not strictly 1.8 related).
 - Did some reformatting (not strictly 1.8 related).
 - Updated references to the default token TTL (was infinite, now 24 hours).
 - Documented the new `--discovery-token-ca-cert-hash` and `--discovery-token-unsafe-skip-ca-verification` flags for `kubeadm join`.
 - Added references to the new `--discovery-token-ca-cert-hash` flag in all the default examples.
 - Added a new _Security model_ section that describes the security tradeoffs of the various discovery modes.
 - Documented the new `--groups` flag for `kubeadm token create`.
 - Added a note of caution under _Automating kubeadm_ that references the _Security model_ section.
 - Updated the component version table to drop 1.6 and add 1.8.
 - Update `_data/reference.yml` to try to get the sidebar fixed up and more consistent with `kubefed`.

cc @kubernetes/sig-cluster-lifecycle-misc @luxas @mhausenblas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5440)
<!-- Reviewable:end -->
