### PR TITLE
Removed unessary caracters when outputing the CA key hash using openssl

### DIFF
--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -325,7 +325,7 @@ Here's an example on how to use it:
   [RFC7469](https://tools.ietf.org/html/rfc7469#section-2.4)) and can also be
   calculated by 3rd party tools or provisioning systems. For example, using the
   OpenSSL CLI:
-  `openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex`
+  `openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | awk '{print $2}'`
 
   _Skipping this flag is allowed in Kubernetes 1.8, but makes certain spoofing
   attacks possible._ See the [security model](#security-model) for details.

--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -325,7 +325,7 @@ Here's an example on how to use it:
   [RFC7469](https://tools.ietf.org/html/rfc7469#section-2.4)) and can also be
   calculated by 3rd party tools or provisioning systems. For example, using the
   OpenSSL CLI:
-  `openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | awk '{print $2}'`
+  `openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'`
 
   _Skipping this flag is allowed in Kubernetes 1.8, but makes certain spoofing
   attacks possible._ See the [security model](#security-model) for details.


### PR DESCRIPTION
Removed unessary caracters when outputing the CA key hash using openssl.

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.
>
> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box. This is a temporary workaround to address a known issue with GitHub.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5784)
<!-- Reviewable:end -->
