### PR TITLE
kubeadm iptables settings on centos 

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -164,10 +164,18 @@ yum install -y kubelet kubeadm kubectl
 systemctl enable kubelet && systemctl start kubelet
 ```
 
-**Note:** Disabling SELinux by running `setenforce 0` is required to allow
-containers to access the host filesystem, which is required for the `kubeadm init`
-process to complete successfully. You have to do this until SELinux support
-is improved.
+  **Note:**
+
+  - Disabling SELinux by running `setenforce 0` is required to allow containers to access the host filesystem, which is required by pod networks for example. You have to do this until SELinux support is improved in the kubelet.
+  - Some users on RHEL/CentOS 7 have reported issues with traffic being routed incorrectly due to iptables being bypassed. You should ensure `net.bridge.bridge-nf-call-iptables` is set to 1 in your `sysctl` config, e.g.
+  
+    ``` bash
+    cat <<EOF >  /etc/sysctl.d/k8s.conf
+    net.bridge.bridge-nf-call-ip6tables = 1
+    net.bridge.bridge-nf-call-iptables = 1
+    EOF
+    sysctl --system
+    ```
 
 {% endcapture %}
 


### PR DESCRIPTION
**Important!**  this is re submit of https://github.com/kubernetes/kubernetes.github.io/pull/4340 (sorry for this)
CC @luxas @chenopis 

when running kubeadm on centos pre-fligth check fails due to
```bash
[preflight] Some fatal errors occurred:
	/proc/sys/net/bridge/bridge-nf-call-iptables contents are not set to 1
```
this PR contains description of required step to fix this issue (solution was described in previous version of kubeadm documentation, reported here with few little improvements)

After updating docs, IMO we can close https://github.com/kubernetes/kubeadm/issues/312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5707)
<!-- Reviewable:end -->
