### PR TITLE
Make non-kubeadm component versioning explicit

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -132,6 +132,11 @@ You will install these packages on all of your machines:
 
 * `kubectl`: the command line util to talk to your cluster.
 
+kubeadm **will not** install or manage `kubelet` or `kubectl` for you, so you will 
+need to ensure they match the version of the Kubernetes control panel you want 
+kubeadm to install for you. If you do not, there is a risk of a version skew occurring that
+can lead to unexpected, buggy behaviour.
+
 Please proceed with executing the following commands based on your OS as `root`.
 You may become the `root` user by executing `sudo -i` after SSH-ing to each host.
 


### PR DESCRIPTION
Some users find the implicit version requirements between kubeadm and kubelet confusing, so adding docs to clarify this.

Fixes https://github.com/kubernetes/kubeadm/issues/467

/cc @luxas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5815)
<!-- Reviewable:end -->
