### PR TITLE
Add TOC and fix links for kube-dns documentation

### DIFF
--- a/docs/concepts/services-networking/dns-pod-service.md
+++ b/docs/concepts/services-networking/dns-pod-service.md
@@ -5,6 +5,9 @@ approvers:
 title: DNS Pods and Services
 ---
 
+* TOC
+{:toc}
+
 ## Introduction
 
 As of Kubernetes 1.3, DNS is a built-in service launched automatically using the addon manager [cluster add-on](http://releases.k8s.io/{{page.githubbranch}}/cluster/addons/README.md).
@@ -30,6 +33,8 @@ DNS query for `foo.bar`.
 The following sections detail the supported record types and layout that is
 supported.  Any other layout or names or queries that happen to work are
 considered implementation details and are subject to change without warning.
+For more up-to-date specification, see
+[Kubernetes DNS-Based Service Discovery](https://github.com/kubernetes/dns/blob/master/docs/specification.md).
 
 ### Services
 

--- a/docs/concepts/workloads/controllers/statefulset.md
+++ b/docs/concepts/workloads/controllers/statefulset.md
@@ -123,8 +123,8 @@ is `$(statefulset name)-$(ordinal)`. The example above will create three Pods
 named `web-0,web-1,web-2`.
 A StatefulSet can use a [Headless Service](/docs/concepts/services-networking/service/#headless-services)
 to control the domain of its Pods. The domain managed by this Service takes the form:
-`$(service name).$(namespace).svc.cluster.local`, where "cluster.local"
-is the [cluster domain](http://releases.k8s.io/{{page.githubbranch}}/cluster/addons/dns/README.md).
+`$(service name).$(namespace).svc.cluster.local`, where "cluster.local" is the
+cluster domain.
 As each Pod is created, it gets a matching DNS subdomain, taking the form:
 `$(podname).$(governing service domain)`, where the governing service is defined
 by the `serviceName` field on the StatefulSet.
@@ -139,7 +139,7 @@ Cluster Domain | Service (ns/name) | StatefulSet (ns/name)  | StatefulSet Domain
  kube.local    | foo/nginx         | foo/web           | nginx.foo.svc.kube.local        | web-{0..N-1}.nginx.foo.svc.kube.local        | web-{0..N-1} |
 
 Note that Cluster Domain will be set to `cluster.local` unless
-[otherwise configured](http://releases.k8s.io/{{page.githubbranch}}/cluster/addons/dns/README.md).
+[otherwise configured](/docs/concepts/services-networking/dns-pod-service/#how-it-works).
 
 ### Stable Storage
 


### PR DESCRIPTION
The link (https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/README.md) on statefulset page doesn't talk anything about cluster domain, so re-link it to https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#how-it-works instead.

Also added a link to the specification doc on [kubernetes/dns](https://github.com/kubernetes/dns).

cc @bowei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5748)
<!-- Reviewable:end -->
