### PR TITLE
do not include the command prompt

### DIFF
--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -487,5 +487,5 @@ federation control plane's etcd. You can delete the federation
 namespace by running the following command:
 
 ```
-$ kubectl delete ns federation-system
+kubectl delete ns federation-system
 ```


### PR DESCRIPTION
According to the [dont-include-the-command-prompt](https://kubernetes.io/docs/home/contribute/style-guide/#dont-include-the-command-prompt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5729)
<!-- Reviewable:end -->
