### PR TITLE
Polish AppArmor tutorial

### DIFF
--- a/docs/tutorials/clusters/apparmor.md
+++ b/docs/tutorials/clusters/apparmor.md
@@ -192,20 +192,7 @@ Next, we'll run a simple "Hello AppArmor" pod with the deny-write profile:
 {% include code.html language="yaml" file="hello-apparmor-pod.yaml" ghlink="/docs/tutorials/clusters/hello-apparmor-pod.yaml" %}
 
 ```shell
-$ kubectl create -f /dev/stdin <<EOF
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello-apparmor
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/hello: localhost/k8s-apparmor-example-deny-write
-spec:
-  containers:
-  - name: hello
-    image: busybox
-    command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]
-EOF
-pod "hello-apparmor" created
+$ kubectl create -f ./hello-apparmor-pod.yaml
 ```
 
 If we look at the pod events, we can see that the Pod container was created with the AppArmor
@@ -260,7 +247,7 @@ Node:          gke-test-default-pool-239f5d02-x1kf/
 Start Time:    Tue, 30 Aug 2016 17:58:56 -0700
 Labels:        <none>
 Annotations:   container.apparmor.security.beta.kubernetes.io/hello=localhost/k8s-apparmor-example-allow-write
-Status:        Failed
+Status:        Pending
 Reason:        AppArmor
 Message:       Pod Cannot enforce AppArmor: profile "k8s-apparmor-example-allow-write" is not loaded
 IP:


### PR DESCRIPTION
This patch proposes some edits to the AppArmor tutorial:

- The sample yaml file used doesn't have to be consumed from stdin given that its full content was already shown.
- When a profile doesn't exist, a pod is in 'Pending' state rather than 'Failed' state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5628)
<!-- Reviewable:end -->
