### PR TITLE
Update NetworkPolicy concept guide with egress and CIDR changes

### DIFF
--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -21,7 +21,7 @@ Network policies are implemented by the network plugin, so you must be using a n
 
 By default, pods are non-isolated; they accept traffic from any source.
 
-Pods become isolated by having a NetworkPolicy that selects them. Once there is any NetworkPolicy in a Namespace selecting a particular pod, that pod will reject any connections that are not allowed by any NetworkPolicy. (Other pods in the Namespace that are not selected by any NetworkPolicy will continue to accept all traffic.)
+Pods become isolated by having a NetworkPolicy that selects them. Once there is any NetworkPolicy in a namespace selecting a particular pod, that pod will reject any connections that are not allowed by any NetworkPolicy. (Other pods in the namespace that are not selected by any NetworkPolicy will continue to accept all traffic.)
 
 ## The `NetworkPolicy` Resource
 
@@ -39,6 +39,9 @@ spec:
   podSelector:
     matchLabels:
       role: db
+  policyTypes:
+  - Ingress
+  - Egress
   ingress:
   - from:
     - namespaceSelector:
@@ -50,6 +53,13 @@ spec:
     ports:
     - protocol: TCP
       port: 6379
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/24
+    ports:
+    - protocol: TCP
+      port: 5978
 ```
 
 *POSTing this to the API server will have no effect unless your chosen networking solution supports network policy.*
@@ -60,19 +70,29 @@ __spec__: `NetworkPolicy` [spec](https://git.k8s.io/community/contributors/devel
 
 __podSelector__: Each `NetworkPolicy` includes a `podSelector` which selects the grouping of pods to which the policy applies. Since `NetworkPolicy` currently only supports defining `ingress` rules, this `podSelector` essentially defines the "destination pods" for the policy. The example policy selects pods with the label "role=db". An empty `podSelector` selects all pods in the namespace.
 
-__ingress__: Each `NetworkPolicy` includes a list of whitelist `ingress` rules.  Each rule allows traffic which matches both the `from` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port, from either of two sources, the first specified via a `namespaceSelector` and the second specified via a `podSelector`.
+__policyTypes__: Each `NetworkPolicy` includes a `policyTypes` list which may include either `Ingress`, `Egress`, or both. The `policyTypes` field indicates whether or not the given policy applies to ingress traffic to selected pod, egress traffic from selected pods, or both. If no `policyTypes` are specified on a NetworkPolicy then by default `Ingress` will always be set and `Egress` will be set if the NetworkPolicy has any egress rules.
+
+__ingress__: Each `NetworkPolicy` may include a list of whitelist `ingress` rules.  Each rule allows traffic which matches both the `from` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port, from either of two sources, the first specified via a `namespaceSelector` and the second specified via a `podSelector`.
+
+__egress__: Each `NetworkPolicy` may include a list of whitelist `egress` rules.  Each rule allows traffic which matches both the `to` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port to any destination in `10.0.0.0/24`.
 
 So, the example NetworkPolicy:
 
-1. isolates "role=db" pods in the "default" namespace (if they weren't already isolated)
+1. isolates "role=db" pods in the "default" namespace for both ingress and egress traffic (if they weren't already isolated)
 2. allows connections to TCP port 6379 of "role=db" pods in the "default" namespace from any pod in the "default" namespace with the label "role=frontend"
 3. allows connections to TCP port 6379 of "role=db" pods in the "default" namespace from any pod in a namespace with the label "project=myproject"
+3. allows connections from any pod in the "default" namespace with the label "role=db" to CIDR 10.0.0.0/24 on TCP port 5978
 
 See the [NetworkPolicy getting started guide](/docs/getting-started-guides/network-policy/walkthrough) for further examples.
 
 ## Default policies
 
-You can create a "default" isolation policy for a Namespace by creating a NetworkPolicy that selects all pods but does not allow any traffic:
+By default, if no policies exist in a namespace, then all ingress and egress traffic is allowed to and from pods in that namespace. The following examples let you change the default behavior
+in that namespace.
+
+### Default deny all ingress traffic
+
+You can create a "default" isolation policy for a namespace by creating a NetworkPolicy that selects all pods but does not allow any ingress traffic to those pods.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -81,11 +101,15 @@ metadata:
   name: default-deny
 spec:
   podSelector:
+  policyTypes:
+  - Ingress
 ```
 
-This ensures that even pods that aren't selected by any other NetworkPolicy will still be isolated.
+This ensures that even pods that aren't selected by any other NetworkPolicy will still be isolated. This policy does not change the default egress isolation behavior.
 
-Alternatively, if you want to allow all traffic for all pods in a Namespace (even if policies are added that cause some pods to be treated as "isolated"), you can create a policy that explicitly allows all traffic:
+### Default allow all ingress traffic
+
+If you want to allow all traffic to all pods in a namespace (even if policies are added that cause some pods to be treated as "isolated"), you can create a policy that explicitly allows all traffic in that namespace.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -97,6 +121,57 @@ spec:
   ingress:
   - {}
 ```
+
+### Default deny all egress traffic.
+
+You can create a "default" egress isolation policy for a namespace by creating a NetworkPolicy that selects all pods but does not allow any egress traffic from those pods.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  podSelector:
+  policyTypes:
+  - Egress
+```
+
+This ensures that even pods that aren't selected by any other NetworkPolicy will not be allowed egress traffic. This policy does not
+change the default ingress isolation behavior.
+
+### Default allow all egress traffic
+
+If you want to allow all traffic from all pods in a namespace (even if policies are added that cause some pods to be treated as "isolated"), you can create a policy that explicitly allows all egress traffic in that namespace.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all
+spec:
+  podSelector:
+  egress:
+  - {}
+```
+
+### Default deny all ingress and all egress traffic
+
+You can create a "default" policy for a namespace which prevents all ingress AND egress traffic by creating the following NetworkPolicy in that namespace.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  podSelector:
+  policyTypes:
+  - Ingress
+  - Egress
+```
+
+This ensures that even pods that aren't selected by any other NetworkPolicy will not be allowed ingress or egress traffic.
 
 ## What's next?
 


### PR DESCRIPTION
Documentation updates for two new NetworkPolicy features in Kubernetes 1.8.

- CIDRs: https://github.com/kubernetes/features/issues/367 
- Egress: https://github.com/kubernetes/features/issues/366

Both of these features are marked as "beta" - advice on how to indicate that in the documentation would be much appreciated.

CC @cmluciano

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5529)
<!-- Reviewable:end -->
