### PR TITLE
Correct setup link

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -127,7 +127,8 @@ example. You have to do this until SELinux support is improved in the kubelet.
 
 {% capture whatsnext %}
 
-* [Using kubeadm to Create a Cluster](/docs/getting-started-guides/kubeadm/)
+* [Using kubeadm to Create a
+  Cluster](/docs/setup/independent/create-cluster-kubeadm/)
 
 {% endcapture %}
 


### PR DESCRIPTION
The current link to https://kubernetes.io/docs/setup/ presently ends up
redirecting to https://kubernetes.io/docs/setup/. This corrects the link
to what seems to be the correct endpoint.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5634)
<!-- Reviewable:end -->
