### PR TITLE
Switch references in HPA docs from alpha to beta

### DIFF
--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -9,7 +9,7 @@ title: Horizontal Pod Autoscaling Walkthrough
 
 Horizontal Pod Autoscaling automatically scales the number of pods
 in a replication controller, deployment or replica set based on observed CPU utilization
-(or, with alpha support, on some other, application-provided metrics).
+(or, with beta support, on some other, application-provided metrics).
 
 This document walks you through an example of enabling Horizontal Pod Autoscaling for the php-apache server.  For more information on how Horizontal Pod Autoscaling behaves, see the [Horizontal Pod Autoscaling user guide](/docs/tasks/run-application/horizontal-pod-autoscale/).
 
@@ -129,18 +129,18 @@ Here CPU utilization dropped to 0, and so HPA autoscaled the number of replicas 
 ## Autoscaling on multiple metrics and custom metrics
 
 You can introduce additional metrics to use when autoscaling the `php-apache` Deployment
-by making use of the `autoscaling/v2alpha1` API version.
+by making use of the `autoscaling/v2beta1` API version.
 
-First, get the YAML of your HorizontalPodAutoscaler in the `autoscaling/v2alpha1` form:
+First, get the YAML of your HorizontalPodAutoscaler in the `autoscaling/v2beta1` form:
 
 ```shell
-$ kubectl get hpa.v2alpha1.autoscaling -o yaml > /tmp/hpa-v2.yaml
+$ kubectl get hpa.v2beta1.autoscaling -o yaml > /tmp/hpa-v2.yaml
 ```
 
 Open the `/tmp/hpa-v2.yaml` file in an editor, and you should see YAML which looks like this:
 
 ```yaml
-apiVersion: autoscaling/v2alpha1
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
@@ -220,7 +220,7 @@ For example, if you had your monitoring system collecting metrics about network 
 you could update the definition above using `kubectl edit` to look like this:
 
 ```yaml
-apiVersion: autoscaling/v2alpha1
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
@@ -268,7 +268,7 @@ Ingress were serving a total of 10000 requests per second.
 
 ## Appendix: Horizontal Pod Autoscaler Status Conditions
 
-When using the `autoscaling/v2alpha1` form of the HorizontalPodAutoscaler, you will be able to see
+When using the `autoscaling/v2beta1` form of the HorizontalPodAutoscaler, you will be able to see
 *status conditions* set by Kubernetes on the HorizontalPodAutoscaler.  These status conditions indicate
 whether or not the HorizontalPodAutoscaler is able to scale, and whether or not it is currently restricted
 in any way.

--- a/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -12,7 +12,7 @@ This document describes the current state of Horizontal Pod Autoscaling in Kuber
 
 With Horizontal Pod Autoscaling, Kubernetes automatically scales the number of pods
 in a replication controller, deployment or replica set based on observed CPU utilization
-(or, with alpha support, on some other, application-provided metrics). Note that Horizontal
+(or, with beta support, on some other, application-provided metrics). Note that Horizontal
 Pod Autoscaling does not apply to objects that can't be scaled, for example, DaemonSet.
 
 The Horizontal Pod Autoscaler is implemented as a Kubernetes API resource and a controller.
@@ -73,8 +73,8 @@ The Horizontal Pod Autoscaler is an API resource in the Kubernetes `autoscaling`
 The current stable version, which only includes support for CPU autoscaling,
 can be found in the `autoscaling/v1` API version.
 
-The alpha version, which includes support for scaling on memory and custom metrics,
-can be found in `autoscaling/v2alpha1`. The new fields introduced in `autoscaling/v2alpha1`
+The beta version, which includes support for scaling on memory and custom metrics,
+can be found in `autoscaling/v2beta1`. The new fields introduced in `autoscaling/v2beta1`
 are preserved as annotations when working with `autoscaling/v1`.
 
 More details about the API object can be found at
@@ -108,7 +108,7 @@ the Horizontal Pod Autoscaler will not be bound to the new replication controlle
 
 ## Support for multiple metrics
 
-Kubernetes 1.6 adds support for scaling based on multiple metrics. You can use the `autoscaling/v2alpha1` API
+Kubernetes 1.6 adds support for scaling based on multiple metrics. You can use the `autoscaling/v2beta1` API
 version to specify multiple metrics for the Horizontal Pod Autoscaler to scale on. Then, the Horizontal Pod
 Autoscaler controller will evaluate each metric, and propose a new scale based on that metric. The largest of the
 proposed scales will be used as the new scale.
@@ -116,12 +116,12 @@ proposed scales will be used as the new scale.
 ## Support for custom metrics
 
 **Note**: Kubernetes 1.2 added alpha support for scaling based on application-specific metrics using special annotations.
-Support for these annotations was removed in Kubernetes 1.6 in favor of the `autoscaling/v2alpha1` API.  While the old method for collecting
+Support for these annotations was removed in Kubernetes 1.6 in favor of the new autoscaling API.  While the old method for collecting
 custom metrics is still available, these metrics will not be available for use by the Horizontal Pod Autoscaler, and the former
 annotations for specifying which custom metrics to scale on are no longer honored by the Horizontal Pod Autoscaler controller.
 
 Kubernetes 1.6 adds support for making use of custom metrics in the Horizontal Pod Autoscaler.
-You can add custom metrics for the Horizontal Pod Autoscaler to use in the `autoscaling/v2alpha1` API.
+You can add custom metrics for the Horizontal Pod Autoscaler to use in the `autoscaling/v2beta1` API.
 Kubernetes then queries the new custom metrics API to fetch the values of the appropriate custom metrics.
 
 ### Requirements


### PR DESCRIPTION
The HPA docs still referenced the alpha version.  This switches them to
talk about v2beta1, which is the appropriate version for Kubernetes 1.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5671)
<!-- Reviewable:end -->
