### PR TITLE
Experiment: Add trailing slash to one redirect target.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -147,7 +147,9 @@
 /docs/user-guide/connecting-to-applications-proxy				/docs/tasks/access-kubernetes-api/http-proxy-access-api		301
 /docs/user-guide/container-environment							/docs/concepts/containers/container-lifecycle-hooks		301
 /docs/user-guide/cron-jobs										/docs/concepts/workloads/controllers/cron-jobs		301
-/docs/user-guide/debugging-pods-and-replication-controllers		/docs/tasks/debug-application-cluster/debug-pod-replication-controller		301
+
+/docs/user-guide/debugging-pods-and-replication-controllers/	/docs/tasks/debug-application-cluster/debug-pod-replication-controller/		301
+
 /docs/user-guide/debugging-services								/docs/tasks/debug-application-cluster/debug-service		301
 /docs/user-guide/deploying-applications							/docs/tasks/run-application/run-stateless-application-deployment		301
 /docs/user-guide/deployments									/docs/concepts/workloads/controllers/deployment		301


### PR DESCRIPTION
This is an experiment to test the redirection mechanism. I think it will be better to have trailing slashes on our redirect targets. Otherwise, there is an extra redirect from xxx to xxx/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5576)
<!-- Reviewable:end -->
