### PR TITLE
pod-security-policy.md: fix broken link to PSP proposal

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -8,7 +8,7 @@ Objects of type `PodSecurityPolicy` govern the ability
 to make requests on a pod that affect the `SecurityContext` that will be
 applied to a pod and container.
 
-See [PodSecurityPolicy proposal](https://git.k8s.io/community/contributors/design-proposals/auth/security-context-constraints.md) for more information.
+See [PodSecurityPolicy proposal](https://git.k8s.io/community/contributors/design-proposals/auth/pod-security-policy.md) for more information.
 
 * TOC
 {:toc}


### PR DESCRIPTION
Update doc to fix a broken link (after renaming PSP proposal in https://github.com/kubernetes/community/pull/1112)

CC @simo5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5583)
<!-- Reviewable:end -->
