### PR TITLE
update on state of HostAlias in 1.8 with hostNetwork Pod support

### DIFF
--- a/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -80,7 +80,11 @@ With the additional entries specified at the bottom.
 
 ## Limitations
 
-As of 1.7, Pods with hostNetwork enabled will not be able to use this feature. This is because kubelet only manages the hosts file for non-hostNetwork Pods. There are ongoing discussions to change this.
+HostAlias is only supported in 1.7+.
+
+HostAlias support in 1.7 is limited to non-hostNetwork Pods because kubelet only manages the hosts file for non-hostNetwork Pods.
+
+In 1.8, HostAlias is supported for all Pods regardless of network configuration.
 
 ## Why Does Kubelet Manage the Hosts File?
 


### PR DESCRIPTION
HostAlias in 1.8 has been updated to support Pods using hostNetwork with https://github.com/kubernetes/kubernetes/pull/50646

The documentation should reflect this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5644)
<!-- Reviewable:end -->
