### PR TITLE
Update network policy link

### DIFF
--- a/docs/tasks/administer-cluster/calico-network-policy.md
+++ b/docs/tasks/administer-cluster/calico-network-policy.md
@@ -55,7 +55,7 @@ There are two main components to be aware of:
 {% endcapture %}
 
 {% capture whatsnext %}
-Once your cluster is running, you can follow the [NetworkPolicy getting started guide](/docs/getting-started-guides/network-policy/walkthrough) to try out Kubernetes NetworkPolicy.
+Once your cluster is running, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/calico-network-policy.md
+++ b/docs/tasks/administer-cluster/calico-network-policy.md
@@ -55,7 +55,7 @@ There are two main components to be aware of:
 {% endcapture %}
 
 {% capture whatsnext %}
-Once your cluster is running, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
+Once your cluster is running, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy.
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/cilium-network-policy.md
+++ b/docs/tasks/administer-cluster/cilium-network-policy.md
@@ -72,7 +72,7 @@ There are two main components to be aware of:
 {% endcapture %}
 
 {% capture whatsnext %}
-Once your cluster is running, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy with Cilium.  Have fun, and if you have questions, contact us using the [Cilium Slack Channel](https://cilium.herokuapp.com/).
+Once your cluster is running, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy with Cilium.  Have fun, and if you have questions, contact us using the [Cilium Slack Channel](https://cilium.herokuapp.com/).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/cilium-network-policy.md
+++ b/docs/tasks/administer-cluster/cilium-network-policy.md
@@ -72,7 +72,7 @@ There are two main components to be aware of:
 {% endcapture %}
 
 {% capture whatsnext %}
-Once your cluster is running, you can follow the [NetworkPolicy getting started guide](/docs/getting-started-guides/network-policy/walkthrough) to try out Kubernetes NetworkPolicy with Cilium.  Have fun, and if you have questions, contact us using the [Cilium Slack Channel](https://cilium.herokuapp.com/).
+Once your cluster is running, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy with Cilium.  Have fun, and if you have questions, contact us using the [Cilium Slack Channel](https://cilium.herokuapp.com/).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/kube-router-network-policy.md
+++ b/docs/tasks/administer-cluster/kube-router-network-policy.md
@@ -18,8 +18,7 @@ The Kube-router Addon comes with a Network Policy Controller that watches Kubern
 {% endcapture %}
 
 {% capture whatsnext %}
-Once you have installed the Kube-router addon, you can follow the [NetworkPolicy getting started guide](/docs/getting-started-guides/network-policy/walkthrough) to try out Kubernetes NetworkPolicy.
+Once you have installed the Kube-router addon, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
 {% endcapture %}
 
 {% include templates/task.md %}
-

--- a/docs/tasks/administer-cluster/kube-router-network-policy.md
+++ b/docs/tasks/administer-cluster/kube-router-network-policy.md
@@ -18,7 +18,7 @@ The Kube-router Addon comes with a Network Policy Controller that watches Kubern
 {% endcapture %}
 
 {% capture whatsnext %}
-Once you have installed the Kube-router addon, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
+Once you have installed the Kube-router addon, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy.
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/romana-network-policy.md
+++ b/docs/tasks/administer-cluster/romana-network-policy.md
@@ -34,12 +34,8 @@ To apply network policies use one of the following:
 
 {% capture whatsnext %}
 
-Once your have installed Romana, you can follow the [NetworkPolicy getting started guide](/docs/getting-started-guides/network-policy/walkthrough) to try out Kubernetes NetworkPolicy.
+Once your have installed Romana, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
 
 {% endcapture %}
 
 {% include templates/task.md %}
-
-
-
-

--- a/docs/tasks/administer-cluster/romana-network-policy.md
+++ b/docs/tasks/administer-cluster/romana-network-policy.md
@@ -34,7 +34,7 @@ To apply network policies use one of the following:
 
 {% capture whatsnext %}
 
-Once your have installed Romana, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
+Once your have installed Romana, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy.
 
 {% endcapture %}
 

--- a/docs/tasks/administer-cluster/weave-network-policy.md
+++ b/docs/tasks/administer-cluster/weave-network-policy.md
@@ -108,7 +108,7 @@ spec:
 
 {% capture whatsnext %}
 
-Once you have installed the Weave Net addon, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
+Once you have installed the Weave Net addon, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy.
 
 {% endcapture %}
 

--- a/docs/tasks/administer-cluster/weave-network-policy.md
+++ b/docs/tasks/administer-cluster/weave-network-policy.md
@@ -108,7 +108,7 @@ spec:
 
 {% capture whatsnext %}
 
-Once you have installed the Weave Net addon, you can follow the [NetworkPolicy getting started guide](/docs/getting-started-guides/network-policy/walkthrough) to try out Kubernetes NetworkPolicy.
+Once you have installed the Weave Net addon, you can follow the [NetworkPolicy guide](/docs/concepts/services-networking/network-policies) to try out Kubernetes NetworkPolicy.
 
 {% endcapture %}
 


### PR DESCRIPTION
The `NetworkPolicy getting started guide` page is already removed, so fix links to direct to `NetworkPolicy guide` page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5701)
<!-- Reviewable:end -->
