### PR TITLE
Update _redirects.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,451 +4,437 @@
 # test at https://play.netlify.com/redirects  #
 ###############################################
 
-/docs/admin/addons												/docs/concepts/cluster-administration/addons		301
-/docs/admin/apparmor											/docs/tutorials/clusters/apparmor		301
-/docs/admin/audit												/docs/tasks/debug-application-cluster/audit		301
-/docs/admin/cluster-components									/docs/concepts/overview/components		301
-/docs/admin/cluster-management									/docs/tasks/administer-cluster/cluster-management		301
-/docs/admin/cluster-troubleshooting								/docs/tasks/debug-application-cluster/debug-cluster		301
-/docs/admin/daemons												/docs/concepts/workloads/controllers/daemonset		301
-/docs/admin/disruptions											/docs/concepts/workloads/pods/disruptions		301
-/docs/admin/dns													/docs/concepts/services-networking/dns-pod-service		301
-/docs/admin/etcd												/docs/tasks/administer-cluster/configure-upgrade-etcd		301
-/docs/admin/etcd_upgrade										/docs/tasks/administer-cluster/configure-upgrade-etcd		301
-/docs/admin/federation/kubefed									/docs/tasks/federation/set-up-cluster-federation-kubefed		301
-/docs/admin/garbage-collection									/docs/concepts/cluster-administration/kubelet-garbage-collection		301
-/docs/admin/ha-master-gce										/docs/tasks/administer-cluster/highly-available-master		301
-/docs/admin/													/docs/concepts/cluster-administration/cluster-administration-overview		301
-/docs/admin/kubeadm-upgrade-1-7									/docs/tasks/administer-cluster/kubeadm-upgrade-1-7		301
-/docs/admin/limitrange/											/docs/tasks/administer-cluster/cpu-memory-limit		301
-/docs/admin/master-node-communication							/docs/concepts/architecture/master-node-communication		301
-/docs/admin/multi-cluster										/docs/concepts/cluster-administration/federation		301
-/docs/admin/multiple-schedulers									/docs/tasks/administer-cluster/configure-multiple-schedulers		301
-/docs/admin/namespaces											/docs/tasks/administer-cluster/namespaces		301
-/docs/admin/namespaces/walkthrough								/docs/tasks/administer-cluster/namespaces-walkthrough		301
-/docs/admin/network-plugins										/docs/concepts/cluster-administration/network-plugins		301
-/docs/admin/networking											/docs/concepts/cluster-administration/networking		301
-/docs/admin/node												/docs/concepts/architecture/nodes		301
-/docs/admin/node-allocatable									/docs/tasks/administer-cluster/reserve-compute-resources		301
-/docs/admin/node-problem										/docs/tasks/debug-application-cluster/monitor-node-health		301
-/docs/admin/out-of-resource										/docs/tasks/administer-cluster/out-of-resource		301
-/docs/admin/rescheduler											/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods		301
-/docs/admin/resourcequota/limitstorageconsumption				/docs/tasks/administer-cluster/limit-storage-consumption		301
-/docs/admin/resourcequota/walkthrough							/docs/tasks/administer-cluster/quota-api-object		301
-/docs/admin/static-pods											/docs/tasks/administer-cluster/static-pod		301
-/docs/admin/sysctls												/docs/concepts/cluster-administration/sysctl-cluster		301
-/docs/admin/upgrade-1-6											/docs/tasks/administer-cluster/upgrade-1-6		301
+############################
+# pattern matching redirects
+#
 
-/docs/api														/docs/concepts/overview/kubernetes-api		301
+/docs/user-guide/kubectl/kubectl_*/     /docs/user-guide/kubectl/v1.7/#:splat 200
+/v1.1/docs/*     /docs/ 301
+/docs/user-guide/kubectl/1_5/*     https://v1-5.docs.kubernetes.io/docs/user-guide/kubectl/v1.5/ 301
+/docs/user-guide/kubectl/v1.5/node_modules/*     https://v1-5.docs.kubernetes.io/docs/user-guide/kubectl/v1.5/ 301
+/docs/resources-reference/1_5/*     https://v1-5.docs.kubernetes.io/docs/resources-reference/v1.5/ 301
+/docs/resources-reference/v1.5/node_modules/*     https://v1-5.docs.kubernetes.io/docs/resources-reference/v1.5/ 301
+/docs/api-reference/1_5/*     https://v1-5.docs.kubernetes.io/docs/api-reference/v1.5 301
+/docs/api-reference/v1.5/node_modules/*     https://v1-5.docs.kubernetes.io/docs/api-reference/v1.5 301
+/docs/user-guide/kubectl/v1.6/node_modules/*     https://v1-6.docs.kubernetes.io/docs/user-guide/kubectl/v1.6/ 301
+/docs/api-reference/v1.6/node_modules/*     https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6 301
+/docs/api-reference/v1.7/node_modules/*     /docs/api-reference/v1.7/ 301
+/docs/getting-started-guides/docker-multinode/*     /docs/setup/independent/create-cluster-kubeadm/ 301
+/docs/admin/resourcequota/*     /docs/concepts/policy/resource-quotas/ 301
+/docs/getting-started-guide/*     /docs/setup/ 301
+/docs/api-reference/1_5/*     /docs/api-reference/v1.5/ 301
+/docs/resources-reference/1_5/*     /docs/resources-reference/v1.5/ 301
+/docs/resources-reference/1_6/*     /docs/resources-reference/v1.6/ 301
+/docs/resources-reference/1_7/*     /docs/resources-reference/v1.7/ 301
+/docs/templatedemos/*     /docs/home/contribute/page-templates/ 301
+/docs/tutorials/getting-started/*docs/tutorials/kubernetes-basics/ 301
+/docs/user-guide/federation/*/     /docs/concepts/cluster-administration/federation/ 301
+/docs/user-guide/garbage-collector/     /docs/concepts/workloads/controllers/garbage-collection/ 301
+/docs/user-guide/horizontal-pod-autoscaler/*     /docs/tasks/run-application/horizontal-pod-autoscale/ 301
+/kubernetes-bootcamp/*     /docs/tutorials/kubernetes-basics/ 301
+/swagger-spec/*     https://github.com/kubernetes/kubernetes/tree/master/api/swagger-spec/ 301
+/third_party/swagger-ui/*     /docs/reference/ 301
 
-/docs/concepts/abstractions/controllers/garbage-collection		/docs/concepts/workloads/controllers/garbage-collection		301
-/docs/concepts/abstractions/controllers/petsets					/docs/concepts/workloads/controllers/petset		301
-/docs/concepts/abstractions/controllers/statefulsets			/docs/concepts/workloads/controllers/statefulset		301
-/docs/concepts/abstractions/init-containers						/docs/concepts/workloads/pods/init-containers		301
-/docs/concepts/abstractions/overview							/docs/concepts/overview/working-with-objects/kubernetes-objects		301
-/docs/concepts/abstractions/pod									/docs/concepts/workloads/pods/pod-overview		301
+############################
+# individual redirects
+#
 
-/docs/concepts/cluster-administration/access-cluster			/docs/tasks/access-application-cluster/access-cluster		301
-/docs/concepts/cluster-administration/audit						/docs/tasks/debug-application-cluster/audit		301
-/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig	/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig		301
-/docs/concepts/cluster-administration/cluster-management		/docs/tasks/administer-cluster/cluster-management		301
-/docs/concepts/cluster-administration/configure-etcd			/docs/tasks/administer-cluster/configure-upgrade-etcd		301
-/docs/concepts/cluster-administration/etcd-upgrade				/docs/tasks/administer-cluster/configure-upgrade-etcd		301
-/docs/concepts/cluster-administration/federation-service-discovery	/docs/tasks/federation/federation-service-discovery		301
-/docs/concepts/cluster-administration/guaranteed-scheduling-critical-addon-pods	/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods		301
-/docs/concepts/cluster-administration/master-node-communication	/docs/concepts/architecture/master-node-communication		301
-/docs/concepts/cluster-administration/multiple-clusters			/docs/concepts/cluster-administration/federation		301
-/docs/concepts/cluster-administration/out-of-resource			/docs/tasks/administer-cluster/out-of-resource		301
-/docs/concepts/cluster-administration/resource-usage-monitoring	/docs/tasks/debug-application-cluster/resource-usage-monitoring		301
-/docs/concepts/cluster-administration/static-pod				/docs/tasks/administer-cluster/static-pod		301
+/docs/admin/addons/     /docs/concepts/cluster-administration/addons/ 301
+/docs/admin/apparmor/     /docs/tutorials/clusters/apparmor/ 301
+/docs/admin/audit/     /docs/tasks/debug-application-cluster/audit/ 301
+/docs/admin/cluster-components/     /docs/concepts/overview/components/ 301
+/docs/admin/cluster-management/     /docs/tasks/administer-cluster/cluster-management/ 301
+/docs/admin/cluster-troubleshooting/     /docs/tasks/debug-application-cluster/debug-cluster/ 301
+/docs/admin/daemons/     /docs/concepts/workloads/controllers/daemonset/ 301
+/docs/admin/disruptions/     /docs/concepts/workloads/pods/disruptions/ 301
+/docs/admin/dns/     /docs/concepts/services-networking/dns-pod-service/ 301
+/docs/admin/etcd/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
+/docs/admin/etcd_upgrade/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
+/docs/admin/federation/kubefed/     /docs/tasks/federation/set-up-cluster-federation-kubefed/ 301
+/docs/admin/garbage-collection/     /docs/concepts/cluster-administration/kubelet-garbage-collection/ 301
+/docs/admin/ha-master-gce/     /docs/tasks/administer-cluster/highly-available-master/ 301
+/docs/admin/     /docs/concepts/cluster-administration/cluster-administration-overview/ 301
+/docs/admin/kubeadm-upgrade-1-7/     /docs/tasks/administer-cluster/kubeadm-upgrade-1-7/ 301
+/docs/admin/limitrange/docs/tasks/administer-cluster/cpu-memory-limit/ 301
+/docs/admin/master-node-communication/     /docs/concepts/architecture/master-node-communication/ 301
+/docs/admin/multi-cluster/     /docs/concepts/cluster-administration/federation/ 301
+/docs/admin/multiple-schedulers/     /docs/tasks/administer-cluster/configure-multiple-schedulers/ 301
+/docs/admin/namespaces/     /docs/tasks/administer-cluster/namespaces/ 301
+/docs/admin/namespaces/walkthrough/     /docs/tasks/administer-cluster/namespaces-walkthrough/ 301
+/docs/admin/network-plugins/     /docs/concepts/cluster-administration/network-plugins/ 301
+/docs/admin/networking/     /docs/concepts/cluster-administration/networking/ 301
+/docs/admin/node/     /docs/concepts/architecture/nodes/ 301
+/docs/admin/node-allocatable/     /docs/tasks/administer-cluster/reserve-compute-resources/ 301
+/docs/admin/node-problem/     /docs/tasks/debug-application-cluster/monitor-node-health/ 301
+/docs/admin/out-of-resource/     /docs/tasks/administer-cluster/out-of-resource/ 301
+/docs/admin/rescheduler/     /docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/ 301
+/docs/admin/resourcequota/limitstorageconsumption/     /docs/tasks/administer-cluster/limit-storage-consumption/ 301
+/docs/admin/resourcequota/walkthrough/     /docs/tasks/administer-cluster/quota-api-object/ 301
+/docs/admin/static-pods/     /docs/tasks/administer-cluster/static-pod/ 301
+/docs/admin/sysctls/     /docs/concepts/cluster-administration/sysctl-cluster/ 301
+/docs/admin/upgrade-1-6/     /docs/tasks/administer-cluster/upgrade-1-6/ 301
 
-/docs/concepts/clusters/logging									/docs/concepts/cluster-administration/logging		301
-/docs/concepts/configuration/container-command-arg				/docs/tasks/inject-data-application/define-command-argument-container/docs/concepts/ecosystem/thirdpartyresource		301						/docs/tasks/access-kubernetes-api/extend-api-third-party-resource
-/docs/concepts/jobs/cron-jobs									/docs/concepts/workloads/controllers/cron-jobs		301
-/docs/concepts/jobs/run-to-completion-finite-workloads			/docs/concepts/workloads/controllers/jobs-run-to-completion		301
-/docs/concepts/nodes/node										/docs/concepts/architecture/nodes		301
-/docs/concepts/storage/etcd-store-api-object					/docs/tasks/administer-cluster/configure-upgrade-etcd		301
+/docs/api/     /docs/concepts/overview/kubernetes-api/ 301
 
-/docs/concepts/tools/kubectl/object-management-overview			/docs/tutorials/object-management-kubectl/object-management		301
-/docs/concepts/tools/kubectl/object-management-using-declarative-config	/docs/tutorials/object-management-kubectl/declarative-object-management-configuration		301
-/docs/concepts/tools/kubectl/object-management-using-imperative-commands	/docs/tutorials/object-management-kubectl/imperative-object-management-command		301
-/docs/concepts/tools/kubectl/object-management-using-imperative-config	/docs/tutorials/object-management-kubectl/imperative-object-management-configuration		301
+/docs/concepts/abstractions/controllers/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
+/docs/concepts/abstractions/controllers/petsets/     /docs/concepts/workloads/controllers/petset/ 301
+/docs/concepts/abstractions/controllers/statefulsets/     /docs/concepts/workloads/controllers/statefulset/ 301
+/docs/concepts/abstractions/init-containers/     /docs/concepts/workloads/pods/init-containers/ 301
+/docs/concepts/abstractions/overview/     /docs/concepts/overview/working-with-objects/kubernetes-objects/ 301
+/docs/concepts/abstractions/pod/     /docs/concepts/workloads/pods/pod-overview/ 301
 
-/docs/getting-started-guides									/docs/setup/pick-right-solution		301
-/docs/getting-started-guides/kubeadm							/docs/setup/independent/create-cluster-kubeadm		301
-/docs/getting-started-guides/network-policy/calico				/docs/tasks/administer-cluster/calico-network-policy		301
-/docs/getting-started-guides/network-policy/romana				/docs/tasks/administer-cluster/romana-network-policy		301
-/docs/getting-started-guides/network-policy/walkthrough			/docs/tasks/administer-cluster/declare-network-policy		301
-/docs/getting-started-guides/network-policy/weave				/docs/tasks/administer-cluster/weave-network-policy		301
-/docs/getting-started-guides/running-cloud-controller			/docs/tasks/administer-cluster/running-cloud-controller		301
-/docs/getting-started-guides/ubuntu/calico						/docs/getting-started-guides/ubuntu/		301
+/docs/concepts/cluster-administration/access-cluster/     /docs/tasks/access-application-cluster/access-cluster/ 301
+/docs/concepts/cluster-administration/audit/     /docs/tasks/debug-application-cluster/audit/ 301
+/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/     /docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/ 301
+/docs/concepts/cluster-administration/cluster-management/     /docs/tasks/administer-cluster/cluster-management/ 301
+/docs/concepts/cluster-administration/configure-etcd/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
+/docs/concepts/cluster-administration/etcd-upgrade/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
+/docs/concepts/cluster-administration/federation-service-discovery/     /docs/tasks/federation/federation-service-discovery/ 301
+/docs/concepts/cluster-administration/guaranteed-scheduling-critical-addon-pods/     /docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/ 301
+/docs/concepts/cluster-administration/master-node-communication/     /docs/concepts/architecture/master-node-communication/ 301
+/docs/concepts/cluster-administration/multiple-clusters/     /docs/concepts/cluster-administration/federation/ 301
+/docs/concepts/cluster-administration/out-of-resource/     /docs/tasks/administer-cluster/out-of-resource/ 301
+/docs/concepts/cluster-administration/resource-usage-monitoring/     /docs/tasks/debug-application-cluster/resource-usage-monitoring/ 301
+/docs/concepts/cluster-administration/static-pod/     /docs/tasks/administer-cluster/static-pod/ 301
+/docs/concepts/clusters/logging/     /docs/concepts/cluster-administration/logging/ 301
+/docs/concepts/configuration/container-command-arg/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
+/docs/concepts/ecosystem/thirdpartyresource/     /docs/tasks/access-kubernetes-api/extend-api-third-party-resource/ 301
+/docs/concepts/jobs/cron-jobs/     /docs/concepts/workloads/controllers/cron-jobs/ 301
+/docs/concepts/jobs/run-to-completion-finite-workloads/     /docs/concepts/workloads/controllers/jobs-run-to-completion/ 301
+/docs/concepts/nodes/node/     /docs/concepts/architecture/nodes/ 301
+/docs/concepts/storage/etcd-store-api-object/     /docs/tasks/administer-cluster/configure-upgrade-etcd/ 301
+/docs/concepts/tools/kubectl/object-management-overview/     /docs/tutorials/object-management-kubectl/object-management/ 301
+/docs/concepts/tools/kubectl/object-management-using-declarative-config/     /docs/tutorials/object-management-kubectl/declarative-object-management-configuration/ 301
+/docs/concepts/tools/kubectl/object-management-using-imperative-commands/     /docs/tutorials/object-management-kubectl/imperative-object-management-command/ 301
+/docs/concepts/tools/kubectl/object-management-using-imperative-config/     /docs/tutorials/object-management-kubectl/imperative-object-management-configuration/ 301
 
-/docs/hellonode													/docs/tutorials/stateless-application/hello-minikube		301
-/docs/															/docs/home/		301
-/docs/samples													/docs/tutorials/		301
+/docs/getting-started-guides/     /docs/setup/pick-right-solution/ 301
+/docs/getting-started-guides/kubeadm/     /docs/setup/independent/create-cluster-kubeadm/ 301
+/docs/getting-started-guides/network-policy/calico/     /docs/tasks/administer-cluster/calico-network-policy/ 301
+/docs/getting-started-guides/network-policy/romana/     /docs/tasks/administer-cluster/romana-network-policy/ 301
+/docs/getting-started-guides/network-policy/walkthrough/     /docs/tasks/administer-cluster/declare-network-policy/ 301
+/docs/getting-started-guides/network-policy/weave/     /docs/tasks/administer-cluster/weave-network-policy/ 301
+/docs/getting-started-guides/running-cloud-controller/     /docs/tasks/administer-cluster/running-cloud-controller/ 301
+/docs/getting-started-guides/ubuntu/calico/     /docs/getting-started-guides/ubuntu/ 301
 
-/docs/tasks/administer-cluster/apply-resource-quota-limit		/docs/tasks/administer-cluster/quota-api-object		301
-/docs/tasks/administer-cluster/assign-pods-nodes				/docs/tasks/configure-pod-container/assign-pods-nodes		301
-/docs/tasks/administer-cluster/overview							/docs/concepts/cluster-administration/cluster-administration-overview		301
-/docs/tasks/administer-cluster/cpu-memory-limit					/docs/tasks/administer-cluster/memory-default-namespace		301
-/docs/tasks/administer-cluster/share-configuration				/docs/tasks/access-application-cluster/configure-access-multiple-clusters	301
+/docs/hellonode/     /docs/tutorials/stateless-application/hello-minikube/ 301
+/docs/     /docs/home/ 301
+/docs/samples/     /docs/tutorials/ 301
 
-/docs/tasks/configure-pod-container/apply-resource-quota-limit	/docs/tasks/administer-cluster/apply-resource-quota-limit		301
-/docs/tasks/configure-pod-container/calico-network-policy		/docs/tasks/administer-cluster/calico-network-policy		301
-/docs/tasks/configure-pod-container/communicate-containers-same-pod	/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume		301
-/docs/tasks/configure-pod-container/declare-network-policy		/docs/tasks/administer-cluster/declare-network-policy		301
-/docs/tasks/configure-pod-container/define-environment-variable-container	/docs/tasks/inject-data-application/define-environment-variable-container		301
-/docs/tasks/configure-pod-container/distribute-credentials-secure	/docs/tasks/inject-data-application/distribute-credentials-secure		301
-/docs/tasks/configure-pod-container/downward-api-volume-expose-pod-information	/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information		301
-/docs/tasks/configure-pod-container/environment-variable-expose-pod-information	/docs/tasks/inject-data-application/environment-variable-expose-pod-information		301
-/docs/tasks/configure-pod-container/limit-range					/docs/tasks/administer-cluster/cpu-memory-limit		301
-/docs/tasks/configure-pod-container/romana-network-policy		/docs/tasks/administer-cluster/romana-network-policy		301
-/docs/tasks/configure-pod-container/weave-network-policy		/docs/tasks/administer-cluster/weave-network-policy			301
-/docs/tasks/configure-pod-container/assign-cpu-ram-container	/docs/tasks/configure-pod-container/assign-memory-resource	301	
+/docs/tasks/administer-cluster/apply-resource-quota-limit/     /docs/tasks/administer-cluster/quota-api-object/ 301
+/docs/tasks/administer-cluster/assign-pods-nodes/     /docs/tasks/configure-pod-container/assign-pods-nodes/ 301
+/docs/tasks/administer-cluster/overview/     /docs/concepts/cluster-administration/cluster-administration-overview/ 301
+/docs/tasks/administer-cluster/cpu-memory-limit/     /docs/tasks/administer-cluster/memory-default-namespace/ 301
+/docs/tasks/administer-cluster/share-configuration/     /docs/tasks/access-application-cluster/configure-access-multiple-clusters/ 301
 
-/docs/tasks/kubectl/get-shell-running-container					/docs/tasks/debug-application-cluster/get-shell-running-container		301
-/docs/tasks/kubectl/install										/docs/tasks/tools/install-kubectl		301
-/docs/tasks/kubectl/list-all-running-container-images			/docs/tasks/access-application-cluster/list-all-running-container-images		301
+/docs/tasks/configure-pod-container/apply-resource-quota-limit/     /docs/tasks/administer-cluster/apply-resource-quota-limit/ 301
+/docs/tasks/configure-pod-container/calico-network-policy/     /docs/tasks/administer-cluster/calico-network-policy/ 301
+/docs/tasks/configure-pod-container/communicate-containers-same-pod/     /docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/ 301
+/docs/tasks/configure-pod-container/declare-network-policy/     /docs/tasks/administer-cluster/declare-network-policy/ 301
+/docs/tasks/configure-pod-container/define-environment-variable-container/     /docs/tasks/inject-data-application/define-environment-variable-container/ 301
+/docs/tasks/configure-pod-container/distribute-credentials-secure/     /docs/tasks/inject-data-application/distribute-credentials-secure/ 301
+/docs/tasks/configure-pod-container/downward-api-volume-expose-pod-information/     /docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/ 301
+/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/     /docs/tasks/inject-data-application/environment-variable-expose-pod-information/ 301
+/docs/tasks/configure-pod-container/limit-range/     /docs/tasks/administer-cluster/cpu-memory-limit/ 301
+/docs/tasks/configure-pod-container/romana-network-policy/     /docs/tasks/administer-cluster/romana-network-policy/ 301
+/docs/tasks/configure-pod-container/weave-network-policy/     /docs/tasks/administer-cluster/weave-network-policy/ 301
+/docs/tasks/configure-pod-container/assign-cpu-ram-container/     /docs/tasks/configure-pod-container/assign-memory-resource/ 301
 
-/docs/tasks/manage-stateful-set/debugging-a-statefulset			/docs/tasks/debug-application-cluster/debug-stateful-set		301
-/docs/tasks/manage-stateful-set/delete-pods						/docs/tasks/run-application/force-delete-stateful-set-pod		301
-/docs/tasks/manage-stateful-set/deleting-a-statefulset			/docs/tasks/run-application/delete-stateful-set		301
-/docs/tasks/manage-stateful-set/scale-stateful-set				/docs/tasks/run-application/scale-stateful-set		301
-/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set	/docs/tasks/run-application/upgrade-pet-set-to-stateful-set		301
+/docs/tasks/kubectl/get-shell-running-container/     /docs/tasks/debug-application-cluster/get-shell-running-container/ 301
+/docs/tasks/kubectl/install/     /docs/tasks/tools/install-kubectl/ 301
+/docs/tasks/kubectl/list-all-running-container-images/     /docs/tasks/access-application-cluster/list-all-running-container-images/ 301
 
-/docs/tasks/run-application/podpreset							/docs/tasks/inject-data-application/podpreset		301
-/docs/tasks/troubleshoot/debug-init-containers					/docs/tasks/debug-application-cluster/debug-init-containers		301
-/docs/tasks/web-ui-dashboard									/docs/tasks/access-application-cluster/web-ui-dashboard		301
-/docs/templatedemos												/docs/home/contribute/page-templates		301
-/docs/tools/kompose												/docs/tools/kompose/user-guide		301
+/docs/tasks/manage-stateful-set/debugging-a-statefulset/     /docs/tasks/debug-application-cluster/debug-stateful-set/ 301
+/docs/tasks/manage-stateful-set/delete-pods/     /docs/tasks/run-application/force-delete-stateful-set-pod/ 301
+/docs/tasks/manage-stateful-set/deleting-a-statefulset/     /docs/tasks/run-application/delete-stateful-set/ 301
+/docs/tasks/manage-stateful-set/scale-stateful-set/     /docs/tasks/run-application/scale-stateful-set/ 301
+/docs/tasks/manage-stateful-set/upgrade-pet-set-to-stateful-set/     /docs/tasks/run-application/upgrade-pet-set-to-stateful-set/ 301
 
-/docs/tutorials/clusters/multiple-schedulers					/docs/tasks/administer-cluster/configure-multiple-schedulers		301
-/docs/tutorials/connecting-apps/connecting-frontend-backend		/docs/tasks/access-application-cluster/connecting-frontend-backend		301
-/docs/tutorials/federation/set-up-cluster-federation-kubefed	/docs/tasks/federation/set-up-cluster-federation-kubefed		301
-/docs/tutorials/federation/set-up-coredns-provider-federation	/docs/tasks/federation/set-up-coredns-provider-federation		301
-/docs/tutorials/federation/set-up-placement-policies-federation	/docs/tasks/federation/set-up-placement-policies-federation		301
-/docs/tutorials/getting-started/create-cluster					/docs/tutorials/kubernetes-basics/cluster-intro		301
-/docs/tutorials/stateful-application/run-replicated-stateful-application	/docs/tasks/run-application/run-replicated-stateful-application		301
-/docs/tutorials/stateful-application/run-stateful-application	/docs/tasks/run-application/run-single-instance-stateful-application		301
-/docs/tutorials/stateless-application/expose-external-ip-address-service	/docs/tasks/access-application-cluster/service-access-application-cluster		301
-/docs/tutorials/stateless-application/run-stateless-ap-replication-controller	/docs/tasks/run-application/run-stateless-application-deployment		301
-/docs/tutorials/stateless-application/run-stateless-application-deployment	/docs/tasks/run-application/run-stateless-application-deployment		301
+/docs/tasks/run-application/podpreset/     /docs/tasks/inject-data-application/podpreset/ 301
+/docs/tasks/troubleshoot/debug-init-containers/     /docs/tasks/debug-application-cluster/debug-init-containers/ 301
+/docs/tasks/web-ui-dashboard/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
+/docs/templatedemos/     /docs/home/contribute/page-templates/ 301
+/docs/tools/kompose/     /docs/tools/kompose/user-guide/ 301
 
-/docs/user-guide/accessing-the-cluster							/docs/tasks/access-application-cluster/access-cluster		301
-/docs/user-guide/add-entries-to-pod-etc-hosts-with-host-aliases	/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases		301
-/docs/user-guide/annotations									/docs/concepts/overview/working-with-objects/annotations		301
-/docs/user-guide/application-troubleshooting					/docs/tasks/debug-application-cluster/debug-application		301
-/docs/user-guide/compute-resources								/docs/concepts/configuration/manage-compute-resources-container		301
-/docs/user-guide/config-best-practices							/docs/concepts/configuration/overview		301
-/docs/user-guide/configmap										/docs/tasks/configure-pod-container/configmap		301
-/docs/user-guide/configuring-containers							/docs/tasks/		301
-/docs/user-guide/connecting-applications						/docs/concepts/services-networking/connect-applications-service		301
-/docs/user-guide/connecting-to-applications-port-forward		/docs/tasks/access-application-cluster/port-forward-access-application-cluster		301
-/docs/user-guide/connecting-to-applications-proxy				/docs/tasks/access-kubernetes-api/http-proxy-access-api		301
-/docs/user-guide/container-environment							/docs/concepts/containers/container-lifecycle-hooks		301
-/docs/user-guide/cron-jobs										/docs/concepts/workloads/controllers/cron-jobs		301
+/docs/tutorials/clusters/multiple-schedulers/     /docs/tasks/administer-cluster/configure-multiple-schedulers/ 301
+/docs/tutorials/connecting-apps/connecting-frontend-backend/     /docs/tasks/access-application-cluster/connecting-frontend-backend/ 301
+/docs/tutorials/federation/set-up-cluster-federation-kubefed/     /docs/tasks/federation/set-up-cluster-federation-kubefed/ 301
+/docs/tutorials/federation/set-up-coredns-provider-federation/     /docs/tasks/federation/set-up-coredns-provider-federation/ 301
+/docs/tutorials/federation/set-up-placement-policies-federation/     /docs/tasks/federation/set-up-placement-policies-federation/ 301
+/docs/tutorials/getting-started/create-cluster/     /docs/tutorials/kubernetes-basics/cluster-intro/ 301
+/docs/tutorials/stateful-application/run-replicated-stateful-application/     /docs/tasks/run-application/run-replicated-stateful-application/ 301
+/docs/tutorials/stateful-application/run-stateful-application/     /docs/tasks/run-application/run-single-instance-stateful-application/ 301
+/docs/tutorials/stateless-application/expose-external-ip-address-service/     /docs/tasks/access-application-cluster/service-access-application-cluster/ 301
+/docs/tutorials/stateless-application/run-stateless-ap-replication-controller/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
+/docs/tutorials/stateless-application/run-stateless-application-deployment/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
 
-/docs/user-guide/debugging-pods-and-replication-controllers/	/docs/tasks/debug-application-cluster/debug-pod-replication-controller/		301
+/docs/user-guide/accessing-the-cluster/     /docs/tasks/access-application-cluster/access-cluster/ 301
+/docs/user-guide/add-entries-to-pod-etc-hosts-with-host-aliases/     /docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ 301
+/docs/user-guide/annotations/     /docs/concepts/overview/working-with-objects/annotations/ 301
+/docs/user-guide/application-troubleshooting/     /docs/tasks/debug-application-cluster/debug-application/ 301
+/docs/user-guide/compute-resources/     /docs/concepts/configuration/manage-compute-resources-container/ 301
+/docs/user-guide/config-best-practices/     /docs/concepts/configuration/overview/ 301
+/docs/user-guide/configmap/     /docs/tasks/configure-pod-container/configmap/ 301
+/docs/user-guide/configuring-containers/     /docs/tasks/ 301
+/docs/user-guide/connecting-applications/     /docs/concepts/services-networking/connect-applications-service/ 301
+/docs/user-guide/connecting-to-applications-port-forward/     /docs/tasks/access-application-cluster/port-forward-access-application-cluster/ 301
+/docs/user-guide/connecting-to-applications-proxy/     /docs/tasks/access-kubernetes-api/http-proxy-access-api/ 301
+/docs/user-guide/container-environment/     /docs/concepts/containers/container-lifecycle-hooks/ 301
+/docs/user-guide/cron-jobs/     /docs/concepts/workloads/controllers/cron-jobs/ 301
+/docs/user-guide/debugging-pods-and-replication-controllers/     /docs/tasks/debug-application-cluster/debug-pod-replication-controller/ 301
+/docs/user-guide/debugging-services/     /docs/tasks/debug-application-cluster/debug-service/ 301
+/docs/user-guide/deploying-applications/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
+/docs/user-guide/deployments/     /docs/concepts/workloads/controllers/deployment/ 301
+/docs/user-guide/downward-api/     /docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/ 301
+/docs/user-guide/downward-api/volume/     /docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/ 301
+/docs/user-guide/environment-guide/     /docs/tasks/inject-data-application/environment-variable-expose-pod-information/ 301
+/docs/user-guide/federation/cluster/     /docs/tasks/administer-federation/cluster/ 301
+/docs/user-guide/federation/configmap/     /docs/tasks/administer-federation/configmap/ 301
+/docs/user-guide/federation/daemonsets/     /docs/tasks/administer-federation/daemonset/ 301
+/docs/user-guide/federation/deployment/     /docs/tasks/administer-federation/deployment/ 301
+/docs/user-guide/federation/events/     /docs/tasks/administer-federation/events/ 301
+/docs/user-guide/federation/federated-ingress/     /docs/tasks/administer-federation/ingress/ 301
+/docs/user-guide/federation/federated-services/     /docs/tasks/federation/federation-service-discovery/ 301
+/docs/user-guide/federation/     /docs/concepts/cluster-administration/federation/ 301
+/docs/user-guide/federation/namespaces/     /docs/tasks/administer-federation/namespaces/ 301
+/docs/user-guide/federation/replicasets/     /docs/tasks/administer-federation/replicaset/ 301
+/docs/user-guide/federation/secrets/     /docs/tasks/administer-federation/secret/ 301
+/docs/user-guide/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
+/docs/user-guide/getting-into-containers/     /docs/tasks/debug-application-cluster/get-shell-running-container/ 301
+/docs/user-guide/gpus/     /docs/tasks/manage-gpus/scheduling-gpus/ 301
+/docs/user-guide/horizontal-pod-autoscaling/     /docs/tasks/run-application/horizontal-pod-autoscale/ 301
+/docs/user-guide/horizontal-pod-autoscaling/walkthrough/     /docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ 301
+/docs/user-guide/identifiers/     /docs/concepts/overview/working-with-objects/names/ 301
+/docs/user-guide/images/     /docs/concepts/containers/images/ 301
+/docs/user-guide/     /docs/home/ 301
+/docs/user-guide/ingress/     /docs/concepts/services-networking/ingress/ 301
+/docs/user-guide/introspection-and-debugging/     /docs/tasks/debug-application-cluster/debug-application-introspection/ 301
+/docs/user-guide/jobs/     /docs/concepts/workloads/controllers/jobs-run-to-completion/ 301
+/docs/user-guide/jobs/expansions/     /docs/tasks/job/parallel-processing-expansion/ 301
+/docs/user-guide/jobs/work-queue-1/     /docs/tasks/job/coarse-parallel-processing-work-queue/ 301
+/docs/user-guide/jobs/work-queue-2/     /docs/tasks/job/fine-parallel-processing-work-queue/ 301
+/docs/user-guide/kubeconfig-file/     /docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/ 301
+/docs/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/ 301
+/docs/user-guide/liveness/     /docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ 301
+/docs/user-guide/load-balancer/     /docs/tasks/access-application-cluster/create-external-load-balancer/ 301
+/docs/user-guide/logging/elasticsearch/     /docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/ 301
+/docs/user-guide/logging/overview/     /docs/concepts/cluster-administration/logging/ 301
+/docs/user-guide/logging/stackdriver/     /docs/tasks/debug-application-cluster/logging-stackdriver/ 301
+/docs/user-guide/managing-deployments/     /docs/concepts/cluster-administration/manage-deployment/ 301
+/docs/user-guide/monitoring/     /docs/tasks/debug-application-cluster/resource-usage-monitoring/ 301
+/docs/user-guide/namespaces/     /docs/concepts/overview/working-with-objects/namespaces/ 301
+/docs/user-guide/networkpolicies/     /docs/concepts/services-networking/network-policies/ 301
+/docs/user-guide/node-selection/     /docs/concepts/configuration/assign-pod-node/ 301
+/docs/user-guide/persistent-volumes/     /docs/concepts/storage/persistent-volumes/ 301
+/docs/user-guide/persistent-volumes/walkthrough/     /docs/tasks/configure-pod-container/configure-persistent-volume-storage/ 301
+/docs/user-guide/petset/     /docs/concepts/workloads/controllers/petset/ 301
+/docs/user-guide/petset/bootstrapping/     /docs/concepts/workloads/controllers/petset/ 301
+/docs/user-guide/pod-preset/     /docs/tasks/inject-data-application/podpreset/ 301
+/docs/user-guide/pod-security-policy/     /docs/concepts/policy/pod-security-policy/ 301
+/docs/user-guide/pod-states/     /docs/concepts/workloads/pods/pod-lifecycle/ 301
+/docs/user-guide/pod-templates/     /docs/concepts/workloads/pods/pod-overview/ 301
+/docs/user-guide/pods/     /docs/concepts/workloads/pods/pod/ 301
+/docs/user-guide/pods/init-container/     /docs/concepts/workloads/pods/init-containers/ 301
+/docs/user-guide/pods/multi-container/     /docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/ 301
+/docs/user-guide/pods/single-container/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
+/docs/user-guide/prereqs/     /docs/tasks/tools/install-kubectl/ 301
+/docs/user-guide/production-pods/     /docs/tasks/ 301
+/docs/user-guide/projected-volume/     /docs/tasks/configure-pod-container/configure-projected-volume-storage/ 301
+/docs/user-guide/quick-start/     /docs/tasks/access-application-cluster/service-access-application-cluster/ 301
+/docs/user-guide/replicasets/     /docs/concepts/workloads/controllers/replicaset/ 301
+/docs/user-guide/replication-controller/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
+/docs/user-guide/rolling-updates/     /docs/tasks/run-application/rolling-update-replication-controller/ 301
+/docs/user-guide/secrets/     /docs/concepts/configuration/secret/ 301
+/docs/user-guide/secrets/walkthrough/     /docs/tasks/inject-data-application/distribute-credentials-secure/ 301
+/docs/user-guide/service-accounts/     /docs/tasks/configure-pod-container/configure-service-account/ 301
+/docs/user-guide/services-firewalls/     /docs/tasks/access-application-cluster/configure-cloud-provider-firewall/ 301
+/docs/user-guide/services/     /docs/concepts/services-networking/service/ 301
+/docs/user-guide/services/operations/     /docs/tasks/access-application-cluster/connecting-frontend-backend/ 301
+/docs/user-guide/sharing-clusters/     /docs/tasks/administer-cluster/share-configuration/ 301
+/docs/user-guide/simple-nginx/     /docs/tasks/run-application/run-stateless-application-deployment/ 301
+/docs/user-guide/thirdpartyresources/     /docs/tasks/access-kubernetes-api/extend-api-third-party-resource/ 301
+/docs/user-guide/ui/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
+/docs/user-guide/update-dem/     /docs/tasks/run-application/rolling-update-replication-controller/ 301
+/docs/user-guide/volumes/     /docs/concepts/storage/volumes/ 301
+/docs/user-guide/working-with-resources/     /docs/tutorials/object-management-kubectl/object-management/ 301
 
-/docs/user-guide/debugging-services								/docs/tasks/debug-application-cluster/debug-service		301
-/docs/user-guide/deploying-applications							/docs/tasks/run-application/run-stateless-application-deployment		301
-/docs/user-guide/deployments									/docs/concepts/workloads/controllers/deployment		301
-/docs/user-guide/downward-api									/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information		301
-/docs/user-guide/downward-api/volume							/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information		301
-/docs/user-guide/environment-guide								/docs/tasks/inject-data-application/environment-variable-expose-pod-information		301
-/docs/user-guide/federation/cluster								/docs/tasks/administer-federation/cluster		301
-/docs/user-guide/federation/configmap							/docs/tasks/administer-federation/configmap		301
-/docs/user-guide/federation/daemonsets							/docs/tasks/administer-federation/daemonset		301
-/docs/user-guide/federation/deployment							/docs/tasks/administer-federation/deployment		301
-/docs/user-guide/federation/events								/docs/tasks/administer-federation/events		301
-/docs/user-guide/federation/federated-ingress					/docs/tasks/administer-federation/ingress		301
-/docs/user-guide/federation/federated-services					/docs/tasks/federation/federation-service-discovery		301
-/docs/user-guide/federation										/docs/concepts/cluster-administration/federation		301
-/docs/user-guide/federation/namespaces							/docs/tasks/administer-federation/namespaces		301
-/docs/user-guide/federation/replicasets							/docs/tasks/administer-federation/replicaset		301
-/docs/user-guide/federation/secrets								/docs/tasks/administer-federation/secret		301
-/docs/user-guide/garbage-collection								/docs/concepts/workloads/controllers/garbage-collection		301
-/docs/user-guide/getting-into-containers						/docs/tasks/debug-application-cluster/get-shell-running-container		301
-/docs/user-guide/gpus											/docs/tasks/manage-gpus/scheduling-gpus		301
-/docs/user-guide/horizontal-pod-autoscaling						/docs/tasks/run-application/horizontal-pod-autoscale		301
-/docs/user-guide/horizontal-pod-autoscaling/walkthrough			/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough		301
-/docs/user-guide/identifiers									/docs/concepts/overview/working-with-objects/names		301
-/docs/user-guide/images											/docs/concepts/containers/images		301
-/docs/user-guide												/docs/home/		301
-/docs/user-guide/ingress										/docs/concepts/services-networking/ingress		301
-/docs/user-guide/introspection-and-debugging					/docs/tasks/debug-application-cluster/debug-application-introspection		301
-/docs/user-guide/jobs											/docs/concepts/workloads/controllers/jobs-run-to-completion		301
-/docs/user-guide/jobs/expansions								/docs/tasks/job/parallel-processing-expansion		301
-/docs/user-guide/jobs/work-queue-1								/docs/tasks/job/coarse-parallel-processing-work-queue/		301
-/docs/user-guide/jobs/work-queue-2								/docs/tasks/job/fine-parallel-processing-work-queue/		301
-/docs/user-guide/kubeconfig-file								/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig		301
-/docs/user-guide/labels											/docs/concepts/overview/working-with-objects/labels		301
-/docs/user-guide/liveness										/docs/tasks/configure-pod-container/configure-liveness-readiness-probes		301
-/docs/user-guide/load-balancer									/docs/tasks/access-application-cluster/create-external-load-balancer		301
-/docs/user-guide/logging/elasticsearch							/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana		301
-/docs/user-guide/logging/overview								/docs/concepts/cluster-administration/logging		301
-/docs/user-guide/logging/stackdriver							/docs/tasks/debug-application-cluster/logging-stackdriver		301
-/docs/user-guide/managing-deployments							/docs/concepts/cluster-administration/manage-deployment		301
-/docs/user-guide/monitoring										/docs/tasks/debug-application-cluster/resource-usage-monitoring		301
-/docs/user-guide/namespaces										/docs/concepts/overview/working-with-objects/namespaces		301
-/docs/user-guide/networkpolicies								/docs/concepts/services-networking/network-policies		301
-/docs/user-guide/node-selection									/docs/concepts/configuration/assign-pod-node		301
-/docs/user-guide/persistent-volumes								/docs/concepts/storage/persistent-volumes		301
-/docs/user-guide/persistent-volumes/walkthrough					/docs/tasks/configure-pod-container/configure-persistent-volume-storage		301
-/docs/user-guide/petset											/docs/concepts/workloads/controllers/petset		301
-/docs/user-guide/petset/bootstrapping							/docs/concepts/workloads/controllers/petset		301
-/docs/user-guide/pod-preset										/docs/tasks/inject-data-application/podpreset		301
-/docs/user-guide/pod-security-policy							/docs/concepts/policy/pod-security-policy		301
-/docs/user-guide/pod-states										/docs/concepts/workloads/pods/pod-lifecycle		301
-/docs/user-guide/pod-templates									/docs/concepts/workloads/pods/pod-overview		301
-/docs/user-guide/pods											/docs/concepts/workloads/pods/pod		301
-/docs/user-guide/pods/init-container							/docs/concepts/workloads/pods/init-containers		301
-/docs/user-guide/pods/multi-container							/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume		301
-/docs/user-guide/pods/single-container							/docs/tasks/run-application/run-stateless-application-deployment		301
-/docs/user-guide/prereqs										/docs/tasks/tools/install-kubectl		301
-/docs/user-guide/production-pods								/docs/tasks/		301
-/docs/user-guide/projected-volume								/docs/tasks/configure-pod-container/configure-projected-volume-storage		301
-/docs/user-guide/quick-start									/docs/tasks/access-application-cluster/service-access-application-cluster		301
-/docs/user-guide/replicasets									/docs/concepts/workloads/controllers/replicaset		301
-/docs/user-guide/replication-controller							/docs/concepts/workloads/controllers/replicationcontroller		301
-/docs/user-guide/rolling-updates								/docs/tasks/run-application/rolling-update-replication-controller		301
-/docs/user-guide/secrets										/docs/concepts/configuration/secret		301
-/docs/user-guide/secrets/walkthrough							/docs/tasks/inject-data-application/distribute-credentials-secure		301
-/docs/user-guide/service-accounts								/docs/tasks/configure-pod-container/configure-service-account		301
-/docs/user-guide/services-firewalls								/docs/tasks/access-application-cluster/configure-cloud-provider-firewall		301
-/docs/user-guide/services										/docs/concepts/services-networking/service		301
-/docs/user-guide/services/operations							/docs/tasks/access-application-cluster/connecting-frontend-backend		301
-/docs/user-guide/sharing-clusters								/docs/tasks/administer-cluster/share-configuration		301
-/docs/user-guide/simple-nginx									/docs/tasks/run-application/run-stateless-application-deployment		301
-/docs/user-guide/thirdpartyresources							/docs/tasks/access-kubernetes-api/extend-api-third-party-resource		301
-/docs/user-guide/ui												/docs/tasks/access-application-cluster/web-ui-dashboard		301
-/docs/user-guide/update-demo									/docs/tasks/run-application/rolling-update-replication-controller		301
-/docs/user-guide/volumes										/docs/concepts/storage/volumes		301
-/docs/user-guide/working-with-resources							/docs/tutorials/object-management-kubectl/object-management		301
-
-/docs/whatisk8s													/docs/concepts/overview/what-is-kubernetes		301
+/docs/whatisk8s/     /docs/concepts/overview/what-is-kubernetes/ 301
 
 
 ##############
 # address 404s
 #
-/concepts/containers/container-lifecycle-hooks					/docs/concepts/containers/container-lifecycle-hooks		301
+/concepts/containers/container-lifecycle-hooks/     /docs/concepts/containers/container-lifecycle-hooks/ 301
 
-/docs/api-reference/apps/v1alpha1/definitions					https://v1-4.docs.kubernetes.io/docs/api-reference/apps/v1alpha1/definitions		301
-/docs/api-reference/apps/v1beta1/operations						https://v1-4.docs.kubernetes.io/docs/api-reference/apps/v1beta1/operations		301
-/docs/api-reference/authorization.k8s.io/v1beta1/definitions	https://v1-4.docs.kubernetes.io/docs/api-reference/authorization.k8s.io/v1beta1/definitions		301
-/docs/api-reference/authorization.k8s.io/v1beta1/operations		https://v1-4.docs.kubernetes.io/docs/api-reference/authorization.k8s.io/v1beta1/operations		301
-/docs/api-reference/autoscaling/v1/operations					https://v1-4.docs.kubernetes.io/docs/api-reference/autoscaling/v1/operations		301
-/docs/api-reference/batch/v1/operations							https://v1-4.docs.kubernetes.io/docs/api-reference/batch/v1/operations		301
-/docs/api-reference/batch/v2alpha1/definitions					https://v1-4.docs.kubernetes.io/docs/api-reference/batch/v2alpha1/definitions		301
-/docs/api-reference/certificates.k8s.io/v1alpha1/definitions	https://v1-4.docs.kubernetes.io/docs/api-reference/certificates.k8s.io/v1alpha1/definitions		301
-/docs/api-reference/certificates/v1alpha1/operations			https://v1-4.docs.kubernetes.io/docs/api-reference/certificates/v1alpha1/operations		301
-/docs/api-reference/extensions/v1beta1/operations				https://v1-4.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/operations		301
-/docs/api-reference/policy/v1alpha1/definitions					https://v1-4.docs.kubernetes.io/docs/api-reference/policy/v1alpha1/definitions		301
-/docs/api-reference/policy/v1beta1/definitions					https://v1-4.docs.kubernetes.io/docs/api-reference/policy/v1beta1/definitions		301
-/docs/api-reference/README										https://v1-4.docs.kubernetes.io/docs/api-reference/README		301
-/docs/api-reference/storage.k8s.io/v1beta1/operations			https://v1-4.docs.kubernetes.io/docs/api-reference/storage.k8s.io/v1beta1/operations		301
+/docs/api-reference/apps/v1alpha1/definitions     https://v1-4.docs.kubernetes.io/docs/api-reference/apps/v1alpha1/definitions/ 301
+/docs/api-reference/apps/v1beta1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/apps/v1beta1/operations/ 301
+/docs/api-reference/authorization.k8s.io/v1beta1/definitions     https://v1-4.docs.kubernetes.io/docs/api-reference/authorization.k8s.io/v1beta1/definitions/ 301
+/docs/api-reference/authorization.k8s.io/v1beta1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/authorization.k8s.io/v1beta1/operations/ 301
+/docs/api-reference/autoscaling/v1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/autoscaling/v1/operations/ 301
+/docs/api-reference/batch/v1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/batch/v1/operations/ 301
+/docs/api-reference/batch/v2alpha1/definitions     https://v1-4.docs.kubernetes.io/docs/api-reference/batch/v2alpha1/definitions/ 301
+/docs/api-reference/certificates.k8s.io/v1alpha1/definitions     https://v1-4.docs.kubernetes.io/docs/api-reference/certificates.k8s.io/v1alpha1/definitions/ 301
+/docs/api-reference/certificates/v1alpha1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/certificates/v1alpha1/operations/ 301
+/docs/api-reference/extensions/v1beta1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/operations/ 301
+/docs/api-reference/policy/v1alpha1/definitions     https://v1-4.docs.kubernetes.io/docs/api-reference/policy/v1alpha1/definitions/ 301
+/docs/api-reference/policy/v1beta1/definitions     https://v1-4.docs.kubernetes.io/docs/api-reference/policy/v1beta1/definitions/ 301
+/docs/api-reference/README     https://v1-4.docs.kubernetes.io/docs/api-reference/README/ 301
+/docs/api-reference/storage.k8s.io/v1beta1/operations     https://v1-4.docs.kubernetes.io/docs/api-reference/storage.k8s.io/v1beta1/operations/ 301
 
-/docs/api-reference/v1/definitions								/docs/api-reference/v1.7		301
+/docs/api-reference/v1/definitions/     /docs/api-reference/v1.7/ 301
 
-/docs/concepts/cluster											/docs/concepts/cluster-administration/cluster-administration-overview/		301
-/docs/concepts/object-metadata/annotations						/docs/concepts/overview/working-with-objects/annotations		301
+/docs/concepts/cluster/     /docs/concepts/cluster-administration/cluster-administration-overview/ 301
+/docs/concepts/object-metadata/annotations/     /docs/concepts/overview/working-with-objects/annotations/ 301
 
-/docs/concepts/workloads/controllers/daemonset/docs/concepts/workloads/pods/pod			/docs/concepts/workloads/pods/pod		301
-/docs/concepts/workloads/controllers/deployment/docs/concepts/workloads/pods/pod		/docs/concepts/workloads/pods/pod		301
+/docs/concepts/workloads/controllers/daemonset/     /docs/concepts/workloads/pods/poddocs/concepts/workloads/pods/pod/ 301
+/docs/concepts/workloads/controllers/deployment/     /docs/concepts/workloads/pods/poddocs/concepts/workloads/pods/pod/ 301
 
-/docs/contribute/write-new-topic		/docs/home/contribute/write-new-topic		301
+/docs/contribute/write-new-topic/     /docs/home/contribute/write-new-topic/ 301
 
-/docs/getting-started-guides/coreos/azure				/docs/getting-started-guides/coreos		301
-/docs/getting-started-guides/coreos/bare_metal_calico	/docs/getting-started-guides/coreos		301
-/docs/getting-started-guides/juju						/docs/getting-started-guides/ubuntu/installation		301
-/docs/getting-started-guides/kargo						/docs/getting-started-guides/kubespray		301
-/docs/getting-started-guides/logging-elasticsearch		/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana		301
-/docs/getting-started-guides/logging					/docs/concepts/cluster-administration/logging		301
-/docs/getting-started-guides/rackspace					/docs/setup/pick-right-solution		301
-/docs/getting-started-guides/ubuntu-calico				/docs/getting-started-guides/ubuntu		301
-/docs/getting-started-guides/ubuntu/automated			/docs/getting-started-guides/ubuntu		301
-/docs/getting-started-guides/vagrant					/docs/getting-started-guides/alternatives		301
-/docs/getting-started-guides/windows/While				/docs/getting-started-guides/windows		301
+/docs/getting-started-guides/coreos/azure/     /docs/getting-started-guides/coreos/ 301
+/docs/getting-started-guides/coreos/bare_metal_calico/     /docs/getting-started-guides/coreos/ 301
+/docs/getting-started-guides/juju/     /docs/getting-started-guides/ubuntu/installation/ 301
+/docs/getting-started-guides/kargo/     /docs/getting-started-guides/kubespray/ 301
+/docs/getting-started-guides/logging-elasticsearch/     /docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/ 301
+/docs/getting-started-guides/logging/     /docs/concepts/cluster-administration/logging/ 301
+/docs/getting-started-guides/rackspace/     /docs/setup/pick-right-solution/ 301
+/docs/getting-started-guides/ubuntu-calico/     /docs/getting-started-guides/ubuntu/ 301
+/docs/getting-started-guides/ubuntu/automated/     /docs/getting-started-guides/ubuntu/ 301
+/docs/getting-started-guides/vagrant/     /docs/getting-started-guides/alternatives/ 301
+/docs/getting-started-guides/windows/While/     /docs/getting-started-guides/windows/ 301
 
-/docs/federation/api-reference/extensions/v1beta1/definitions	/docs/reference/federation/extensions/v1beta1/definitions		301
-/docs/federation/api-reference/federation/v1beta1/definitions	/docs/reference/federation/extensions/v1beta1/definitions		301
-/docs/federation/api-reference/README							/docs/reference/federation		301
-/docs/federation/api-reference/v1/definitions					/docs/reference/federation/v1/definitions		301
-/docs/reference/federation/v1beta1/definitions					/docs/reference/federation/extensions/v1beta1/definitions		301
-/docs/reference/federation/v1beta1/operations					/docs/reference/federation/extensions/v1beta1/operations		301
+/docs/federation/api-reference/extensions/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
+/docs/federation/api-reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
+/docs/federation/api-reference/README/     /docs/reference/federation/ 301
+/docs/federation/api-reference/v1/definitions/     /docs/reference/federation/v1/definitions/ 301
+/docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
+/docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
 
-/docs/reporting-security-issues		/security		301
+/docs/reporting-security-issues/     /security/ 301
 
-/docs/stable/user-guide/labels													/docs/concepts/overview/working-with-objects/labels		301
-/docs/tasks/access-application-cluster/access-cluster.md						/docs/tasks/access-application-cluster/access-cluster		301
-/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig	/docs/tasks/access-application-cluster/configure-access-multiple-clusters	301
-/docs/tasks/access-kubernetes-api/access-kubernetes-api/http-proxy-access-api	/docs/tasks/access-kubernetes-api/http-proxy-access-api		301
-/docs/tasks/administer-cluster/reserve-compute-resources/out-of-resource.md		/docs/tasks/administer-cluster/out-of-resource		301
-/docs/tasks/configure-pod-container/configure-pod-disruption-budget				/docs/tasks/run-application/configure-pdb		301
-/docs/tasks/configure-pod-container/define-command-argument-container			/docs/tasks/inject-data-application/define-command-argument-container		301
-/docs/tasks/debug-application-cluster/sematext-logging-monitoring				https://sematext.com/kubernetes/		301
-/docs/tasks/job/work-queue-1													/docs/concepts/workloads/controllers/jobs-run-to-completion		301
-/docs/tasks/manage-stateful-set/delete-pods										/docs/tasks/run-application/delete-stateful-set		301
+/docs/stable/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/ 301
+/docs/tasks/access-application-cluster/access-cluster.md      /docs/tasks/access-application-cluster/access-cluster/ 301
+/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/     /docs/tasks/access-application-cluster/configure-access-multiple-clusters/ 301
+/docs/tasks/access-kubernetes-api/access-kubernetes-api/http-proxy-access-api/     /docs/tasks/access-kubernetes-api/http-proxy-access-api/ 301
+/docs/tasks/administer-cluster/reserve-compute-resources/out-of-resource.md     /docs/tasks/administer-cluster/out-of-resource/ 301
+/docs/tasks/configure-pod-container/configure-pod-disruption-budget/     /docs/tasks/run-application/configure-pdb/ 301
+/docs/tasks/configure-pod-container/define-command-argument-container/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
 
-/docs/tutorials/getting-started/cluster-intro			/docs/tutorials/kubernetes-basics/cluster-intro		301
-/docs/tutorials/getting-started/expose-intro			/docs/tutorials/kubernetes-basics/expose-intro		301
-/docs/tutorials/getting-started/scale-app				/docs/tutorials/kubernetes-basics/scale-interactive		301
-/docs/tutorials/getting-started/scale-intro				/docs/tutorials/kubernetes-basics/scale-intro		301
-/docs/tutorials/getting-started/update-interactive		/docs/tutorials/kubernetes-basics/update-interactive		301
-/docs/tutorials/getting-started/update-intro			/docs/tutorials/kubernetes-basics/		301
+/docs/tasks/debug-application-cluster/sematext-logging-monitoring/     https://sematext.com/kubernetes/ 301
 
-/docs/user-guide/containers									/docs/tasks/inject-data-application/define-command-argument-container		301
-/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md	/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough		301
-/docs/user-guide/ingress.md									/docs/concepts/services-networking/ingress		301
-/docs/user-guide/replication-controller/operations			/docs/concepts/workloads/controllers/replicationcontroller		301
-/docs/user-guide/resizing-a-replication-controller			/docs/concepts/workloads/controllers/replicationcontroller		301
-/docs/user-guide/scheduled-jobs								/docs/concepts/workloads/controllers/cron-jobs		301
-/docs/user-guide/security-context							/docs/tasks/configure-pod-container/security-context		301
+/docs/tasks/job/work-queue-1/     /docs/concepts/workloads/controllers/jobs-run-to-completion/ 301
+/docs/tasks/manage-stateful-set/delete-pods/     /docs/tasks/run-application/delete-stateful-set/ 301
 
-/kubernetes-bootcamp/2-1.html			/docs/tutorials/kubernetes-basics		301
-/kubernetes-bootcamp/2-3-2.html			/docs/tutorials/kubernetes-basics		301
-/kubernetes								/docs		301
-/kubernetes/swagger-spec				https://github.com/kubernetes/kubernetes/tree/master/api/swagger-spec		301
-/serviceaccount/token					/docs/tasks/configure-pod-container/configure-service-account		301
+/docs/tutorials/getting-started/cluster-intro/     /docs/tutorials/kubernetes-basics/cluster-intro/ 301
+/docs/tutorials/getting-started/expose-intro/     /docs/tutorials/kubernetes-basics/expose-intro/ 301
+/docs/tutorials/getting-started/scale-app/     /docs/tutorials/kubernetes-basics/scale-interactive/ 301
+/docs/tutorials/getting-started/scale-intro/     /docs/tutorials/kubernetes-basics/scale-intro/ 301
+/docs/tutorials/getting-started/update-interactive/     /docs/tutorials/kubernetes-basics/update-interactive/ 301
+/docs/tutorials/getting-started/update-intro/     /docs/tutorials/kubernetes-basics/ 301
 
-/v1.1/docs/admin/networking.html		/docs/concepts/cluster-administration/networking		301
-/v1.1/docs/getting-started-guides		/docs/tutorials/kubernetes-basics/						301
+/docs/user-guide/containers/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
+/docs/user-guide/horizontal-pod-autoscaling/walkthrough.md     /docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ 301
+/docs/user-guide/ingress.md     /docs/concepts/services-networking/ingress/ 301
+/docs/user-guide/replication-controller/operations/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
+/docs/user-guide/resizing-a-replication-controller/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
+/docs/user-guide/scheduled-jobs/     /docs/concepts/workloads/controllers/cron-jobs/ 301
+/docs/user-guide/security-context/     /docs/tasks/configure-pod-container/security-context/ 301
 
+/kubernetes-bootcamp/2-1.html     /docs/tutorials/kubernetes-basics/ 301
+/kubernetes-bootcamp/2-3-2.html     /docs/tutorials/kubernetes-basics/ 301
+/kubernetes     /docs/ 301
+/kubernetes/swagger-spec     https://github.com/kubernetes/kubernetes/tree/master/api/swagger-spec/ 301
+/serviceaccount/token/     /docs/tasks/configure-pod-container/configure-service-account/ 301
 
-############################
-# pattern matching redirects
-#
-/docs/user-guide/kubectl/kubectl_*					/docs/user-guide/kubectl/v1.7/#:splat		200
-
-/v1.1/docs/*										/docs/										301
-
-/docs/user-guide/kubectl/1_5/*					https://v1-5.docs.kubernetes.io/docs/user-guide/kubectl/v1.5		301
-/docs/user-guide/kubectl/v1.5/node_modules/*	https://v1-5.docs.kubernetes.io/docs/user-guide/kubectl/v1.5		301
-/docs/resources-reference/1_5/*					https://v1-5.docs.kubernetes.io/docs/resources-reference/v1.5		301
-/docs/resources-reference/v1.5/node_modules/*	https://v1-5.docs.kubernetes.io/docs/resources-reference/v1.5		301
-/docs/api-reference/1_5/*						https://v1-5.docs.kubernetes.io/docs/api-reference/v1.5				301
-/docs/api-reference/v1.5/node_modules/*			https://v1-5.docs.kubernetes.io/docs/api-reference/v1.5				301
-
-/docs/user-guide/kubectl/v1.6/node_modules/*	https://v1-6.docs.kubernetes.io/docs/user-guide/kubectl/v1.6		301
-/docs/api-reference/v1.6/node_modules/*			https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6				301
-
-/docs/api-reference/v1.7/node_modules/*				/docs/api-reference/v1.7		301
-
-/docs/getting-started-guides/docker-multinode/*		/docs/setup/independent/create-cluster-kubeadm		301
-
-/docs/admin/resourcequota/*							/docs/concepts/policy/resource-quotas		301
-
+/v1.1/docs/admin/networking.html/     /docs/concepts/cluster-administration/networking/ 301
+/v1.1/docs/getting-started-guides/     /docs/tutorials/kubernetes-basics/ 301
 
 #################################
 # redirects from /js/redirects.js
 #
-/resource-quota													/docs/concepts/policy/resource-quotas		301
-/horizontal-pod-autoscaler										/docs/tasks/run-application/horizontal-pod-autoscale		301
-/docs/roadmap													https://github.com/kubernetes/kubernetes/milestones/		301
-/api-ref														https://github.com/kubernetes/kubernetes/milestones/		301
-/kubernetes/third_party/swagger-ui								/docs/reference		301
-/docs/user-guide/overview										/docs/concepts/overview/what-is-kubernetes		301
-/docs/troubleshooting											/docs/tasks/debug-application-cluster/troubleshooting		301
-/docs/concepts/services-networking/networkpolicies				/docs/concepts/services-networking/network-policies		301
-/docs/getting-started-guides/meanstack							https://medium.com/google-cloud/running-a-mean-stack-on-google-cloud-platform-with-kubernetes-149ca81c2b5d		301
-/docs/samples													/docs/tutorials		301
-/v1.1															/		301
-/v1.0															/		301
 
+/resource-quota/     /docs/concepts/policy/resource-quotas/ 301
+/horizontal-pod-autoscaler/     /docs/tasks/run-application/horizontal-pod-autoscale/ 301
+/docs/roadmap/     https://github.com/kubernetes/kubernetes/milestones/ 301
+/api-ref/     https://github.com/kubernetes/kubernetes/milestones/ 301
+/kubernetes/third_party/swagger-ui/     /docs/reference/ 301
+/docs/user-guide/overview/     /docs/concepts/overview/what-is-kubernetes/ 301
+/docs/troubleshooting/     /docs/tasks/debug-application-cluster/troubleshooting/ 301
+/docs/concepts/services-networking/networkpolicies/     /docs/concepts/services-networking/network-policies/ 301
+/docs/getting-started-guides/meanstack/     https://medium.com/google-cloud/running-a-mean-stack-on-google-cloud-platform-with-kubernetes-149ca81c2b5d/ 301
+/docs/samples/     /docs/tutorials/ 301
+
+/v1.1 301
+/v1.0 301
 
 ########################################################
 # Redirect users with chinese language preference to /cn
 #
-#/  /cn  302  Language=zh
-
+#/     /cn  302  Language=zh
 
 ###########################
 # Fixed 404s from analytics
+#
 
-/concepts/containers/container-lifecycle-hooks		/docs/concepts/containers/container-lifecycle-hooks		301
-/docs/abstractions/controllers/petset				/docs/concepts/workloads/controllers/petset		301
+/concepts/containers/container-lifecycle-hooks/     /docs/concepts/containers/container-lifecycle-hooks/ 301
+/docs/abstractions/controllers/petset/     /docs/concepts/workloads/controllers/petset/ 301
 
-/docs/admin/add-ons					/docs/concepts/cluster-administration/addons		301
-/docs/admin/limitrange/Limits		/docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage		301
+/docs/admin/add-ons/     /docs/concepts/cluster-administration/addons/ 301
+/docs/admin/limitrange/Limits/     /docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage/ 301
 
-/docs/api-reference/1_5/*		/docs/api-reference/v1.5		301
+/docs/concepts/cluster-administration/device-plugins/     /docs/concepts/cluster-administration/network-plugins/ 301
+/docs/concepts/configuration/container-command-args/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
+/docs/concepts/ecosystem/thirdpartyresource/     /docs/tasks/access-kubernetes-api/extend-api-third-party-resource/ 301
+/docs/concepts/overview/     /docs/concepts/overview/what-is-kubernetes/ 301
+/docs/concepts/policy/container-capabilities/     /docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container/ 301
+/docs/concepts/policy/security-context/     /docs/tasks/configure-pod-container/security-context/ 301
+/docs/concepts/storage/volumes/emptyDirapiVersion/     /docs/concepts/storage/volumes/#emptydir/ 301
+/docs/concepts/tools/kubectl/object-management-using-commands/     /docs/tutorials/object-management-kubectl/imperative-object-management-command/ 301
+/docs/concepts/workload/pods/pod-overview/     /docs/concepts/workloads/pods/pod-overview 301
+/docs/concepts/workloads/controllers/cron-jobs/deployment/     /docs/concepts/workloads/controllers/cron-jobs/ 301
+/docs/concepts/workloads/controllers/statefulsets/     /docs/concepts/workloads/controllers/statefulset/ 301
+/docs/concepts/workloads/pods/init-containers/Kubernetes     /docs/concepts/workloads/pods/init-containers/ 301
 
-/docs/concepts/cluster-administration/device-plugins			/docs/concepts/cluster-administration/network-plugins		301
-/docs/concepts/configuration/container-command-args				/docs/tasks/inject-data-application/define-command-argument-container		301
-/docs/concepts/ecosystem/thirdpartyresource						/docs/tasks/access-kubernetes-api/extend-api-third-party-resource		301
-/docs/concepts/overview											/docs/concepts/overview/what-is-kubernetes		301
-/docs/concepts/policy/container-capabilities					/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container		301
-/docs/concepts/policy/security-context							/docs/tasks/configure-pod-container/security-context		301
-/docs/concepts/storage/volumes/emptyDirapiVersion				/docs/concepts/storage/volumes/#emptydir		301
-/docs/concepts/tools/kubectl/object-management-using-commands	/docs/tutorials/object-management-kubectl/imperative-object-management-command		301
-/docs/concepts/workload/pods/pod-overview						/docs/concepts/workloads/pods/pod-overview			301
-/docs/concepts/workloads/controllers/cron-jobs/deployment		/docs/concepts/workloads/controllers/cron-jobs		301
-/docs/concepts/workloads/controllers/statefulsets				/docs/concepts/workloads/controllers/statefulset	301
-/docs/concepts/workloads/pods/init-containers/Kubernetes		/docs/concepts/workloads/pods/init-containers		301
+/docs/consumer-guideline/pod-security-coverage/     /docs/concepts/policy/pod-security-policy/ 301
 
-/docs/consumer-guideline/pod-security-coverage		/docs/concepts/policy/pod-security-policy		301
+/docs/contribute/create-pull-request/     /docs/home/contribute/create-pull-request 301
+/docs/contribute/page-templates/     /docs/home/contribute/page-templates 301
+/docs/contribute/review-issues/     /docs/home/contribute/review-issues 301
+/docs/contribute/stage-documentation-changes/     /docs/home/contribute/stage-documentation-changes/ 301
+/docs/contribute/style-guide/     /docs/home/contribute/style-guide 301
 
-/docs/contribute/create-pull-request			/docs/home/contribute/create-pull-request			301
-/docs/contribute/page-templates					/docs/home/contribute/page-templates				301
-/docs/contribute/review-issues					/docs/home/contribute/review-issues					301
-/docs/contribute/stage-documentation-changes	/docs/home/contribute/stage-documentation-changes	301
-/docs/contribute/style-guide					/docs/home/contribute/style-guide					301
+/docs/deprecate/     /ddocs/reference/deprecation-policy/ 301
+/docs/deprecation-policy/     /docs/reference/deprecation-policy/ 301
 
-/docs/deprecated				/docs/reference/deprecation-policy		301
-/docs/deprecation-policy		/docs/reference/deprecation-policy		301
+/docs/federation/api-reference/     /docs/reference/federation/v1/operations/ 301
+/docs/federation/api-reference/extensions/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
+/docs/federation/api-reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
+/docs/federation/api-reference/v1/operations/     /docs/reference/federation/v1/operations/ 301
 
+/docs/home/deprecation-policy/     /docs/reference/deprecation-policy/ 301
 
-/docs/federation/api-reference										/docs/reference/federation/v1/operations		301
-/docs/federation/api-reference/extensions/v1beta1/operations		/docs/reference/federation/extensions/v1beta1/operations		301
-/docs/federation/api-reference/federation/v1beta1/operations		/docs/reference/federation/extensions/v1beta1/operations		301
-/docs/federation/api-reference/v1/operations						/docs/reference/federation/v1/operations		301
+/docs/stable/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/ 301
 
-/docs/getting-started-guide/*			/docs/setup		301
+/docs/tasks/administer-cluster/apply-resource-quota-limit/     /docs/tasks/administer-cluster/quota-api-object/ 301
+/docs/tasks/administer-cluster/configure-namespace-isolation/     /docs/concepts/services-networking/network-policies/ 301
+/docs/tasks/administer-cluster/configure-pod-disruption-budget/     /docs/tasks/run-application/configure-pdb/ 301
+/docs/tasks/administer-cluster/cpu-management-policies/     /docs/concepts/configuration/manage-compute-resources-container/ 301
+/docs/tasks/administer-cluster/default-cpu-request-limit/     /docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit/ 301
+/docs/tasks/administer-cluster/default-memory-request-limit/     /docs/tasks/configure-pod-container/assign-memory-resource/#specify-a-memory-request-and-a-memory-limit/ 301
 
-/docs/home/deprecation-policy			/docs/reference/deprecation-policy		301
+/docs/tasks/configure-pod-container/cilium-network-policy/     /docs/tasks/administer-cluster/cilium-network-policy/ 301
+/docs/tasks/configure-pod-container/define-command-argument-container/     /docs/tasks/inject-data-application/define-command-argument-container/ 301
+/docs/tasks/configure-pod-container/projected-volume/     /docs/tasks/configure-pod-container/configure-projected-volume-storage/ 301
 
-/docs/resources-reference/1_5/*			/docs/resources-reference/v1.5		301
-/docs/resources-reference/1_6/*			/docs/resources-reference/v1.6		301
-/docs/resources-reference/1_7/*			/docs/resources-reference/v1.7		301
+/docs/tasks/stateful-sets/deleting-pods/     /docs/tasks/run-application/force-delete-stateful-set-pod/ 301
 
-/docs/stable/user-guide/labels			/docs/concepts/overview/working-with-objects/labels		301
+/docs/user-guide/liveness/     /docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ 301
+/docs/user-guide/logging/     /docs/concepts/cluster-administration/logging/ 301
+/docs/user-guide/replication-controller/operations/     /docs/concepts/workloads/controllers/replicationcontroller/ 301
+/docs/user-guide/service-accounts/working-with-resources/     /docs/tutorials/object-management-kubectl/object-management/ 301
+/docs/user-guide/StatefulSet/     /docs/concepts/workloads/controllers/statefulset/ 301
+/docs/user-guide/ui-access/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
 
+/latest/docs/     /docs/home/ 301
 
-/docs/tasks/administer-cluster/apply-resource-quota-limit		/docs/tasks/administer-cluster/quota-api-object		301
-/docs/tasks/administer-cluster/configure-namespace-isolation	/docs/concepts/services-networking/network-policies		301
-/docs/tasks/administer-cluster/configure-pod-disruption-budget	/docs/tasks/run-application/configure-pdb		301
-
-/docs/tasks/administer-cluster/cpu-management-policies			/docs/concepts/configuration/manage-compute-resources-container		301
-/docs/tasks/administer-cluster/default-cpu-request-limit		/docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit		301
-/docs/tasks/administer-cluster/default-memory-request-limit		/docs/tasks/configure-pod-container/assign-memory-resource/#specify-a-memory-request-and-a-memory-limit		301
-
-/docs/tasks/configure-pod-container/cilium-network-policy					/docs/tasks/administer-cluster/cilium-network-policy		301
-/docs/tasks/configure-pod-container/define-command-argument-container		/docs/tasks/inject-data-application/define-command-argument-container		301
-/docs/tasks/configure-pod-container/projected-volume						/docs/tasks/configure-pod-container/configure-projected-volume-storage		301
-
-/docs/tasks/stateful-sets/deleting-pods			/docs/tasks/run-application/force-delete-stateful-set-pod		301
-
-/docs/templatedemos/*							/docs/home/contribute/page-templates		301
-
-/docs/tutorials/getting-started/*				/docs/tutorials/kubernetes-basics		301
-
-/docs/user-guide/federation/*					/docs/concepts/cluster-administration/federation		301
-/docs/user-guide/garbage-collector				/docs/concepts/workloads/controllers/garbage-collection		301
-/docs/user-guide/horizontal-pod-autoscaler/*	/docs/tasks/run-application/horizontal-pod-autoscale		301
-
-
-/docs/user-guide/liveness									/docs/tasks/configure-pod-container/configure-liveness-readiness-probes		301
-/docs/user-guide/logging									/docs/concepts/cluster-administration/logging		301
-/docs/user-guide/replication-controller/operations			/docs/concepts/workloads/controllers/replicationcontroller		301
-/docs/user-guide/service-accounts/working-with-resources	/docs/tutorials/object-management-kubectl/object-management		301
-/docs/user-guide/StatefulSet								/docs/concepts/workloads/controllers/statefulset		301
-/docs/user-guide/ui-access									/docs/tasks/access-application-cluster/web-ui-dashboard		301
-
-/kubernetes-bootcamp/*				/docs/tutorials/kubernetes-basics		301
-
-/latest/docs						/docs/home		301
-
-/kubernetes/swagger-spec			https://github.com/kubernetes/kubernetes/tree/master/api/swagger-spec		301
-/swagger-spec/*						https://github.com/kubernetes/kubernetes/tree/master/api/swagger-spec		301
-/third_party/swagger-ui/*			/docs/reference		301
+/kubernetes/swagger-spec     https://github.com/kubernetes/kubernetes/tree/master/api/swagger-spec/ 301


### PR DESCRIPTION
I've been using Screaming Frog SEO Spider to study redirection in the kubernetes.io site. It appears that it is best for redirect targets to end in a trailing slash. Otherwise, we get one redirect to new-topic, and then a second redirect o new-topic/. Also, it looks like most URLs that get redirected end in a trailing slash. So for most rows in _redirects, I've added trailing slashes to both the From URL and the To URL.

Also, I've changed from tabs to spaces. Tabs between the From URL and To URL weren't helping, because the spacing was only pretty in certain text editors. I propose that we adopt a convention of five spaces between From URL and To URL.

This PR contains one round of updates to _redirects. We will need additional PRs to address other issues like the redirection of old ref pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5589)
<!-- Reviewable:end -->
