### PR TITLE
docs(health checks): remove the unnecessary indentation

### DIFF
--- a/cn/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/cn/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -118,8 +118,8 @@ spec:
         path: /healthz
         port: 8080
         httpHeaders:
-          - name: X-Custom-Header
-            value: Awesome
+        - name: X-Custom-Header
+          value: Awesome
       initialDelaySeconds: 15
       timeoutSeconds: 1
     name: liveness

--- a/cn/docs/tasks/configure-pod-container/http-liveness.yaml
+++ b/cn/docs/tasks/configure-pod-container/http-liveness.yaml
@@ -6,20 +6,16 @@ metadata:
   name: liveness-http
 spec:
   containers:
-
   - name: liveness
-
     args:
     - /server
-
     image: gcr.io/google_containers/liveness
-
     livenessProbe:
       httpGet:
         path: /healthz
         port: 8080
         httpHeaders:
-          - name: X-Custom-Header
-            value: Awesome
+        - name: X-Custom-Header
+          value: Awesome
       initialDelaySeconds: 3
       periodSeconds: 3

--- a/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -208,8 +208,8 @@ spec:
         path: /healthz
         port: 8080
         httpHeaders:
-          - name: X-Custom-Header
-            value: Awesome
+        - name: X-Custom-Header
+          value: Awesome
       initialDelaySeconds: 15
       timeoutSeconds: 1
     name: liveness

--- a/docs/tasks/configure-pod-container/http-liveness.yaml
+++ b/docs/tasks/configure-pod-container/http-liveness.yaml
@@ -15,7 +15,7 @@ spec:
         path: /healthz
         port: 8080
         httpHeaders:
-          - name: X-Custom-Header
-            value: Awesome
+        - name: X-Custom-Header
+          value: Awesome
       initialDelaySeconds: 3
       periodSeconds: 3

--- a/docs/user-guide/liveness/http-liveness-named-port.yaml
+++ b/docs/user-guide/liveness/http-liveness-named-port.yaml
@@ -18,8 +18,8 @@ spec:
         path: /healthz
         port: liveness-port
         httpHeaders:
-          - name: X-Custom-Header
-            value: Awesome
+        - name: X-Custom-Header
+          value: Awesome
       initialDelaySeconds: 15
       timeoutSeconds: 1
     name: liveness

--- a/docs/user-guide/liveness/http-liveness.yaml
+++ b/docs/user-guide/liveness/http-liveness.yaml
@@ -14,8 +14,8 @@ spec:
         path: /healthz
         port: 8080
         httpHeaders:
-          - name: X-Custom-Header
-            value: Awesome
+        - name: X-Custom-Header
+          value: Awesome
       initialDelaySeconds: 15
       timeoutSeconds: 1
     name: liveness


### PR DESCRIPTION
The pod manifest in it's `httpHeaders` has unnecessary indentation,
removed that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5805)
<!-- Reviewable:end -->
