### PR TITLE
Remove 3 links in jobs-run-to-completion.md which go nowhere

### DIFF
--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -92,9 +92,7 @@ $ kubectl logs $pods
 
 ## Writing a Job Spec
 
-As with all other Kubernetes config, a Job needs `apiVersion`, `kind`, and `metadata` fields.  For
-general information about working with config files, see [here](/docs/user-guide/simple-yaml),
-[here](/docs/user-guide/configuring-containers), and [here](/docs/user-guide/working-with-resources).
+As with all other Kubernetes config, a Job needs `apiVersion`, `kind`, and `metadata` fields.
 
 A Job also needs a [`.spec` section](https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status).
 


### PR DESCRIPTION
These 3 links don't go anywhere (anymore, the respective pages must have been moved?), and are more of a distraction than adding any real value when reading that paragraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5601)
<!-- Reviewable:end -->
