### PR TITLE
Add links to CustomResourceDefinition reference.

### DIFF
--- a/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
+++ b/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
@@ -6,19 +6,26 @@ approvers:
 ---
 
 {% capture overview %}
-This page shows how to install a [custom resource](/docs/concepts/api-extension/custom-resources/)
-into the Kubernetes API by creating a CustomResourceDefinition.
+This page shows how to install a
+[custom resource](/docs/concepts/api-extension/custom-resources/)
+into the Kubernetes API by creating a
+[CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
 {% endcapture %}
 
 {% capture prerequisites %}
-* Read about [custom resources](/docs/concepts/api-extension/custom-resources/).
+
+{% include task-tutorial-prereqs.md %}
+
 * Make sure your Kubernetes cluster has a master version of 1.7.0 or higher.
+
+* Read about [custom resources](/docs/concepts/api-extension/custom-resources/).
+
 {% endcapture %}
 
 {% capture steps %}
 ## Create a CustomResourceDefinition
 
-When you create a new *CustomResourceDefinition* (CRD), the Kubernetes API Server
+When you create a new CustomResourceDefinition (CRD), the Kubernetes API Server
 reacts by creating a new RESTful resource path, either namespaced or cluster-scoped,
 as specified in the CRD's `scope` field. As with existing built-in objects, deleting a
 namespace deletes all custom objects in that namespace.
@@ -174,7 +181,8 @@ meaning all finalizers are done.
 
 ### Validation
 
-Validation of custom objects is possible via [OpenAPI v3 schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject).
+Validation of custom objects is possible via
+[OpenAPI v3 schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject).
 Additionally, the following restrictions are applied to the schema:
 
 - The fields `default`, `nullable`, `discriminator`, `readOnly`, `writeOnly`, `xml` and
@@ -293,6 +301,7 @@ crontab "my-new-cron-object" created
 
 {% capture whatsnext %}
 * Learn how to [Migrate a ThirdPartyResource to CustomResourceDefinition](/docs/tasks/access-kubernetes-api/migrate-third-party-resource/).
+* See [CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/access-kubernetes-api/extend-api-third-party-resource.md
+++ b/docs/tasks/access-kubernetes-api/extend-api-third-party-resource.md
@@ -134,3 +134,11 @@ $ kubectl get crontab -o json
     "selfLink": ""
 }
 ```
+
+## What's next
+
+* [Migrate a ThirdPartyResource to a CustomResourceDefinition](/docs/tasks/access-kubernetes-api/migrate-third-party-resource/)
+* [Extend the Kubernetes API with CustomResourceDefinitions](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/)
+* [ThirdPartyResource](/docs/api-reference/v1.7/#thirdpartyresource-v1beta1-extensions)
+
+

--- a/docs/tasks/access-kubernetes-api/migrate-third-party-resource.md
+++ b/docs/tasks/access-kubernetes-api/migrate-third-party-resource.md
@@ -6,7 +6,8 @@ approvers:
 ---
 
 {% capture overview %}
-This page shows how to migrate data stored in a ThirdPartyResource (TPR) to a CustomResourceDefinition (CRD).
+This page shows how to migrate data stored in a ThirdPartyResource (TPR) to a
+[CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions) (CRD).
 
 Kubernetes does not automatically migrate existing TPRs.
 This is due to API changes introduced as part of
@@ -22,6 +23,8 @@ you **on a best-effort basis**.
 {% endcapture %}
 
 {% capture prerequisites %}
+{% include task-tutorial-prereqs.md %}
+
 * Make sure your Kubernetes cluster has a **master version of exactly 1.7.x** (any patch release),
   as this is the only version that supports both TPR and CRD.
 * If you use a TPR-based custom controller, check with the author of the controller first.
@@ -160,6 +163,7 @@ you **on a best-effort basis**.
 {% capture whatsnext %}
 * Learn more about [custom resources](/docs/concepts/api-extension/custom-resources/).
 * Learn more about [using CustomResourceDefinitions](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
+* See [CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
 {% endcapture %}
 
 {% include templates/task.md %}


### PR DESCRIPTION
Fixes #4573.
@jbeda @nikhita

In two topics, I have added links to the ref page for CustomResourceDefinition.

It has been my habit, ever since I started writing Kubernetes docs, to include links to API objects when I'm working on task, tutorial, or concept page. So I think we are on the right track in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5788)
<!-- Reviewable:end -->
