### PR TITLE
Kubeadm reference updates

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -7,9 +7,8 @@ title: CentOS
 * TOC
 {:toc}
 
-## Warning
-
-This guide [has been deprecated](https://github.com/kubernetes/kubernetes.github.io/issues/1613). It was originally written for Kubernetes 1.1.0. Please check [the latest guide](/docs/getting-started-guides/kubeadm/).
+**Caution:** This guide was originally written for Kubernetes 1.1.0 and [is deprecated](https://github.com/kubernetes/kubernetes.github.io/issues/1613) and is replaced by [kubeadm](/docs/admin/kubeadm/).
+{: .caution}
 
 ## Prerequisites
 
@@ -79,6 +78,7 @@ KUBE_MASTER="--master=http://centos-master:8080"
 ```
 
 * Disable the firewall on the master and all the nodes, as docker does not play well with other firewall rule managers. CentOS won't let you disable the firewall as long as SELinux is enforcing, so that needs to be disabled first.
+* If you disable SELinux, make sure you reboot your machine before continuing to more steps.
 
 ```shell
 setenforce 0
@@ -222,7 +222,7 @@ kubectl config use-context default-context
 $ kubectl get nodes
 NAME                   STATUS     AGE     VERSION
 centos-minion-1        Ready      3d      v1.6.0+fff5156
-centos-minion-2        Ready      3d      v1.6.0+fff5156   
+centos-minion-2        Ready      3d      v1.6.0+fff5156
 centos-minion-3        Ready      3d      v1.6.0+fff5156
 ```
 

--- a/docs/getting-started-guides/docker-multinode.md
+++ b/docs/getting-started-guides/docker-multinode.md
@@ -1,1 +1,0 @@
-# Stop. This guide has been superseded by [kubeadm](../kubeadm/). This page is only present for historical purposes.

--- a/docs/getting-started-guides/kops.md
+++ b/docs/getting-started-guides/kops.md
@@ -56,7 +56,7 @@ from clients.
 
 kops has a strong opinion on the cluster name: it should be a valid DNS name.  By doing so you will
 no longer get your clusters confused, you can share clusters with your colleagues unambiguously,
-and you can reach them without relying on remembering an IP address. 
+and you can reach them without relying on remembering an IP address.
 
 You can, and probably should, use subdomains to divide your clusters.  As our example we will use
 `useast1.dev.example.com`.  The API server endpoint will then be `api.useast1.dev.example.com`.
@@ -102,8 +102,8 @@ the S3 bucket name.
 
 * Create the S3 bucket using `aws s3 mb s3://clusters.dev.example.com`
 
-* You can `export KOPS_STATE_STORE=s3://clusters.dev.example.com` and then kops will use this location by default. 
-   We suggest putting this in your bash profile or similar. 
+* You can `export KOPS_STATE_STORE=s3://clusters.dev.example.com` and then kops will use this location by default.
+   We suggest putting this in your bash profile or similar.
 
 
 ### (4/5) Build your cluster configuration
@@ -162,4 +162,4 @@ See the [list of add-ons](/docs/concepts/cluster-administration/addons/) to expl
 
 * Slack Channel: [#sig-aws](https://kubernetes.slack.com/messages/sig-aws/) has a lot of kops users
 * [GitHub Issues](https://github.com/kubernetes/kops/issues)
- 
+

--- a/docs/getting-started-guides/kubespray.md
+++ b/docs/getting-started-guides/kubespray.md
@@ -13,7 +13,7 @@ Kubespray is a composition of [Ansible](http://docs.ansible.com/) playbooks, [in
 * support for most popular Linux distributions
 * continuous integration tests
 
-To choose a tool which best fits your use case, read [this comparison](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/comparisons.md) to [kubeadm](../kubeadm) and [kops](../kops).
+To choose a tool which best fits your use case, read [this comparison](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/comparisons.md) to [kubeadm](/docs/admin/kubeadm/) and [kops](../kops).
 
 ## Creating a cluster
 


### PR DESCRIPTION
Found broken references while looking for relevant location to update reference for Kubeadm install process on CentOS. 

CentOS documentation deprecated, but I went ahead and updated it anyway since there was some confusion around it represented by https://github.com/kubernetes/kubernetes.github.io/issues/3159

 - fixes relative references to Kubeadm documentation that was moved
 - resolves https://github.com/kubernetes/kubernetes.github.io/issues/3159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5594)
<!-- Reviewable:end -->
