### PR TITLE
encrypt-data: mention etcdv3 requirement

### DIFF
--- a/docs/tasks/administer-cluster/encrypt-data.md
+++ b/docs/tasks/administer-cluster/encrypt-data.md
@@ -14,6 +14,8 @@ This page shows how to enable and configure encryption of secret data at rest.
 
 * Kubernetes version 1.7.0 or later is required
 
+* etcd v3 or later is required
+
 * Encryption at rest is alpha in 1.7.0 which means it may change without notice. Users may be required to decrypt their data prior to upgrading to 1.8.0.
 
 {% endcapture %}


### PR DESCRIPTION
This PR updates encryption data docs to mention that etcd V3 is required.

PTAL @smarterclayton 
CC @simo5

Fixes #5388

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5521)
<!-- Reviewable:end -->
