### PR TITLE
fix(pod restartPolicy): add restartPolicy to pods

### DIFF
--- a/cn/docs/concepts/configuration/commands.yaml
+++ b/cn/docs/concepts/configuration/commands.yaml
@@ -10,3 +10,4 @@ spec:
     image: debian
     command: ["printenv"]
     args: ["HOSTNAME", "KUBERNETES_PORT"]
+  restartPolicy: OnFailure

--- a/cn/docs/tasks/inject-data-application/commands.yaml
+++ b/cn/docs/tasks/inject-data-application/commands.yaml
@@ -10,3 +10,4 @@ spec:
     image: debian
     command: ["printenv"]
     args: ["HOSTNAME", "KUBERNETES_PORT"]
+  restartPolicy: OnFailure

--- a/docs/concepts/configuration/commands.yaml
+++ b/docs/concepts/configuration/commands.yaml
@@ -10,3 +10,4 @@ spec:
     image: debian
     command: ["printenv"]
     args: ["HOSTNAME", "KUBERNETES_PORT"]
+  restartPolicy: OnFailure

--- a/docs/tasks/inject-data-application/commands.yaml
+++ b/docs/tasks/inject-data-application/commands.yaml
@@ -10,3 +10,4 @@ spec:
     image: debian
     command: ["printenv"]
     args: ["HOSTNAME", "KUBERNETES_PORT"]
+  restartPolicy: OnFailure


### PR DESCRIPTION
Some pods were missing `restartPolicy` which caused them to
go in `CrashLoopBackoff`, so adding `restartPolicy` as
`OnFailure`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5817)
<!-- Reviewable:end -->
