### PR TITLE
Updated the Cassandra tutorial to use apps/v1beta2

### DIFF
--- a/docs/tutorials/stateful-application/cassandra.md
+++ b/docs/tutorials/stateful-application/cassandra.md
@@ -159,7 +159,7 @@ Use `kubectl edit` to modify the size of of a Cassandra StatefulSet.
     # and an empty file will abort the edit. If an error occurs while saving this file will be
     # reopened with the relevant failures.
     #
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1beta2
     kind: StatefulSet
     metadata:
      creationTimestamp: 2016-08-13T18:40:58Z

--- a/docs/tutorials/stateful-application/cassandra/cassandra-statefulset.yaml
+++ b/docs/tutorials/stateful-application/cassandra/cassandra-statefulset.yaml
@@ -1,10 +1,15 @@
-apiVersion: "apps/v1beta1"
+apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
   name: cassandra
+  labels:
+    app: cassandra
 spec:
   serviceName: cassandra
   replicas: 3
+  selector:
+    matchLabels:
+      app: cassandra
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR updated the tutorial doc for running Cassandra using a StatefulSet to use `apps/v1beta2`. This is a part of broader efforts to enhance the workloads controller docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5548)
<!-- Reviewable:end -->
