### PR TITLE
Fix typo in pod preset conflict example

### DIFF
--- a/docs/tasks/inject-data-application/podpreset.md
+++ b/docs/tasks/inject-data-application/podpreset.md
@@ -525,10 +525,10 @@ spec:
         - mountPath: /cache
           name: cache-volume
       ports:
+        - containerPort: 80
   volumes:
     - name: cache-volume
       emptyDir: {}
-        - containerPort: 80
 ```
 
 **If we run `kubectl describe...` we can see the event:**


### PR DESCRIPTION
Move container port definition to the correct line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5615)
<!-- Reviewable:end -->
