### PR TITLE
add the set of sessionAffinity timeoutseconds

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -177,7 +177,7 @@ or `Services` or `Pods`.
 By default, the choice of backend is round robin.  Client-IP based session affinity
 can be selected by setting `service.spec.sessionAffinity` to `"ClientIP"` (the
 default is `"None"`), and you can set the max session sticky time by setting the field
-`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` if you already setted 
+`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` if you have already set 
 `service.spec.sessionAffinity` to `"ClientIP"` (the default is "10800").
 
 ![Services overview diagram for userspace proxy](/images/docs/services-userspace-overview.svg)
@@ -194,7 +194,7 @@ select a backend `Pod`.
 By default, the choice of backend is random.  Client-IP based session affinity
 can be selected by setting `service.spec.sessionAffinity` to `"ClientIP"` (the
 default is `"None"`), and you can set the max session sticky time by setting the field
-`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` if you already setted 
+`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` if you have already set 
 `service.spec.sessionAffinity` to `"ClientIP"` (the default is "10800").
 
 As with the userspace proxy, the net result is that any traffic bound for the

--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -176,7 +176,9 @@ or `Services` or `Pods`.
 
 By default, the choice of backend is round robin.  Client-IP based session affinity
 can be selected by setting `service.spec.sessionAffinity` to `"ClientIP"` (the
-default is `"None"`).
+default is `"None"`), and you can set the max session sticky time by setting the field
+`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` if you already setted 
+`service.spec.sessionAffinity` to `"ClientIP"` (the default is "10800").
 
 ![Services overview diagram for userspace proxy](/images/docs/services-userspace-overview.svg)
 
@@ -191,7 +193,9 @@ select a backend `Pod`.
 
 By default, the choice of backend is random.  Client-IP based session affinity
 can be selected by setting `service.spec.sessionAffinity` to `"ClientIP"` (the
-default is `"None"`).
+default is `"None"`), and you can set the max session sticky time by setting the field
+`service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` if you already setted 
+`service.spec.sessionAffinity` to `"ClientIP"` (the default is "10800").
 
 As with the userspace proxy, the net result is that any traffic bound for the
 `Service`'s IP:Port is proxied to an appropriate backend without the clients


### PR DESCRIPTION
according [this pr](https://github.com/kubernetes/kubernetes/pull/49850), now we can set session affinity tomeoutseconds, so I added something about that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5474)
<!-- Reviewable:end -->
