### PR TITLE
psp.yaml: add allowedCapabilities: '*' to permissive PSP

### DIFF
--- a/docs/concepts/policy/psp.yaml
+++ b/docs/concepts/policy/psp.yaml
@@ -16,3 +16,5 @@ spec:
     max: 8080
   volumes:
   - '*'
+  allowedCapabilities:
+  - '*'


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/51337 adds support for using `*` as a value in the `allowedCapabilities` field. This PR updates example to use a new feature for permissive PSP.

PTAL @pweil- 
CC @simo5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5558)
<!-- Reviewable:end -->
