### PR TITLE
kubelet tls bootstrapping: fix role names

### DIFF
--- a/docs/admin/kubelet-tls-bootstrapping.md
+++ b/docs/admin/kubelet-tls-bootstrapping.md
@@ -133,9 +133,9 @@ rules:
 As of 1.8, equivalent roles to the ones listed above are automatically created as part of the default RBAC roles.
 For 1.8 clusters admins are recommended to bind tokens to the following roles instead of creating their own:
 
-* `system:certificates.k8s.io:certificatesigningrequests:io:certificatesigningrequests:nodeclient`
+* `system:certificates.k8s.io:certificatesigningrequests:nodeclient`
     - Automatically approve CSRs for client certs bound to this role.
-* `system:certificates.k8s.io:certificatesigningrequests:io:certificatesigningrequests:selfnodeclient`
+* `system:certificates.k8s.io:certificatesigningrequests:selfnodeclient`
     - Automatically approve CSRs when a client bound to its role renews its own certificate.
 
 These powers can be granted to credentials, such as bootstrapping tokens. For example, to replicate the behavior


### PR DESCRIPTION
Fixes a mistake committed in https://github.com/kubernetes/kubernetes.github.io/pull/5660

cc @liggitt @luxas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5684)
<!-- Reviewable:end -->
