### PR TITLE
add securityContext field at conatiner level

### DIFF
--- a/docs/tasks/configure-pod-container/security-context.yaml
+++ b/docs/tasks/configure-pod-container/security-context.yaml
@@ -15,4 +15,5 @@ spec:
     volumeMounts:
     - name: sec-ctx-vol
       mountPath: /data/demo
+    securityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
Right now the field `allowPrivilegeEscalation` is not under `securityContext` but under `volumeMounts`, so fixing it in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5734)
<!-- Reviewable:end -->
