### PR TITLE
Remove outdated link

### DIFF
--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -249,7 +249,6 @@ kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel-rbac.yml
 ```
 {% endcapture %}
 


### PR DESCRIPTION
Flannel combained RBAC info into main manifest [1].

[1] https://github.com/coreos/flannel/commit/a154d2f68edd511498c948e33c8cbde20a5901ee

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5584)
<!-- Reviewable:end -->
