### PR TITLE
add 1 to bridge-nf-call-iptables

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -16,6 +16,9 @@ This page shows how to use install kubeadm.
 * Unique MAC address and product_uuid for every node
 * Certain ports are open on your machines. See the section below for more details
 * Swap disabled. You must disable swap in order for the kubelet to work properly.
+* Set `/proc/sys/net/bridge/bridge-nf-call-iptables` to `1` by running `sysctl net.bridge.bridge-nf-call-iptables=1`
+to pass bridged IPv4 traffic to iptables' chains. This is a requirement for CNI plugins to work, for more information
+please see [here](https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
 
 {% endcapture %}
 


### PR DESCRIPTION
add 1 to /proc/sys/net/bridge/bridge-nf-call-iptables, since
pre-flight checks fail when doing `kubeadm init`, if the file
value is not 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5735)
<!-- Reviewable:end -->
