### PR TITLE
Add -a flag.

### DIFF
--- a/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/docs/concepts/workloads/controllers/cron-jobs.md
@@ -94,7 +94,7 @@ your job name and pod name would be different.
 
 ```shell
 # Replace "hello-4111706356" with the job name in your system
-$ pods=$(kubectl get pods --selector=job-name=hello-4111706356 --output=jsonpath={.items..metadata.name})
+$ pods=$(kubectl get pods -a --selector=job-name=hello-4111706356 --output=jsonpath={.items..metadata.name})
 
 $ echo $pods
 hello-4111706356-o9qcm


### PR DESCRIPTION
Add `-a` to the `kubectl get pods` to get terminated pods as well.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5792)
<!-- Reviewable:end -->
