### PR TITLE
do not include the command prompt

### DIFF
--- a/docs/tasks/access-application-cluster/configure-cloud-provider-firewall.md
+++ b/docs/tasks/access-application-cluster/configure-cloud-provider-firewall.md
@@ -65,7 +65,7 @@ Google Compute Engine firewalls are documented [elsewhere](https://cloud.google.
 You can add a firewall with the `gcloud` command line tool:
 
 ```shell
-$ gcloud compute firewall-rules create my-rule --allow=tcp:<port>
+gcloud compute firewall-rules create my-rule --allow=tcp:<port>
 ```
 
 **Note**


### PR DESCRIPTION
According to the [dont-include-the-command-prompt](https://kubernetes.io/docs/home/contribute/style-guide/#dont-include-the-command-prompt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5728)
<!-- Reviewable:end -->
