### PR TITLE
Update cn doc api reference

### DIFF
--- a/cn/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/cn/docs/concepts/configuration/manage-compute-resources-container.md
@@ -159,7 +159,7 @@ Allocated resources:
 
 通过查看 `Pods` 部分，您将看到哪些 Pod 占用的节点上的资源。
 
-Pod 可用的资源量小于节点容量，因为系统守护程序使用一部分可用资源。 [NodeStatus](/docs/resources-reference/{{page.version}}/#nodestatus-v1-core)  的 `allocatable` 字段给出了可用于 Pod 的资源量。有关更多信息，请参阅 [节点可分配资源](https://git.k8s.io/community/contributors/design-proposals/node-allocatable.md)。
+Pod 可用的资源量小于节点容量，因为系统守护程序使用一部分可用资源。 [NodeStatus](/docs/api-reference/{{page.version}}/#nodestatus-v1-core)  的 `allocatable` 字段给出了可用于 Pod 的资源量。有关更多信息，请参阅 [节点可分配资源](https://git.k8s.io/community/contributors/design-proposals/node-allocatable.md)。
 
 可以将 [资源配额](/docs/concepts/policy/resource-quotas/) 功能配置为限制可以使用的资源总量。如果与 namespace 配合一起使用，就可以防止一个团队占用所有资源。
 
@@ -290,9 +290,8 @@ Kubernetes 通过支持通过多级别的 [服务质量](http://issue.k8s.io/168
 
 - 获取将 [CPU 和内存资源分配给容器](/docs/tasks/configure-pod-container/assign-cpu-ram-container/) 的实践经验
 - [容器](/docs/api-reference/{{page.version}}/#container-v1-core)
-- [ResourceRequirements](/docs/resources-reference/{{page.version}}/#resourcerequirements-v1-core)
+- [ResourceRequirements](/docs/api-reference/{{page.version}}/#resourcerequirements-v1-core)
 
 {% endcapture %}
 
 {% include templates/concept.md %}
-

--- a/cn/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/cn/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -18,7 +18,7 @@ redirect_from:
 
 ## Pod phase
 
-Pod 的 `status` 定义在 [PodStatus](/docs/resources-reference/v1.7/#podstatus-v1-core) 对象中，其中有一个 `phase` 字段。
+Pod 的 `status` 定义在 [PodStatus](/docs/api-reference/{{page.version}}/#podstatus-v1-core) 对象中，其中有一个 `phase` 字段。
 
 Pod 的运行阶段（phase）是 Pod 在其生命周期中的简单宏观概述。该阶段并不是对容器或 Pod 的综合汇总，也不是为了做为综合状态机。
 
@@ -34,15 +34,15 @@ Pod 相位的数量和含义是严格指定的。除了本文档中列举的内�
 
 ## Pod 状态
 
-Pod 有一个 PodStatus 对象，其中包含一个 [PodCondition](/docs/resources-reference/v1.7/#podcondition-v1-core) 数组。 PodCondition 数组的每个元素都有一个 `type` 字段和一个 `status` 字段。`type` 字段是字符串，可能的值有 PodScheduled、Ready、Initialized 和 Unschedulable。`status` 字段是一个字符串，可能的值有 True、False 和 Unknown。
+Pod 有一个 PodStatus 对象，其中包含一个 [PodCondition](/docs/api-reference/v1.7/#podcondition-v1-core) 数组。 PodCondition 数组的每个元素都有一个 `type` 字段和一个 `status` 字段。`type` 字段是字符串，可能的值有 PodScheduled、Ready、Initialized 和 Unschedulable。`status` 字段是一个字符串，可能的值有 True、False 和 Unknown。
 
 ## 容器探针
 
-[探针](/docs/resources-reference/v1.7/#probe-v1-core) 是由 [kubelet](/docs/admin/kubelet/) 对容器执行的定期诊断。要执行诊断，kubelet 调用由容器实现的 [Handler](https://godoc.org/k8s.io/kubernetes/pkg/api/v1#Handler)。有三种类型的处理程序：
+[探针](/docs/api-reference/v1.7/#probe-v1-core) 是由 [kubelet](/docs/admin/kubelet/) 对容器执行的定期诊断。要执行诊断，kubelet 调用由容器实现的 [Handler](https://godoc.org/k8s.io/kubernetes/pkg/api/v1#Handler)。有三种类型的处理程序：
 
-- [ExecAction](/docs/resources-reference/v1.7/#execaction-v1-core)：在容器内执行指定命令。如果命令退出时返回码为 0 则认为诊断成功。
-- [TCPSocketAction](/docs/resources-reference/v1.7/#tcpsocketaction-v1-core)：对指定端口上的容器的 IP 地址进行 TCP 检查。如果端口打开，则诊断被认为是成功的。
-- [HTTPGetAction](/docs/resources-reference/v1.7/#httpgetaction-v1-core)：对指定的端口和路径上的容器的 IP 地址执行 HTTP Get 请求。如果响应的状态码大于等于200 且小于 400，则诊断被认为是成功的。
+- [ExecAction](/docs/api-reference/v1.7/#execaction-v1-core)：在容器内执行指定命令。如果命令退出时返回码为 0 则认为诊断成功。
+- [TCPSocketAction](/docs/api-reference/v1.7/#tcpsocketaction-v1-core)：对指定端口上的容器的 IP 地址进行 TCP 检查。如果端口打开，则诊断被认为是成功的。
+- [HTTPGetAction](/docs/api-reference/v1.7/#httpgetaction-v1-core)：对指定的端口和路径上的容器的 IP 地址执行 HTTP Get 请求。如果响应的状态码大于等于200 且小于 400，则诊断被认为是成功的。
 
 每次探测都将获得以下三种结果之一：
 
@@ -69,7 +69,7 @@ Kubelet 可以选择是否执行在容器上运行的两种探针执行和做出
 
 ## Pod 和容器状态
 
-有关 Pod 容器状态的详细信息，请参阅 [PodStatus](/docs/resources-reference/v1.7/#podstatus-v1-core) 和 [ContainerStatus](/docs/resources-reference/v1.7/#containerstatus-v1-core)。请注意，报告的 Pod 状态信息取决于当前的 [ContainerState](/docs/resources-reference/v1.7/#containerstatus-v1-core)。
+有关 Pod 容器状态的详细信息，请参阅 [PodStatus](/docs/api-reference/v1.7/#podstatus-v1-core) 和 [ContainerStatus](/docs/api-reference/v1.7/#containerstatus-v1-core)。请注意，报告的 Pod 状态信息取决于当前的 [ContainerState](/docs/api-reference/v1.7/#containerstatus-v1-core)。
 
 ## 重启策略
 
@@ -171,4 +171,3 @@ spec:
 {% endcapture %}
 
 {% include templates/concept.md %}
-

--- a/cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -34,11 +34,11 @@ title: 通过文件将Pod信息呈现给容器
 
 在配置文件中，你可以看到Pod有一个`downwardAPI`类型的Volume，并且挂载到容器中的`/etc`。
 
-查看`downwardAPI`下面的`items`数组。每个数组元素都是一个[DownwardAPIVolumeFile](/docs/resources-reference/{{page.version}}/#downwardapivolumefile-v1-core)。
+查看`downwardAPI`下面的`items`数组。每个数组元素都是一个[DownwardAPIVolumeFile](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core)。
 第一个元素指示Pod的`metadata.labels`字段的值保存在名为`labels`的文件中。
 第二个元素指示Pod的`annotations`字段的值保存在名为`annotations`的文件中。
 
-**注意:** 本示例中的字段是Pod字段，不是Pod中容器的字段。 
+**注意:** 本示例中的字段是Pod字段，不是Pod中容器的字段。
 {: .note}
 
 创建Pod：
@@ -198,11 +198,11 @@ kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
 
 {% capture whatsnext %}
 
-* [PodSpec](/docs/resources-reference/{{page.version}}/#podspec-v1-core)
-* [Volume](/docs/resources-reference/{{page.version}}/#volume-v1-core)
-* [DownwardAPIVolumeSource](/docs/resources-reference/{{page.version}}/#downwardapivolumesource-v1-core)
-* [DownwardAPIVolumeFile](/docs/resources-reference/{{page.version}}/#downwardapivolumefile-v1-core)
-* [ResourceFieldSelector](/docs/resources-reference/{{page.version}}/#resourcefieldselector-v1-core)
+* [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core)
+* [Volume](/docs/api-reference/{{page.version}}/#volume-v1-core)
+* [DownwardAPIVolumeSource](/docs/api-reference/{{page.version}}/#downwardapivolumesource-v1-core)
+* [DownwardAPIVolumeFile](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core)
+* [ResourceFieldSelector](/docs/api-reference/{{page.version}}/#resourcefieldselector-v1-core)
 
 {% endcapture %}
 

--- a/cn/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/cn/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -7,7 +7,7 @@ title: 通过环境变量将Pod信息呈现给容器
 此页面显示了Pod如何使用环境变量把自己的信息呈现给pod中运行的容器。环境变量可以呈现pod的字段和容器字段。
 
 有两种方式可以将Pod和Container字段呈现给运行中的容器：
-环境变量 和[DownwardAPIVolumeFiles](/docs/resources-reference/{{page.version}}/#downwardapivolumefile-v1-core).
+环境变量 和[DownwardAPIVolumeFiles](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core).
 这两种呈现Pod和Container字段的方式都称为*Downward API*。
 
 {% endcapture %}
@@ -27,7 +27,7 @@ title: 通过环境变量将Pod信息呈现给容器
 有两种方式可以将Pod和Container字段呈现给运行中的容器：
 
 * 环境变量
-* [DownwardAPIVolumeFiles](/docs/resources-reference/{{page.version}}/#downwardapivolumefile-v1-core)
+* [DownwardAPIVolumeFiles](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core)
 
 这两种呈现Pod和Container字段的方式都称为*Downward API*。
 
@@ -38,7 +38,7 @@ title: 通过环境变量将Pod信息呈现给容器
 
 {% include code.html language="yaml" file="dapi-envars-pod.yaml" ghlink="/cn/docs/tasks/inject-data-application/dapi-envars-pod.yaml" %}
 
-这个配置文件中，你可以看到五个环境变量。`env`字段是一个[EnvVars](/docs/resources-reference/{{page.version}}/#envvar-v1-core)类型的数组。
+这个配置文件中，你可以看到五个环境变量。`env`字段是一个[EnvVars](/docs/api-reference/{{page.version}}/#envvar-v1-core)类型的数组。
 数组中第一个元素指定`MY_NODE_NAME`这个环境变量从Pod的`spec.nodeName`字段获取变量值。同样，其它环境变量也是从Pod的字段获取它们的变量值。
 
 **注意:** 本示例中的字段是Pod字段，不是Pod中容器的字段。
@@ -105,7 +105,7 @@ MY_POD_NAME=dapi-envars-fieldref
 
 {% include code.html language="yaml" file="dapi-envars-container.yaml" ghlink="/cn/docs/tasks/inject-data-application/dapi-envars-container.yaml" %}
 
-这个配置文件中，你可以看到四个环境变量。`env`字段是一个[EnvVars](/docs/resources-reference/{{page.version}}/#envvar-v1-core)
+这个配置文件中，你可以看到四个环境变量。`env`字段是一个[EnvVars](/docs/api-reference/{{page.version}}/#envvar-v1-core)
 类型的数组。数组中第一个元素指定`MY_CPU_REQUEST`这个环境变量从容器的`requests.cpu`字段获取变量值。同样，其它环境变量也是从容器的字段获取它们的变量值。
 
 创建Pod：
@@ -140,12 +140,12 @@ kubectl logs dapi-envars-resourcefieldref
 {% capture whatsnext %}
 
 * [给容器定义环境变量](/docs/tasks/configure-pod-container/define-environment-variable-container/)
-* [PodSpec](/docs/resources-reference/{{page.version}}/#podspec-v1-core)
-* [Container](/docs/resources-reference/{{page.version}}/#container-v1-core)
-* [EnvVar](/docs/resources-reference/{{page.version}}/#envvar-v1-core)
-* [EnvVarSource](/docs/resources-reference/{{page.version}}/#envvarsource-v1-core)
-* [ObjectFieldSelector](/docs/resources-reference/{{page.version}}/#objectfieldselector-v1-core)
-* [ResourceFieldSelector](/docs/resources-reference/{{page.version}}/#resourcefieldselector-v1-core)
+* [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core)
+* [Container](/docs/api-reference/{{page.version}}/#container-v1-core)
+* [EnvVar](/docs/api-reference/{{page.version}}/#envvar-v1-core)
+* [EnvVarSource](/docs/api-reference/{{page.version}}/#envvarsource-v1-core)
+* [ObjectFieldSelector](/docs/api-reference/{{page.version}}/#objectfieldselector-v1-core)
+* [ResourceFieldSelector](/docs/api-reference/{{page.version}}/#resourcefieldselector-v1-core)
 
 {% endcapture %}
 

--- a/cn/docs/tutorials/object-management-kubectl/imperative-object-management-command.md
+++ b/cn/docs/tutorials/object-management-kubectl/imperative-object-management-command.md
@@ -130,7 +130,7 @@ kubectl create --edit -f /tmp/srv.yaml
  -  [使用对象配置管理 Kubernetes 对象(必要)](/docs/tutorials/object-management-kubectl/imperative-object-management-configuration/)
  -  [使用对象配置(声明式)管理 Kubernetes 对象](/docs/tutorials/object-management-kubectl/declarative-object-management-configuration/)
  -  [Kubectl 命令参考](/docs/user-guide/kubectl/v1.6/)
- -  [Kubernetes 对象模式参考](/docs/resources-reference/v1.6/)
+ -  [Kubernetes 对象模式参考](/docs/api-reference/{{page.version}}/)
  {% endcapture %}
 
  {% include templates/concept.md %}

--- a/cn/docs/tutorials/object-management-kubectl/object-management.md
+++ b/cn/docs/tutorials/object-management-kubectl/object-management.md
@@ -56,7 +56,7 @@ kubectl create deployment nginx --image nginx
 
 在命令式对象配置中，`kubectl` 命令指定操作(创建，替换等)，可选标志和至少一个文件名称。指定的文件必须包含对象的完整定义以 YAML 或 JSON 格式。
 
-请参阅[参考资源](https://kubernetes.io/docs/resources-reference/v1.6/)
+请参阅[参考资源](https://kubernetes.io/docs/api-reference/v1.6/)
 查看有关对象定义的更多细节。
 
 **警告:** 命令式 `replace` 命令用新提供的命令替换现有资源规格，将对配置文件中缺少的对象的所有更改都丢弃。这种方法不应更新与配置文件无关的资源类型。例如，`LoadBalancer` 类型的服务使其 `externalIPs` 字段与集群的配置无关。
@@ -143,7 +143,7 @@ kubectl apply -R -f configs/
  -  [使用对象配置管理 Kubernetes 对象(必要)](/docs/tutorials/object-management-kubectl/imperative-object-management-configuration/)
  -  [使用对象配置(声明式)管理 Kubernetes 对象](/docs/tutorials/object-management-kubectl/declarative-object-management-configuration/)
  -  [Kubectl 命令参考](/docs/user-guide/kubectl/v1.6/)
- -  [Kubernetes 对象模式参考](/docs/resources-reference/v1.6/)
+ -  [Kubernetes 对象模式参考](/docs/api-reference/v1.6/)
 
  {% comment %}
  {% endcomment %}


### PR DESCRIPTION
The `resources-reference` doc is not support in v1.8, we need move to `api-reference`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5740)
<!-- Reviewable:end -->
