### PR TITLE
Updated PR template for GH workaround

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,6 @@
 >
 > Please delete this note before submitting the pull request.
 >
-> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box (see image below) to [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.
+> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box. This is a temporary workaround to address a known issue with GitHub.
 
 ![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,8 @@
 >
 > Please delete this note before submitting the pull request.
 
+> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box (see image below) to [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
+>
+> This is a temporary workaround to address a known issue with GitHub.
+
 ![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 > [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
 >
 > Please delete this note before submitting the pull request.
-
+>
 > NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box (see image below) to [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
 >
 > This is a temporary workaround to address a known issue with GitHub.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,6 @@
 >
 > Please delete this note before submitting the pull request.
 >
-> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box (see image below) to [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
->
-> This is a temporary workaround to address a known issue with GitHub.
+> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box (see image below) to [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.
 
 ![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)


### PR DESCRIPTION
This PR is a workaround for a known issue with the GitHub UI for allowing edits from maintainers. 

I'd love nothing more than to have to revert this PR tomorrow. 😭

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5719)
<!-- Reviewable:end -->
