### PR TITLE
Deprecate openstack heat

### DIFF
--- a/docs/getting-started-guides/openstack-heat.md
+++ b/docs/getting-started-guides/openstack-heat.md
@@ -10,6 +10,9 @@ title: OpenStack Heat
 
 ## Getting started with OpenStack
 
+**Note:** The `openstack-heat` provider that this guide uses is deprecated as of
+Kubernetes v1.8 and will be removed in a future release.
+
 This guide will take you through the steps of deploying Kubernetes to Openstack using `kube-up.sh`. The primary mechanisms for this are [OpenStack Heat](https://wiki.openstack.org/wiki/Heat) and the [SaltStack](https://git.k8s.io/kubernetes/cluster/saltbase) distributed with Kubernetes.
 
 The default OS is CentOS 7, this has not been tested on other operating systems.

--- a/docs/tasks/inject-data-application/podpreset.md
+++ b/docs/tasks/inject-data-application/podpreset.md
@@ -526,10 +526,10 @@ spec:
         - mountPath: /cache
           name: cache-volume
       ports:
+        - containerPort: 80
   volumes:
     - name: cache-volume
       emptyDir: {}
-        - containerPort: 80
 ```
 
 **If we run `kubectl describe...` we can see the event:**


### PR DESCRIPTION
The openstack-heat provider for kube-up is being deprecated and will be
removed in a future release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5670)
<!-- Reviewable:end -->
