### PR TITLE
Fixed hyperlinks for different ConfigMap headers

### DIFF
--- a/docs/tasks/configure-pod-container/configmap.md
+++ b/docs/tasks/configure-pod-container/configmap.md
@@ -23,7 +23,7 @@ This page shows you how to configure an application using a ConfigMap. ConfigMap
 
 ## Use kubectl to create a ConfigMap
 
-Use the `kubectl create configmap` command to create configmaps from [directories](#creating-configmaps-from-directories), [files](#creating-configmaps-from-files), or [literal values](#creating-configmaps-from-literal-values):
+Use the `kubectl create configmap` command to create configmaps from [directories](#create-configmaps-from-directories), [files](#create-configmaps-from-files), or [literal values](#create-configmaps-from-literal-values):
 
 ```shell
 kubectl create configmap <map-name> <data-source>


### PR DESCRIPTION
ConfigMap Header names are starting with "create", but in link it is written as "creating", because of that hyperlink was not working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5606)
<!-- Reviewable:end -->
