### PR TITLE
Updated Deployments concepts doc

### DIFF
--- a/docs/concepts/workloads/controllers/deployment.md
+++ b/docs/concepts/workloads/controllers/deployment.md
@@ -288,7 +288,8 @@ It is generally discouraged to make label selector updates and it is suggested t
 In any case, if you need to perform a label selector update, exercise great caution and make sure you have grasped
 all of the implications.
 
-Note that in API version `apps/v1beta2`, a Deployment's label selector is immutable after it gets created.
+**Note:** In API version `apps/v1beta2`, a Deployment's label selector is immutable after it gets created.
+{: .note}
 
 * Selector additions require the pod template labels in the Deployment spec to be updated with the new label too,
 otherwise a validation error is returned. This change is a non-overlapping one, meaning that the new selector does
@@ -928,7 +929,7 @@ a Pod is considered ready, see [Container Probes](/docs/concepts/workloads/pods/
 
 ### Rollback To
 
-Field `.spec.rollbackTo` has been deprecated in API versions `extensions/v1beta1` and `apps/v1beta1`, and removed in API version `apps/v1beta2`. Instead, `kubectl rollout undo` as introduced in [Rolling Back to a Previous Revision](#rolling-back-to-a-previous-revision) should be used.
+Field `.spec.rollbackTo` has been deprecated in API versions `extensions/v1beta1` and `apps/v1beta1`, and is no longer supported in API version `apps/v1beta2`. Instead, `kubectl rollout undo` as introduced in [Rolling Back to a Previous Revision](#rolling-back-to-a-previous-revision) should be used.
 
 ### Revision History Limit
 

--- a/docs/concepts/workloads/controllers/deployment.md
+++ b/docs/concepts/workloads/controllers/deployment.md
@@ -288,6 +288,8 @@ It is generally discouraged to make label selector updates and it is suggested t
 In any case, if you need to perform a label selector update, exercise great caution and make sure you have grasped
 all of the implications.
 
+In Kubernetes 1.8 or later, after a Deployment gets created, its label selector is immutable.
+
 * Selector additions require the pod template labels in the Deployment spec to be updated with the new label too,
 otherwise a validation error is returned. This change is a non-overlapping one, meaning that the new selector does
 not select ReplicaSets and Pods created with the old selector, resulting in orphaning all old ReplicaSets and
@@ -850,9 +852,9 @@ allowed, which is the default if not specified.
 `.spec.selector` is an optional field that specifies a [label selector](/docs/concepts/overview/working-with-objects/labels/)
 for the Pods targeted by this deployment.
 
-If specified, `.spec.selector` must match `.spec.template.metadata.labels`, or it will be rejected by
-the API.  If `.spec.selector` is unspecified, `.spec.selector.matchLabels` defaults to
-`.spec.template.metadata.labels`.
+`.spec.selector` must match `.spec.template.metadata.labels`, or it will be rejected by the API.
+
+In Kubernetes 1.8 or later, `.spec.selector` and `.metadata.labels` no longer default to `.spec.template.metadata.labels` if not set. So they must be set explicitly. Also note that `.spec.selector` is immutable after creation of the Deployment in Kubernetes 1.8 or later.
 
 A Deployment may terminate Pods whose labels match the selector if their template is different
 from `.spec.template` or if the total number of such Pods exceeds `.spec.replicas`. It brings up new
@@ -926,20 +928,7 @@ a Pod is considered ready, see [Container Probes](/docs/concepts/workloads/pods/
 
 ### Rollback To
 
-`.spec.rollbackTo` is an optional field with the configuration the Deployment
-should roll back to. Setting this field triggers a rollback, and this field will
-be cleared by the server after a rollback is done.
-
-Because this field will be cleared by the server, it should not be used
-declaratively. For example, you should not perform `kubectl apply` with a
-manifest with `.spec.rollbackTo` field set.
-
-#### Revision
-
-`.spec.rollbackTo.revision` is an optional field specifying the revision to roll
-back to. Setting to 0 means rolling back to the last revision in history;
-otherwise, means rolling back to the specified revision. This defaults to 0 when
-[`spec.rollbackTo`](#rollback-to) is set.
+In Kubernetes 1.8 or later, field `.spec.rollbackTo` is deprecated. Instead, `kubectl rollout undo` as introduced in [Rolling Back to a Previous Revision](#rolling-back-to-a-previous-revision) should be used.
 
 ### Revision History Limit
 

--- a/docs/concepts/workloads/controllers/deployment.md
+++ b/docs/concepts/workloads/controllers/deployment.md
@@ -288,7 +288,7 @@ It is generally discouraged to make label selector updates and it is suggested t
 In any case, if you need to perform a label selector update, exercise great caution and make sure you have grasped
 all of the implications.
 
-In Kubernetes 1.8 or later, after a Deployment gets created, its label selector is immutable.
+Note that in API version `apps/v1beta2`, a Deployment's label selector is immutable after it gets created.
 
 * Selector additions require the pod template labels in the Deployment spec to be updated with the new label too,
 otherwise a validation error is returned. This change is a non-overlapping one, meaning that the new selector does
@@ -854,7 +854,7 @@ for the Pods targeted by this deployment.
 
 `.spec.selector` must match `.spec.template.metadata.labels`, or it will be rejected by the API.
 
-In Kubernetes 1.8 or later, `.spec.selector` and `.metadata.labels` no longer default to `.spec.template.metadata.labels` if not set. So they must be set explicitly. Also note that `.spec.selector` is immutable after creation of the Deployment in Kubernetes 1.8 or later.
+In API version `apps/v1beta2`, `.spec.selector` and `.metadata.labels` no longer default to `.spec.template.metadata.labels` if not set. So they must be set explicitly. Also note that `.spec.selector` is immutable after creation of the Deployment in `apps/v1beta2`.
 
 A Deployment may terminate Pods whose labels match the selector if their template is different
 from `.spec.template` or if the total number of such Pods exceeds `.spec.replicas`. It brings up new
@@ -928,7 +928,7 @@ a Pod is considered ready, see [Container Probes](/docs/concepts/workloads/pods/
 
 ### Rollback To
 
-In Kubernetes 1.8 or later, field `.spec.rollbackTo` is deprecated. Instead, `kubectl rollout undo` as introduced in [Rolling Back to a Previous Revision](#rolling-back-to-a-previous-revision) should be used.
+Field `.spec.rollbackTo` has been deprecated in API versions `extensions/v1beta1` and `apps/v1beta1`, and removed in API version `apps/v1beta2`. Instead, `kubectl rollout undo` as introduced in [Rolling Back to a Previous Revision](#rolling-back-to-a-previous-revision) should be used.
 
 ### Revision History Limit
 

--- a/docs/concepts/workloads/controllers/nginx-deployment.yaml
+++ b/docs/concepts/workloads/controllers/nginx-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1beta2 # for versions before 1.7.0 use apps/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/concepts/workloads/controllers/nginx-deployment.yaml
+++ b/docs/concepts/workloads/controllers/nginx-deployment.yaml
@@ -2,8 +2,13 @@ apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment
+  labels:
+    app: nginx
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR updated the concept doc for Deployments. This is a part of broader efforts to enhance the workloads controller docs. The corresponding example nginx deployment YAML file was also updated to reflect the removal of selector defaulting for apps/v1beta2 in kubernetes/kubernetes#50164.

@janetkuo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5491)
<!-- Reviewable:end -->
