### PR TITLE
docs(Configure Pod Initialization task): correct pod name in output

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-initialization.md
+++ b/docs/tasks/configure-pod-container/configure-pod-initialization.md
@@ -49,8 +49,8 @@ Verify that the nginx container is running:
 
 The output shows that the nginx container is running:
 
-    NAME      READY     STATUS    RESTARTS   AGE
-    nginx     1/1       Running   0          43m
+    NAME        READY     STATUS    RESTARTS   AGE
+    init-demo   1/1       Running   0          1m
 
 Get a shell into the nginx container running in the init-demo Pod:
 


### PR DESCRIPTION
Pod name in the output was shown wrong, so corrected it.
docs: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-initialization/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5803)
<!-- Reviewable:end -->
