### PR TITLE
Add URL to `kubectl create` in projected volume docs

### DIFF
--- a/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -34,7 +34,7 @@ Here is the configuration file for the Pod:
 
 1. Create the Pod:
 
-       kubectl create -f projected-volume.yaml
+       kubectl create -f https://k8s.io/docs/tasks/configure-pod-container/projected-volume.yaml
 
 1. Verify that the Pod's Container is running, and then watch for changes to
 the Pod:


### PR DESCRIPTION
Earlier it had only `kubectl create -f projected-volume.yaml` which is not a URL, so user has to create a file with the same name from the content given earlier in the task and then run that command now it becomes easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5733)
<!-- Reviewable:end -->
