### PR TITLE
RBAC doc describes escalation of privilege via pod creation.

### DIFF
--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -141,9 +141,5 @@ As of version 1.3, clusters created by kube-up.sh are configured so that the A
 
 Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  They can create pods that access secrets the user cannot themselves read, or that run under a service account with different/greater permissions.
 
-**Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace has the ability to:
-    * Read all secrets in the namespace.
-    * Read all config maps in the namespace.
-    * Impersonate any service account in the namespace and take any action the account could take.
-This applies regardless of authorization mode.
+**Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace can: read all secrets in the namespace; read all config maps in the namespace; and impersonate any service account in the namespace and take any action the account could take. This applies regardless of authorization mode.
 {: .caution}

--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -139,7 +139,7 @@ As of version 1.3, clusters created by kube-up.sh are configured so that the A
 
 ## Privilege escalation via pod creation
 
-Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  If a user is granted permission to create pods (or controllers that create pods), the Kubernetes API does not police the privileges of the pods being created.  This means that users can create pods that access secrets the user herself cannot read, or that run under a service account with different/greater permissions.
+Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  They can create pods that access secrets the user cannot themselves read, or that run under a service account with different/greater permissions.
 
 **Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace has the ability to:
     * Read all secrets in the namespace.

--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -141,9 +141,9 @@ As of version 1.3, clusters created by kube-up.sh are configured so that the A
 
 Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  If a user is granted permission to create pods (or controllers that create pods), the Kubernetes API does not police the privileges of the pods being created.  This means that users can create pods that access secrets the user herself cannot read, or that run under a service account with different/greater permissions.
 
-**Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace essentially has the ability to:
- * Read all secrets in the namespace.
- * Read all config maps in the namespace.
- * Impersonate any service account in the namespace and take any action the account could take.
+**Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace has the ability to:
+    * Read all secrets in the namespace.
+    * Read all config maps in the namespace.
+    * Impersonate any service account in the namespace and take any action the account could take.
 This applies regardless of authorization mode.
 {: .caution}

--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -136,3 +136,15 @@ As of version 1.3, clusters created by kube-up.sh are configured so that the A
 {% endcapture %}
 
 {% include templates/concept.md %}
+
+## Privilege Escalation via Pod Creation
+
+Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  If a user is granted permission to create pods (or controllers that create pods), the Kubernetes API does not police the privileges of the pods being created.  This means that users can create pods that access secrets the user herself cannot read, or that run under a service account with different/greater permissions.
+
+System administrators are cautioned to use care in granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace essentially has the ability to:
+
+ * Read all secrets in the namespace.
+ * Read all config maps in the namespace.
+ * Impersonate any service account in the namespace and take any action the account could take.
+
+This applies regardless of authorization mode.

--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -142,10 +142,8 @@ As of version 1.3, clusters created by kube-up.sh are configured so that the A
 Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  If a user is granted permission to create pods (or controllers that create pods), the Kubernetes API does not police the privileges of the pods being created.  This means that users can create pods that access secrets the user herself cannot read, or that run under a service account with different/greater permissions.
 
 **Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace essentially has the ability to:
-
  * Read all secrets in the namespace.
  * Read all config maps in the namespace.
  * Impersonate any service account in the namespace and take any action the account could take.
-
 This applies regardless of authorization mode.
 {: .caution}

--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -137,14 +137,15 @@ As of version 1.3, clusters created by kube-up.sh are configured so that the A
 
 {% include templates/concept.md %}
 
-## Privilege Escalation via Pod Creation
+## Privilege escalation via pod creation
 
 Users who have ability to create pods in a namespace can potentially escalate their privileges within that namespace.  If a user is granted permission to create pods (or controllers that create pods), the Kubernetes API does not police the privileges of the pods being created.  This means that users can create pods that access secrets the user herself cannot read, or that run under a service account with different/greater permissions.
 
-System administrators are cautioned to use care in granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace essentially has the ability to:
+**Caution:** System administrators, use care when granting access to pod creation.  A user granted permission to create pods (or controllers that create pods) in the namespace essentially has the ability to:
 
  * Read all secrets in the namespace.
  * Read all config maps in the namespace.
  * Impersonate any service account in the namespace and take any action the account could take.
 
 This applies regardless of authorization mode.
+{: .caution}


### PR DESCRIPTION
Adds a section to RBAC docs explaining what the ability to create pods confers to a user.  A reasonable admin might assume that RBAC prevents users creating pods that do things the user isn't allow to do, so it's important that we document the fact this is not the case. 

C.f. #4957 for example.

cc @lxpollitt @erictune @deads2k @liggitt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5551)
<!-- Reviewable:end -->
