### PR TITLE
kubectl-apply doc: fix link to api types

### DIFF
--- a/docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
+++ b/docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
@@ -572,7 +572,7 @@ Add, delete, or update individual elements. This does not preserve ordering.
 
 This merge strategy uses a special tag on each field called a `patchMergeKey`. The
 `patchMergeKey` is defined for each field in the Kubernetes source code:
-[types.go](https://git.k8s.io/kubernetes/pkg/api/v1/types.go#L2119)
+[types.go](https://git.k8s.io/api/core/v1/types.go#L2565)
 When merging a list of maps, the field specified as the `patchMergeKey` for a given element
 is used like a map key for that element.
 
@@ -646,7 +646,7 @@ by `name`.
 As of Kubernetes 1.5, merging lists of primitive elements is not supported.
 
 **Note:** Which of the above strategies is chosen for a given field is controlled by
-the `patchStrategy` tag in [types.go](https://git.k8s.io/kubernetes/pkg/api/v1/types.go#L2119)
+the `patchStrategy` tag in [types.go](https://git.k8s.io/api/core/v1/types.go#L2565)
 If no `patchStrategy` is specified for a field of type list, then
 the list is replaced.
 


### PR DESCRIPTION
I am not sure what the link pointed to before. Now, it links to the `Containers` field since the example below it updates the containers field of a `PodSpec`.

Also, the docs in `kubernetes/community` uses the "containers" example: https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5799)
<!-- Reviewable:end -->
