### PR TITLE
Fixed links to architecture.md and principles.md

### DIFF
--- a/docs/concepts/overview/what-is-kubernetes.md
+++ b/docs/concepts/overview/what-is-kubernetes.md
@@ -93,7 +93,7 @@ Even though Kubernetes provides a lot of functionality, there are always new sce
 
 Additionally, the [Kubernetes control plane](/docs/concepts/overview/components/) is built upon the same [APIs](/docs/reference/api-overview/) that are available to developers and users. Users can write their own controllers, such as [schedulers](https://github.com/kubernetes/community/blob/{{page.githubbranch}}/contributors/devel/scheduler.md), with [their own APIs](https://github.com/kubernetes/community/blob/{{page.githubbranch}}/contributors/design-proposals/api-machinery/extending-api.md) that can be targeted by a general-purpose [command-line tool](/docs/user-guide/kubectl-overview/).
 
-This [design](https://github.com/kubernetes/community/blob/{{page.githubbranch}}/contributors/design-proposals/architecture/principles.md) has enabled a number of other systems to build atop Kubernetes.
+This [design](https://git.k8s.io/community/contributors/design-proposals/architecture/principles.md) has enabled a number of other systems to build atop Kubernetes.
 
 #### What Kubernetes is not
 


### PR DESCRIPTION
Recently, architecture.md and principles.md were moved into a subdirectory architecture and links to them are now broken.

This PR fixes links to these two documents in the kubernetes.github.io repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5510)
<!-- Reviewable:end -->
