### PR TITLE
Fix link after design proposals move

### DIFF
--- a/docs/concepts/policy/resource-quotas.md
+++ b/docs/concepts/policy/resource-quotas.md
@@ -237,4 +237,4 @@ See a [detailed example for how to use resource quota](/docs/tasks/administer-cl
 
 ## Read More
 
-See [ResourceQuota design doc](https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md) for more information.
+See [ResourceQuota design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_resource_quota.md) for more information.


### PR DESCRIPTION
The design proposals were organized according to SIGs in https://github.com/kubernetes/community/pull/1010. This led to a broken link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5619)
<!-- Reviewable:end -->
