### PR TITLE
Fix input/output of selfsubjectaccess review

### DIFF
--- a/docs/admin/authorization/index.md
+++ b/docs/admin/authorization/index.md
@@ -99,37 +99,28 @@ field of the returned object is the result of the query.
 
 ```bash
 $ kubectl create -f - -o yaml << EOF
-{
-    "kind": "SelfSubjectAccessReview",
-    "apiVersion": "authorization.k8s.io/v1",
-    "spec": {
-         "resourceAttributes": {
-             "group": "apps",
-             "name": "deployments",
-             "verb": "create",
-             "namespace": "dev"
-         }
-     }
-}
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+spec:
+  resourceAttributes:
+    group: apps
+    name: deployments
+    verb: create
+    namespace: dev
 EOF
-{
-    "apiVersion": "authorization.k8s.io/v1",
-    "kind": "SelfSubjectAccessReview",
-    "metadata": {
-        "creationTimestamp": null
-    },
-    "spec": {
-        "resourceAttributes": {
-            "group": "apps",
-            "name": "deployments",
-            "namespace": "dev",
-            "verb": "create"
-        }
-    },
-    "status": {
-        "allowed": true
-    }
-}
+
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+metadata:
+  creationTimestamp: null
+spec:
+  resourceAttributes:
+    group: apps
+    name: deployments
+    namespace: dev
+    verb: create
+status:
+  allowed: true
 ```
 
 ## Using Flags for Your Authorization Module


### PR DESCRIPTION
The recent update to authorization contains incorrect output. The command is producing YAML but the example showed it in JSON. This patch also use YAML as input for brevity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5593)
<!-- Reviewable:end -->
