### PR TITLE
Clarify the API to check for device plugins

### DIFF
--- a/docs/concepts/cluster-administration/device-plugins.md
+++ b/docs/concepts/cluster-administration/device-plugins.md
@@ -31,7 +31,7 @@ A device plugin can register itself with the kubelet through this gRPC service.
 During the registration, the device plugin needs to send:
 
   * The name of its Unix socket.
-  * The API version against which it was built.
+  * The Device Plugin API version against which it was built.
   * The `ResourceName` it wants to advertise. Here `ResourceName` needs to follow the
     [extended resource naming scheme](https://github.com/kubernetes/kubernetes/pull/48922)
     as `vendor-domain/resource`.


### PR DESCRIPTION
This patch clarifies the APIs to be checked against when a device plugin registers itself to kubelet. Simply mentioning API could lead to misunderstandings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5478)
<!-- Reviewable:end -->
