### PR TITLE
Experiment to see whether Netlify preview works.

### DIFF
--- a/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -4,7 +4,7 @@ title: Assign CPU Resources to Containers and Pods
 
 {% capture overview %}
 
-This page shows how to assign a CPU *request* and a CPU *limit* to
+This page shows you how to assign a CPU *request* and a CPU *limit* to
 a Container. A Container is guaranteed to have as much CPU as it requests,
 but is not allowed to use more CPU than its limit.
 


### PR DESCRIPTION
The purpose of the PR is to test the Netlify preview. Here's what I think is happening:

PR https://github.com/kubernetes/kubernetes.github.io/pull/5381 added cn/docs/tasks/inject-data-application/define-command-argument-container.md, which has {% include ... commands.yaml ... %}.
But PR https://github.com/kubernetes/kubernetes.github.io/pull/5381 does not add commands.yaml to cn/docs/tasks/inject-data-application.

So now in other PRs, like this one, the Netlify preview is failing with this:
Liquid Exception: Could not locate the included file 'commands.yaml' in any of ["/opt/build/repo/cn/docs/tasks/inject-data-application"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source. in cn/docs/tasks/inject-data-application/define-command-argument-container.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5527)
<!-- Reviewable:end -->
