### PR TITLE
revert WordPress and MySQL PV doc changes to use apps/v1beta2 APIs

### DIFF
--- a/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
+++ b/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
@@ -25,17 +25,13 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: wordpress-mysql
   labels:
     app: wordpress
 spec:
-  selector:
-    matchLabels:
-      app: wordpress
-      tier: mysql
   strategy:
     type: Recreate
   template:

--- a/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
+++ b/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
@@ -25,17 +25,13 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: wordpress
   labels:
     app: wordpress
 spec:
-  selector:
-    matchLabels:
-      app: wordpress
-      tier: frontend
   strategy:
     type: Recreate
   template:

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
@@ -25,17 +25,13 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: wordpress-mysql
   labels:
     app: wordpress
 spec:
-  selector:
-    matchLabels:
-      app: wordpress
-      tier: mysql
   strategy:
     type: Recreate
   template:

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
@@ -25,17 +25,13 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: wordpress
   labels:
     app: wordpress
 spec:
-  selector:
-    matchLabels:
-      app: wordpress
-      tier: frontend
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
Revert the changes of PR #5424 as the PR targeted the wrong branch.
The auto revert mechanism does not work.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5461)
<!-- Reviewable:end -->
