### PR TITLE
Followup 5655: fix link to garbage collection

### DIFF
--- a/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/docs/concepts/workloads/controllers/cron-jobs.md
@@ -114,7 +114,7 @@ cronjob "hello" deleted
 ```
 
 This stops new jobs from being created and removes all the jobs and pods created by this cronjob.
-You can read more about it in [garbage collection section](/docs/concepts/cluster-administration/kubelet-garbage-collection/).
+You can read more about it in [garbage collection section](/docs/concepts/workloads/controllers/garbage-collection/).
 
 ## Cron Job Limitations
 


### PR DESCRIPTION
Not sure if we still have time to merge this in so I'm proposing it anyway.

This is a followup to the PR #5655 where the link to garbage collection should be corrected.

Another puzzle to me is about how are we porting this back to "master" branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5666)
<!-- Reviewable:end -->
