### PR TITLE
Make it possible to link directly to the list of resource types

### DIFF
--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -229,7 +229,7 @@ $ kubectl cluster-info dump --output-directory=/path/to/cluster-state   # Dump c
 $ kubectl taint nodes foo dedicated=special-user:NoSchedule
 ```
 
-## Resource types
+## [Resource types](#Resource-types)
 
 The following table includes a list of all the supported resource types and their abbreviated aliases:
 


### PR DESCRIPTION
Added an anchor to the 'Resource types' section.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5642)
<!-- Reviewable:end -->
