### PR TITLE
Remove a bad example for selector defaulting

### DIFF
--- a/docs/concepts/configuration/overview.md
+++ b/docs/concepts/configuration/overview.md
@@ -23,7 +23,7 @@ This is a living document. If you think of something that is not on this list bu
 
   Note also that many `kubectl` commands can be called on a directory, so you can also call `kubectl create` on a directory of config files. See below for more details.
 
-- Don't specify default values unnecessarily, in order to simplify and minimize configs, and to reduce error. For example, omit the selector and labels in a `ReplicationController` if you want them to be the same as the labels in its `podTemplate`, since those fields are populated from the `podTemplate` labels by default. See the [guestbook app's](https://github.com/kubernetes/examples/tree/{{page.githubbranch}}/guestbook/) .yaml files for some [examples](https://github.com/kubernetes/examples/tree/{{page.githubbranch}}/guestbook/frontend-deployment.yaml) of this.
+- Don't specify default values unnecessarily -- simple and minimal configs will reduce errors.
 
 - Put an object description in an annotation to allow better introspection.
 


### PR DESCRIPTION
In a rapidly changing world, a previously encouraged practice is now becoming invalid. We should at least stop advocating such practices in the docs.

Changes made: remove a bad example that depends on old behavior of selector defaulting.

xref: #5650

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5665)
<!-- Reviewable:end -->
