### PR TITLE
fix incorrect reference for openstack

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -671,7 +671,7 @@ Apiserver supports several cloud providers.
 Some cloud providers require a config file. If so, you need to put config file into apiserver image or mount through hostPath.
 
 - `--cloud-config=` set if cloud provider requires a config file.
-- Used by `aws`, `gce`, `mesos`, `openshift`, `ovirt` and `rackspace`.
+- Used by `aws`, `gce`, `mesos`, `openstack`, `ovirt` and `rackspace`.
 - You must put config file into apiserver image or mount through hostPath.
 - Cloud config file syntax is [Gcfg](https://code.google.com/p/gcfg/).
 - AWS format defined by type [AWSCloudConfig](https://releases.k8s.io/{{page.githubbranch}}/pkg/cloudprovider/providers/aws/aws.go)


### PR DESCRIPTION
resolves https://github.com/kubernetes/kubernetes.github.io/issues/5779
- verified there isn't an openshift cloud provider and there is one for openstack, not listed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5783)
<!-- Reviewable:end -->
