### PR TITLE
Add warning about using packaged kubeadm

### DIFF
--- a/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
+++ b/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
@@ -41,6 +41,14 @@ $ export ARCH=amd64 # or: arm, arm64, ppc64le, s390x
 $ curl -sSL https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubeadm > /usr/bin/kubeadm
 $ chmod a+rx /usr/bin/kubeadm
 ```
+**Caution:** You will notice that `kubeadm` is also shipped in the Kubernetes
+repositories. It is important that you follow the instructions above and get
+`kubeadm` manually. Upgrading the `kubeadm` package on your system prior to
+upgrading the control plane will bring in new versions of kubelet and other
+packages, resulting in your upgrade going out of order! The kubeadm team is
+working on fixing this limitation. 
+
+{: .caution}
 
 Verify that this download of kubeadm works, and has the expected version:
 

--- a/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
+++ b/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
@@ -41,13 +41,11 @@ $ export ARCH=amd64 # or: arm, arm64, ppc64le, s390x
 $ curl -sSL https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubeadm > /usr/bin/kubeadm
 $ chmod a+rx /usr/bin/kubeadm
 ```
-**Caution:** You will notice that `kubeadm` is also shipped in the Kubernetes
-repositories. It is important that you follow the instructions above and get
-`kubeadm` manually. Upgrading the `kubeadm` package on your system prior to
-upgrading the control plane will bring in new versions of kubelet and other
-packages, resulting in your upgrade going out of order! The kubeadm team is
+**Caution:** Upgrading the `kubeadm` package on your system prior to upgrading
+the control plane brings in new versions of kubelet and other packages, resulting
+in a failed upgrade. Even though `kubeadm` is shipped in the Kubernetes repositories,
+it's important to install `kubeadm` manually. The kubeadm team is
 working on fixing this limitation. 
-
 {: .caution}
 
 Verify that this download of kubeadm works, and has the expected version:

--- a/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
+++ b/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
@@ -41,11 +41,11 @@ $ export ARCH=amd64 # or: arm, arm64, ppc64le, s390x
 $ curl -sSL https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubeadm > /usr/bin/kubeadm
 $ chmod a+rx /usr/bin/kubeadm
 ```
-**Caution:** Upgrading the `kubeadm` package on your system prior to upgrading
-the control plane brings in new versions of kubelet and other packages, resulting
-in a failed upgrade. Even though `kubeadm` is shipped in the Kubernetes repositories,
-it's important to install `kubeadm` manually. The kubeadm team is
-working on fixing this limitation. 
+**Caution:** Upgrading the `kubeadm` package on your system prior to
+upgrading the control plane causes a failed upgrade. Even though 
+`kubeadm` is shipped in the Kubernetes repositories, it's important 
+to install `kubeadm` manually. The kubeadm team is working on fixing
+this limitation. 
 {: .caution}
 
 Verify that this download of kubeadm works, and has the expected version:


### PR DESCRIPTION
This adds a note to reinforce to users to use the upstream binary. See also #4689

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5716)
<!-- Reviewable:end -->
