### PR TITLE
Kubeadm /docs/admin/kubeadm.md cleanup, editing.

### DIFF
--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -14,7 +14,7 @@ This document provides information on how to use kubeadm's advanced options.
 * TOC
 {:toc}
 
-Running `kubeadm init` bootstraps a Kubernetes cluster. This consists of the
+Running `kubeadm init` a Kubernetes master node will be created. This consists of the
 following steps:
 
 1. kubeadm runs a series of pre-flight checks to validate the system state
@@ -24,44 +24,66 @@ following steps:
 
 1. kubeadm generates a token that additional nodes can use to register
    themselves with the master in future.  Optionally, the user can provide a
-   token.
+   token via `--token`, as described in the
+   [section on managing tokens](#manage-tokens) below.
 
 1. kubeadm generates a self-signed CA to provision identities for each component
    (including nodes) in the cluster.  It also generates client certificates to
    be used by various components.  If the user has provided their own CA by
-   dropping it in the cert directory (configured via `--cert-dir`, by default
-   `/etc/kubernetes/pki`), this step is skipped.
+   dropping it in the cert directory configured via `--cert-dir`, by default
+   `/etc/kubernetes/pki`, this step is skipped as described in the
+   [section on using custom certificates](#custom-certificates).
 
-1. kubeadm outputs a kubeconfig file for the master's kubelet to use to connect
-   to the API server, as well as an additional kubeconfig file for cluster
-   administrators.
+1. kubeadm writes  in `/etc/kubernetes/` kubeconfig files for
+   the kubelet, the controller-manager and the scheduler to use to connect to the
+   API server, each one with their respective identities, as well as an additional
+   kubeconfig file for administration.
 
-1. kubeadm generates Kubernetes static Pod manifests for the API server,
-   controller manager and scheduler.  It places them in
-   `/etc/kubernetes/manifests`. The kubelet watches this directory for Pods to
-   create on startup. These are the core components of Kubernetes. Once they are
-   up and running kubeadm can set up and manage any additional components.
+1. kubeadm generates static Pod manifests for the API server,
+   controller manager and scheduler; in case an external etcd is not provided,
+   an additional static Pod manifest will be generated for etcd.
 
-1. kubeadm "taints" the master node so that only control plane components will
-   run there.  It also sets up the RBAC authorization system and writes a
-   special ConfigMap that is used to bootstrap trust with the kubelets.
+   Static Pod manifests are written in `/etc/kubernetes/manifests`; the kubelet
+   watches this directory for Pods to create on startup, as described in
+   the [section about kubelet drop-in](#kubelet-drop-in).
+
+   Once control plabe Pods are up and running kubeadm init sequence can continue.
+
+1. kubeadm "labels" and "taints" the master node so that only control plane
+   components will run there.
+
+1. Kubeadm makes all the necessary configurations for allowing node joining with the
+   [Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) and
+   [TLS Bootstrap](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/)
+   mechanism:
+   - Write a ConfigMap for making available all the information required
+     for joining and set up related RBAC access rules.
+   - Ensure access to the CSR signing API for bootstrap tokens.
+   - Configure auto approval for new CSR requests.
+
+   See [Securing your installation](#Securing-more) for hardening.
 
 1. kubeadm installs add-on components via the API server.  Right now this is
    the internal DNS server and the kube-proxy DaemonSet.
 
+1. Eventually, if `kubeadm init` is invoked with
+  `—features-gates=self-hosting`, the static Pod based control plane will be
+  transformed in a [self-hosed control plane](#self-hosting).
+
 Running `kubeadm join` on each node in the cluster consists of the following
 steps:
 
-1. kubeadm downloads root CA information from the API server.  By default, it
-   uses the bootstrap token and the CA key hash to verify the authenticity of
-   that data. The root CA can also be discovered directly via a file or URL.
+1. kubeadm downloads necessary cluster information from the API server.
+   By default, it uses the bootstrap token and the CA key hash to verify the authenticity of that data. The root CA can also be discovered directly via a file or URL.
 
-1. kubeadm creates a local key pair.  It prepares a certificate signing request
-   (CSR) and sends that off to the API server for signing.  The bootstrap token
-   is used to authenticate.  The control plane will sign this CSR requested
-   automatically.
+1. Once the cluster information are known, kubelet can start the TLS Bootstrapping
+   process (in v.1.7 this step was managed by kubeadm).
 
-1. kubeadm configures the local kubelet to connect to the API server.
+   The TLS bootstrap uses the shared token to temporarily authenticate
+   with the Kubernetes Master to submit a certificate signing request (CSR); by default the control plane will sign this CSR request automatically.
+
+1. Finally, kubeadm will configures the local kubelet to connect to the API server
+   with the defintive identity assigned to the node.
 
 ## Usage
 
@@ -69,9 +91,7 @@ Fields that support multiple values do so either with comma separation, or by
 specifying the flag multiple times.
 
 The kubeadm command line interface is currently in **beta**.  We are aiming to
-not break any scripted use of the main `kubeadm init` and `kubeadm join`.  The
-single exception here is the format of the kubeadm config file as detailed
-below.  That format is still considered alpha and may change.
+not break any scripted use of the main `kubeadm init` and `kubeadm join`.  Exceptions to this are documented below.
 
 ### `kubeadm init`
 
@@ -100,7 +120,7 @@ flags that can be used to customise the Kubernetes installation.
   Alternate Name section for the certificate that the API Server will use.  If you
   expose the API Server through a load balancer and public DNS you could specify
   this with
-  
+
   ```
   --apiserver-cert-extra-sans=kubernetes.example.com,kube.example.com,10.100.245.1
   ```
@@ -115,19 +135,22 @@ flags that can be used to customise the Kubernetes installation.
   A kubeadm specific [config file](#config-file).  This can be used to specify an
   extended set of options including passing arbitrary command line flags to the
   control plane components.
-  
-  **Note**: When providing configuration values using _both_ a configuration file
-  and flags, the file will take precedence. For example, if a file exists with:
-  
-  ```yaml
-  apiVersion: kubeadm.k8s.io/v1alpha1
-  kind: MasterConfiguration
-  token: 1234
-  ```
-  
-  and the user ran `kubeadm init --config file.yaml --token 5678`,
-  the chosen token value will be `1234`.
 
+  **Note**: Since 1.8, when providing a configuration files, it is not
+  allowed to use flags, with the exceptions of flags used to define kubeadm
+  behaviours (not configurations) e.g. `--skip-preflight-checks`
+
+- `--dry-run`
+
+   This flag tells kubeadm to don't apply any changes; just output what would be done.
+
+- `--feature-gates`
+
+  A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+  - SelfHosting=true|false (ALPHA - default=false)
+  - StoreCertsInSecrets=true|false (ALPHA - default=false)
+
+  See [self-hosed control plane](#self-hosting) for more detail.
 
 - `--kubernetes-version` (default 'latest') the kubernetes version to initialise
 
@@ -137,6 +160,12 @@ flags that can be used to customise the Kubernetes installation.
   this flag you can try any future version of Kubernetes.  Check [releases
   page](https://github.com/kubernetes/kubernetes/releases) for a full list of
   available versions.
+
+- `--node-name`
+
+  Allow to specify the node name, if something different than O.S. hostname should be used e.g. in case of Amazon EC2 instances.
+
+  The node-name is also added to the certificate that the API Server uses.
 
 - `--pod-network-cidr`
 
@@ -164,7 +193,7 @@ flags that can be used to customise the Kubernetes installation.
   `--service-dns-domain` to change the DNS name suffix. Again, you will need to
   update the `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` file
   accordingly else DNS will not function correctly.
-  
+
   **Note**: This flag has an effect (it's needed for the kube-dns Deployment
   manifest and the API Server's serving certificate) but not as you might expect,
   since you will have to modify the arguments to the kubelets in the cluster for
@@ -180,6 +209,11 @@ flags that can be used to customise the Kubernetes installation.
   By default, kubeadm runs a series of preflight checks to validate the system
   before making any changes. Advanced users can use this flag to bypass these if
   necessary.
+
+- `--skip-token-print`
+
+  By default, kubeadm prints the token at the end of the init procedure. Advanced
+  users can use this flag to bypass these if necessary.
 
 - `--token`
 
@@ -209,7 +243,7 @@ There are two main schemes for discovery:
    hash of the root CA key:
 
    `kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-ca-cert-hash sha256:1234..cdef 1.2.3.4:6443`
-   
+
  - **Using a file** (a subset of the standard kubeconfig file). This file can
    be a local file or downloaded via an HTTPS URL:
 
@@ -240,13 +274,7 @@ Here's an example on how to use it:
 
 - `--config`
 
-   Extended options are specified in the [kubeadm specific config file](#config-file).
-
-- `--skip-preflight-checks`
-
-  By default, kubeadm runs a series of preflight checks to validate the system
-  before making any changes. Advanced users can use this flag to bypass these if
-  necessary.
+  Extended options are specified in the [kubeadm specific config file](#config-file).
 
 - `--discovery-file`
 
@@ -254,9 +282,9 @@ Here's an example on how to use it:
   with nothing but an unnamed cluster entry.  This is used to find both the
   location of the API server to join along with a root CA bundle to use when
   talking to that server.
-  
+
   This might look something like this:
-  
+
   ``` yaml
   apiVersion: v1
   clusters:
@@ -288,7 +316,7 @@ Here's an example on how to use it:
   calculated by 3rd party tools or provisioning systems. For example, using the
   OpenSSL CLI:
   `openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex`
-  
+
   _Skipping this flag is allowed in Kubernetes 1.8, but makes certain spoofing
   attacks possible._ See the [security model](#security-model) for details.
   Pass `--discovery-token-unsafe-skip-ca-verification` to silence warnings (which
@@ -301,6 +329,12 @@ Here's an example on how to use it:
   [security tradeoffs](#security-model) involved in skipping this verification
   (which may or may not be appropriate in your environment).
 
+- `--node-name`
+
+  Allow to specify the node name, is something different than os hostname should be used e.g. in case of Amazon EC2 instances.
+
+  This node-name is also added to the certificate that the API Server uses.
+
 - `--tls-bootstrap-token`
 
   The token used to authenticate to the API server for the purposes of TLS
@@ -311,6 +345,44 @@ Here's an example on how to use it:
   Often times the same token is used for both `--discovery-token` and
   `--tls-bootstrap-token`.  This option specifies the same token for both.  Other
   flags override this flag if present.
+
+- `--skip-preflight-checks`
+
+  By default, kubeadm runs a series of preflight checks to validate the system
+  before making any changes. Advanced users can use this flag to bypass these if
+  necessary.
+
+### `kubeadm completion`
+
+Output shell completion code for the specified shell (bash or zsh).
+
+### `kubeadm config`
+
+Kubeadm v1.8.0+ automatically creates a ConfigMap with all the parameters
+used config on `kubeadm init`.
+
+But if you initialized your cluster using kubeadm v1.7.x or lower, you must use
+the `kubeadm config upload` command to create this ConfigMap in order
+for `kubeadm upgrade` to be able to configure your upgraded cluster correctly.
+
+### `kubeadm reset`
+
+Reverts any changes made to this host by `kubeadm init` or `kubeadm join`.
+
+### `kubeadm token`
+
+You can use the `kubeadm` tool to manage tokens on a running cluster. see [managing tokens](#manage-tokens) below for further details.
+
+### `kubeadm alpha phases`
+
+**WARNING:** While kubeadm command line interface is in beta, commands under this entry is still considered alpha and may change in future versions.
+
+`kubeadm phase` introduces a set of kubeadm CLI commands allowing to invoke
+individually each phase of the kubeadm init sequence; phases provide a reusable and composable API/toolbox.
+
+**Options for `kubeadm phases`:**
+
+Each kubeadm phase exposes a subset of relevant options from `kubeadm init` .
 
 ## Using kubeadm with a configuration file {#config-file}
 
@@ -337,12 +409,18 @@ etcd:
   caFile: <path|string>
   certFile: <path|string>
   keyFile: <path|string>
+  dataDir: <path|string>
+  extraArgs:
+    <argument>: <value|string>
+    <argument>: <value|string>
+  image: <string>
 networking:
   dnsDomain: <string>
   serviceSubnet: <cidr>
   podSubnet: <cidr>
 kubernetesVersion: <string>
 cloudProvider: <string>
+nodeName: <string>
 authorizationModes:
 - <authorizationMode1|string>
 - <authorizationMode2|string>
@@ -362,6 +440,11 @@ apiServerCertSANs:
 - <name1|string>
 - <name2|string>
 certificatesDir: <string>
+imageRepository: <string>
+unifiedControlPlaneImage: <string>
+featureGates:
+  <feature>: <bool>
+  <feature>: <bool>
 ```
 In addition, if authorizationMode is set to `ABAC`, you should write the config to `/etc/kubernetes/abac_policy.json`.
 However, if authorizationMode is set to `Webhook`, you should write the config to `/etc/kubernetes/webhook_authz.conf`.
@@ -377,10 +460,16 @@ discoveryToken: <string>
 discoveryTokenAPIServers:
 - <address|string>
 - <address|string>
+nodeName: <string>
 tlsBootstrapToken: <string>
+token: <string>
+discoveryTokenCACertHashes:
+- <SHA-256 hash|string>
+- <SHA-256 hash|string>
+discoveryTokenUnsafeSkipCAVerification: <bool>
 ```
 
-## Securing your installation even more
+## Securing your installation even more {#Securing-more}
 
 The defaults for kubeadm may not work for everyone. This section documents how to tighten up a kubeadm install
 at the cost of some usability.
@@ -460,17 +549,17 @@ commands.
 * `kubeadm token create` - Create a new token.
 
     * `--description <description>`
-      
+
       Set the human-readable description for the new token.
 
     * `--ttl <duration>`
-    
+
       Set the expiration time-to-live of the token relative to the current time.
       Default is 24 hours. A value of 0 means "never expire". The default unit
       of the duration is seconds but other units can be specified (e.g., `15m`, `1h`).
 
     * `--usages <usage>[,<usage>...]`
-      
+
       Set the ways that the token can be used.  The default is
       `signing,authentication`.  These are the usages as described above.
 
@@ -513,7 +602,7 @@ know the IP address that the master will have after it is started.
     kubeadm token generate
     ```
 
-1. Start both the master node and the worker nodes concurrently with this token.
+2. Start both the master node and the worker nodes concurrently with this token.
    As they come up they should find each other and form the cluster.  The same
    `--token` argument can be used on both `kubeadm init` and `kubeadm join`.
 
@@ -531,14 +620,14 @@ The right method for your environment depends on how you provision nodes and the
 security expectations you have about your network and node lifecycles.
 
 ### Token-based discovery with CA pinning
-_This is the default mode in Kubernetes 1.8._ In this mode, kubeadm downloads 
+_This is the default mode in Kubernetes 1.8._ In this mode, kubeadm downloads
 the cluster configuration (including root CA) and validates it using the token
 as well as validating that the root CA public key matches the provided hash and
 that the API server certificate is valid under the root CA.
 
 **Example `kubeadm join` command:**
 
- - `kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-ca-cert-hash sha256:1234..cdef 1.2.3.4:6443`
+`kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-ca-cert-hash sha256:1234..cdef 1.2.3.4:6443`
 
 **Advantages:**
 
@@ -572,19 +661,19 @@ using one of the other modes if possible.
 
  - The token can be generated ahead of time and shared with the master and
    worker nodes, which can then bootstrap in parallel without coordination. This
-  allows it to be used in many provisioning scenarios.
+     allows it to be used in many provisioning scenarios.
 
 **Disadvantages:**
 
  - If an attacker is able to steal a bootstrap token via some vulnerability,
    they can use that token (along with network-level access) to impersonate the
    master to other bootstrapping nodes. This may or may not be an appropriate
-   tradeoff in your environment. 
+   tradeoff in your environment.
 
 ### File or HTTPS-based discovery
 This provides an out-of-band way to establish a root of trust between the master
 and bootstrapping nodes.   Consider using this mode if you are building automated provisioning
-using kubeadm. 
+using kubeadm.
 
 **Example `kubeadm join` commands:**
 
@@ -632,6 +721,17 @@ EOF
 
 Now `kubelet` is ready to use the specified CRI runtime, and you can continue with `kubeadm init` and `kubeadm join` workflow to deploy Kubernetes cluster.
 
+## Using custom images {#custom-images}
+
+By default, kubeadm will pull images from `gcr.io/google_containers`, unless requested kubernetes version is a ci version; in this case `gcr.io/kubernetes-ci-image` will be used.
+
+This behaviour can be overriden by [using kubeadm with a configuration file](#config-file). Allowed customization are:
+- provide an alternative `imageRepository` to be used instead of
+  `gcr.io/google_containers` (NB. does not works for ci version)
+- provide an `unifiedControlPlaneImage` to be used instead of single images
+  for control plane components
+- provide an `etcd.image` name to be used
+
 ## Running kubeadm without an internet connection
 
 All of the control plane components run in Pods started by the kubelet and
@@ -655,7 +755,7 @@ Here `v1.7.x` means the "latest patch release of the v1.7 branch".
 
 `${ARCH}` can be one of: `amd64`, `arm`, `arm64`, `ppc64le` or `s390x`.
 
-## Managing the kubeadm drop-in file for the kubelet
+## Managing the kubeadm drop-in file for the kubelet {#kubelet-drop-in}
 
 The kubeadm deb package ships with configuration for how the kubelet should
 be run. Note that the `kubeadm` CLI command will never touch this drop-in file.
@@ -751,19 +851,19 @@ help to fully automate this process in the future.
 
 ## Environment variables
 
+**Note:** These environment variables are deprecated and will stop functioning in v1.8!
+
 There are some environment variables that modify the way that kubeadm works.
 Most users will have no need to set these. These environment variables are a
 short-term solution, eventually they will be integrated in the kubeadm
 configuration file.
 
-**Note:** These environment variables are deprecated and will stop functioning in v1.8!
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `KUBE_KUBERNETES_DIR` | `/etc/kubernetes` | Where most configuration files are written to and read from |
-| `KUBE_HYPERKUBE_IMAGE` | | If set, use a single hyperkube image with this name. If not set, individual images per server component will be used. |
-| `KUBE_ETCD_IMAGE` | `gcr.io/google_containers/etcd-<arch>:3.0.17` | The etcd container image to use. |
-| `KUBE_REPO_PREFIX` | `gcr.io/google_containers` | The image prefix for all images that are used. |
+| Variable               | Default                                  | Description                              |
+| ---------------------- | ---------------------------------------- | ---------------------------------------- |
+| `KUBE_KUBERNETES_DIR`  | `/etc/kubernetes`                        | Where most configuration files are written to and read from |
+| `KUBE_HYPERKUBE_IMAGE` |                                          | If set, use a single hyperkube image with this name. If not set, individual images per server component will be used. |
+| `KUBE_ETCD_IMAGE`      | `gcr.io/google_containers/etcd-<arch>:3.0.17` | The etcd container image to use.         |
+| `KUBE_REPO_PREFIX`     | `gcr.io/google_containers`               | The image prefix for all images that are used. |
 
 If `KUBE_KUBERNETES_DIR` is specified, you may need to rewrite the arguments of the kubelet.
 (e.g. --kubeconfig, --pod-manifest-path)
@@ -803,7 +903,7 @@ export no_proxy="localhost,127.0.0.1,localaddress,.localdomain.com,example.com,1
 Remember to change `proxy_ip` and add a kube master node IP address to
 `no_proxy`.
 
-## Using custom certificates
+## Using custom certificates {#custom-certificates}
 
 By default kubeadm will generate all the certificates needed for a cluster to run.
 You can override this behaviour by providing your own certificates.
@@ -819,6 +919,11 @@ use-case.
 This means you can, for example, prepopulate `/etc/kubernetes/pki/ca.crt`
 and `/etc/kubernetes/pki/ca.key` with an existing CA, which then will be used
 for signing the rest of the certs.
+
+Only for the CA, it is possible to provide the `ca.crt` file but not the `ca.key`
+file; if all other certificates and kubeconfig files already are in place kubeadm
+recognise this condition and activates the so called "ExternalCA" mode, which also
+implies the csrsignercontroller in controller-manager won't be started.
 
 ## Self-hosting the Kubernetes control plane  {#self-hosting}
 As of 1.8, kubeadm can experimentally create a _self-hosted_ Kubernetes control
@@ -854,22 +959,22 @@ The self-hosting bootstrap process is documented in [the kubeadm 1.8 design
 document](https://github.com/kubernetes/kubeadm/blob/master/docs/design/design_v1.8.md#optional-self-hosting).
 In summary, `kubeadm init --feature-gates=SelfHosting=true` works as follows:
 
- 1. As usual, kubeadm creates static pod YAML files in `/etc/kubernetes/manifests/`.
+  1. As usual, kubeadm creates static pod YAML files in `/etc/kubernetes/manifests/`.
 
- 1. Kubelet loads these files and launches the initial static control plane.
+  1. Kubelet loads these files and launches the initial static control plane.
     Kubeadm waits for this initial static control plane to be running and
     healthy. This is identical to the `kubeadm init` process without self-hosting.
 
- 1. Kubeadm uses the static control plane pod manifests to construct a set of
+  1. Kubeadm uses the static control plane pod manifests to construct a set of
     DaemonSet manifests that will run the self-hosted control plane.
 
- 1. Kubeadm creates DaemonSets in the `kube-system` namespace and waits for the
+  1. Kubeadm creates DaemonSets in the `kube-system` namespace and waits for the
     resulting pods to be running.
 
- 1. Once the new control plane is running (but not yet active), kubeadm deletes
+  1. Once the new control plane is running (but not yet active), kubeadm deletes
     the static pod YAML files. This triggers kubelet to stop those static pods.
 
- 1. When the original static control plane stops, the new self-hosted control
+  1. When the original static control plane stops, the new self-hosted control
     plane is able to bind to listening ports and become active.
 
 This process (steps 3-6) can also be triggered with `kubeadm phase selfhosting convert-from-staticpods`.

--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -14,7 +14,7 @@ This document provides information on how to use kubeadm's advanced options.
 * TOC
 {:toc}
 
-Running `kubeadm init` a Kubernetes master node will be created. This consists of the
+Running `kubeadm init` bootstraps a Kubernetes master node. This consists of the
 following steps:
 
 1. kubeadm runs a series of pre-flight checks to validate the system state
@@ -30,11 +30,11 @@ following steps:
 1. kubeadm generates a self-signed CA to provision identities for each component
    (including nodes) in the cluster.  It also generates client certificates to
    be used by various components.  If the user has provided their own CA by
-   dropping it in the cert directory configured via `--cert-dir`, by default
-   `/etc/kubernetes/pki`, this step is skipped as described in the
+   dropping it in the cert directory configured via `--cert-dir`
+   (`/etc/kubernetes/pki` by default) this step is skipped as described in the
    [section on using custom certificates](#custom-certificates).
 
-1. kubeadm writes  in `/etc/kubernetes/` kubeconfig files for
+1. kubeadm writes kubeconfig files in `/etc/kubernetes/`  for
    the kubelet, the controller-manager and the scheduler to use to connect to the
    API server, each one with their respective identities, as well as an additional
    kubeconfig file for administration.
@@ -47,7 +47,7 @@ following steps:
    watches this directory for Pods to create on startup, as described in
    the [section about kubelet drop-in](#kubelet-drop-in).
 
-   Once control plabe Pods are up and running kubeadm init sequence can continue.
+   Once control plane Pods are up and running kubeadm init sequence can continue.
 
 1. kubeadm "labels" and "taints" the master node so that only control plane
    components will run there.
@@ -56,34 +56,40 @@ following steps:
    [Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) and
    [TLS Bootstrap](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/)
    mechanism:
+
    - Write a ConfigMap for making available all the information required
      for joining and set up related RBAC access rules.
+
    - Ensure access to the CSR signing API for bootstrap tokens.
+
    - Configure auto approval for new CSR requests.
 
-   See [Securing your installation](#Securing-more) for hardening.
+   See [Securing your installation](#securing-more) for hardening.
 
 1. kubeadm installs add-on components via the API server.  Right now this is
    the internal DNS server and the kube-proxy DaemonSet.
 
-1. Eventually, if `kubeadm init` is invoked with
-  `—features-gates=self-hosting`, the static Pod based control plane will be
-  transformed in a [self-hosed control plane](#self-hosting).
+1. If `kubeadm init` is invoked with the alpha self-hosting feature enabled,
+   (`--feature-gates=SelfHosting=true`), the static Pod based control plane will
+   be transformed in a [self-hosed control plane](#self-hosting).
 
 Running `kubeadm join` on each node in the cluster consists of the following
 steps:
 
 1. kubeadm downloads necessary cluster information from the API server.
-   By default, it uses the bootstrap token and the CA key hash to verify the authenticity of that data. The root CA can also be discovered directly via a file or URL.
+   By default, it uses the bootstrap token and the CA key hash to verify the
+   authenticity of that data. The root CA can also be discovered directly via a
+   file or URL.
 
-1. Once the cluster information are known, kubelet can start the TLS Bootstrapping
+1. Once the cluster information are known, kubelet can start the TLS bootstrapping
    process (in v.1.7 this step was managed by kubeadm).
 
    The TLS bootstrap uses the shared token to temporarily authenticate
-   with the Kubernetes Master to submit a certificate signing request (CSR); by default the control plane will sign this CSR request automatically.
+   with the Kubernetes Master to submit a certificate signing request (CSR); by
+   default the control plane will sign this CSR request automatically.
 
-1. Finally, kubeadm will configures the local kubelet to connect to the API server
-   with the defintive identity assigned to the node.
+1. Finally, kubeadm will configures the local kubelet to connect to the API
+   server with the definitive identity assigned to the node.
 
 ## Usage
 
@@ -91,7 +97,8 @@ Fields that support multiple values do so either with comma separation, or by
 specifying the flag multiple times.
 
 The kubeadm command line interface is currently in **beta**.  We are aiming to
-not break any scripted use of the main `kubeadm init` and `kubeadm join`.  Exceptions to this are documented below.
+not break any scripted use of the main `kubeadm init` and `kubeadm join`.
+Exceptions to this are documented below.
 
 ### `kubeadm init`
 
@@ -136,9 +143,9 @@ flags that can be used to customise the Kubernetes installation.
   extended set of options including passing arbitrary command line flags to the
   control plane components.
 
-  **Note**: Since 1.8, when providing a configuration files, it is not
-  allowed to use flags, with the exceptions of flags used to define kubeadm
-  behaviours (not configurations) e.g. `--skip-preflight-checks`
+  **Note**: Since 1.8, other flags are not allowed alongside `--config` except
+  for flags used to define kubeadm behaviour (not configuration) such as
+  `--skip-preflight-checks`.
 
 - `--dry-run`
 
@@ -146,11 +153,14 @@ flags that can be used to customise the Kubernetes installation.
 
 - `--feature-gates`
 
-  A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+  A set of key=value pairs that describe feature gates for alpha/experimental
+  features. Options are:
+
   - SelfHosting=true|false (ALPHA - default=false)
+
   - StoreCertsInSecrets=true|false (ALPHA - default=false)
 
-  See [self-hosed control plane](#self-hosting) for more detail.
+  See [self-hosted control plane](#self-hosting) for more detail.
 
 - `--kubernetes-version` (default 'latest') the kubernetes version to initialise
 
@@ -331,9 +341,9 @@ Here's an example on how to use it:
 
 - `--node-name`
 
-  Allow to specify the node name, is something different than os hostname should be used e.g. in case of Amazon EC2 instances.
-
-  This node-name is also added to the certificate that the API Server uses.
+  Specify the Node name. The default is to use the OS hostname. This is useful
+  on some cloud providers such as AWS. This name is also added to the node's
+  TLS certificate.
 
 - `--tls-bootstrap-token`
 
@@ -359,9 +369,9 @@ Output shell completion code for the specified shell (bash or zsh).
 ### `kubeadm config`
 
 Kubeadm v1.8.0+ automatically creates a ConfigMap with all the parameters
-used config on `kubeadm init`.
+used during `kubeadm init`.
 
-But if you initialized your cluster using kubeadm v1.7.x or lower, you must use
+If you initialized your cluster using kubeadm v1.7.x or lower, you must use
 the `kubeadm config upload` command to create this ConfigMap in order
 for `kubeadm upgrade` to be able to configure your upgraded cluster correctly.
 
@@ -371,18 +381,21 @@ Reverts any changes made to this host by `kubeadm init` or `kubeadm join`.
 
 ### `kubeadm token`
 
-You can use the `kubeadm` tool to manage tokens on a running cluster. see [managing tokens](#manage-tokens) below for further details.
+Manage tokens on a running cluster. See [managing tokens](#manage-tokens) below
+for further details.
 
 ### `kubeadm alpha phases`
 
-**WARNING:** While kubeadm command line interface is in beta, commands under this entry is still considered alpha and may change in future versions.
+**WARNING:** While kubeadm command line interface is in beta, commands under
+this entry is still considered alpha and may change in future versions.
 
 `kubeadm phase` introduces a set of kubeadm CLI commands allowing to invoke
-individually each phase of the kubeadm init sequence; phases provide a reusable and composable API/toolbox.
+individually each phase of the kubeadm init sequence; phases provide a reusable
+and composable API/toolbox for building your own automated cluster installer.
 
 **Options for `kubeadm phases`:**
 
-Each kubeadm phase exposes a subset of relevant options from `kubeadm init` .
+Each kubeadm phase exposes a subset of relevant options from `kubeadm init`.
 
 ## Using kubeadm with a configuration file {#config-file}
 
@@ -469,7 +482,7 @@ discoveryTokenCACertHashes:
 discoveryTokenUnsafeSkipCAVerification: <bool>
 ```
 
-## Securing your installation even more {#Securing-more}
+## Securing your installation even more {#securing-more}
 
 The defaults for kubeadm may not work for everyone. This section documents how to tighten up a kubeadm install
 at the cost of some usability.
@@ -602,7 +615,7 @@ know the IP address that the master will have after it is started.
     kubeadm token generate
     ```
 
-2. Start both the master node and the worker nodes concurrently with this token.
+1. Start both the master node and the worker nodes concurrently with this token.
    As they come up they should find each other and form the cluster.  The same
    `--token` argument can be used on both `kubeadm init` and `kubeadm join`.
 
@@ -627,7 +640,7 @@ that the API server certificate is valid under the root CA.
 
 **Example `kubeadm join` command:**
 
-`kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-ca-cert-hash sha256:1234..cdef 1.2.3.4:6443`
+ - `kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-ca-cert-hash sha256:1234..cdef 1.2.3.4:6443`
 
 **Advantages:**
 
@@ -661,7 +674,7 @@ using one of the other modes if possible.
 
  - The token can be generated ahead of time and shared with the master and
    worker nodes, which can then bootstrap in parallel without coordination. This
-     allows it to be used in many provisioning scenarios.
+   allows it to be used in many provisioning scenarios.
 
 **Disadvantages:**
 
@@ -698,19 +711,26 @@ using kubeadm.
 
 ## Use kubeadm with other CRI runtimes
 
-Since [Kubernetes 1.6 release](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#node-components-1), Kubernetes container runtimes have been transferred to using CRI by default. Currently, the build-in container runtime is Docker which is enabled by build-in `dockershim` in `kubelet`.
+Since [Kubernetes 1.6 release](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#node-components-1),
+Kubernetes container runtimes have been transferred to using CRI by default.
+Currently, the build-in container runtime is Docker which is enabled by built-in
+`dockershim` in `kubelet`.
 
-Using other CRI based runtimes with kubeadm is very simple, and currently supported runtimes are:
+Using other CRI based runtimes with kubeadm is very simple, and currently
+supported runtimes are:
 
 - [cri-o](https://github.com/kubernetes-incubator/cri-o)
 - [frakti](https://github.com/kubernetes/frakti)
 - [rkt](https://github.com/kubernetes-incubator/rktlet)
 
-After you have successfully installed `kubeadm` and `kubelet`, please follow these two steps:
+After you have successfully installed `kubeadm` and `kubelet`, please follow
+these two steps:
 
-1. Install runtime shim on every node. You will need to follow the installation document in the runtime shim project listing above.
+1. Install runtime shim on every node. You will need to follow the installation
+   document in the runtime shim project listing above.
 
-2. Configure kubelet to use remote CRI runtime. Please remember to change `RUNTIME_ENDPOINT` to your own value like `/var/run/{your_runtime}.sock`:
+1. Configure kubelet to use remote CRI runtime. Please remember to change
+   `RUNTIME_ENDPOINT` to your own value like `/var/run/{your_runtime}.sock`:
 
 ```shell
   $ cat > /etc/systemd/system/kubelet.service.d/20-cri.conf <<EOF
@@ -719,13 +739,17 @@ EOF
   $ systemctl daemon-reload
 ```
 
-Now `kubelet` is ready to use the specified CRI runtime, and you can continue with `kubeadm init` and `kubeadm join` workflow to deploy Kubernetes cluster.
+Now `kubelet` is ready to use the specified CRI runtime, and you can continue
+with `kubeadm init` and `kubeadm join` workflow to deploy Kubernetes cluster.
 
 ## Using custom images {#custom-images}
 
-By default, kubeadm will pull images from `gcr.io/google_containers`, unless requested kubernetes version is a ci version; in this case `gcr.io/kubernetes-ci-image` will be used.
+By default, kubeadm will pull images from `gcr.io/google_containers`, unless
+requested kubernetes version is a ci version; in this case
+`gcr.io/kubernetes-ci-image` will be used.
 
-This behaviour can be overriden by [using kubeadm with a configuration file](#config-file). Allowed customization are:
+This behaviour can be overridden by [using kubeadm with a configuration file](#config-file).
+Allowed customization are:
 - provide an alternative `imageRepository` to be used instead of
   `gcr.io/google_containers` (NB. does not works for ci version)
 - provide an `unifiedControlPlaneImage` to be used instead of single images
@@ -858,12 +882,12 @@ Most users will have no need to set these. These environment variables are a
 short-term solution, eventually they will be integrated in the kubeadm
 configuration file.
 
-| Variable               | Default                                  | Description                              |
-| ---------------------- | ---------------------------------------- | ---------------------------------------- |
-| `KUBE_KUBERNETES_DIR`  | `/etc/kubernetes`                        | Where most configuration files are written to and read from |
-| `KUBE_HYPERKUBE_IMAGE` |                                          | If set, use a single hyperkube image with this name. If not set, individual images per server component will be used. |
-| `KUBE_ETCD_IMAGE`      | `gcr.io/google_containers/etcd-<arch>:3.0.17` | The etcd container image to use.         |
-| `KUBE_REPO_PREFIX`     | `gcr.io/google_containers`               | The image prefix for all images that are used. |
+| Variable               | Default                                       | Description                              |
+| ---------------------- | --------------------------------------------- | ---------------------------------------- |
+| `KUBE_KUBERNETES_DIR`  | `/etc/kubernetes`                             | Where most configuration files are written to and read from |
+| `KUBE_HYPERKUBE_IMAGE` |                                               | If set, use a single hyperkube image with this name. If not set, individual images per server component will be used. |
+| `KUBE_ETCD_IMAGE`      | `gcr.io/google_containers/etcd-<arch>:3.0.17` | The etcd container image to use. |
+| `KUBE_REPO_PREFIX`     | `gcr.io/google_containers`                    | The image prefix for all images that are used. |
 
 If `KUBE_KUBERNETES_DIR` is specified, you may need to rewrite the arguments of the kubelet.
 (e.g. --kubeconfig, --pod-manifest-path)


### PR DESCRIPTION
This is primarily work from @fabriziopandini. He handed over his edits and I did some cleanup (after taking way too long to share, sorry about that). Some of these changes clarify work that happened in 1.8, but mostly it's general cleanup and rewording.

We agreed to do some heavy editing/reworking of this doc after 1.8. In particular, this page is getting really long and we'd like to break it up into multiple pages like the `kubefed` docs.

cc @luxas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5681)
<!-- Reviewable:end -->
