### PR TITLE
Re-update WordPress and MySQL PV doc to use apps/v1beta2 APIs

### DIFF
--- a/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
+++ b/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
@@ -25,13 +25,17 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: wordpress-mysql
   labels:
     app: wordpress
 spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
   strategy:
     type: Recreate
   template:

--- a/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
+++ b/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
@@ -25,13 +25,17 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: wordpress
   labels:
     app: wordpress
 spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
   strategy:
     type: Recreate
   template:

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
@@ -25,13 +25,17 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: wordpress-mysql
   labels:
     app: wordpress
 spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
   strategy:
     type: Recreate
   template:

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
@@ -25,13 +25,17 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: wordpress
   labels:
     app: wordpress
 spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
This PR re-updates YAML file of WordPress and MySQL persistent volume doc to use apps/v1beta2 APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5526)
<!-- Reviewable:end -->
