### PR TITLE
Update the flannel setup instructions

### DIFF
--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -249,7 +249,6 @@ kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel-rbac.yml
 ```
 {% endcapture %}
 


### PR DESCRIPTION
https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel-rbac.yml link is no more valid and kube-flannel-rbac.yml file content is combined into kube-flannel.yml, so removing the broken link.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5602)
<!-- Reviewable:end -->
