### PR TITLE
Number error

### DIFF
--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -155,7 +155,7 @@ A job can be scaled up using the `kubectl scale` command.  For example, the foll
 command sets `.spec.parallelism` of a job called `myjob` to 10:
 
 ```shell
-$ kubectl scale  --replicas=10 jobs/myjob
+kubectl scale  --replicas=10 jobs/myjob
 job "myjob" scaled
 ```
 

--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -155,7 +155,7 @@ A job can be scaled up using the `kubectl scale` command.  For example, the foll
 command sets `.spec.parallelism` of a job called `myjob` to 10:
 
 ```shell
-kubectl scale  --replicas=10 jobs/myjob
+$ kubectl scale  --replicas=10 jobs/myjob
 job "myjob" scaled
 ```
 

--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -155,7 +155,7 @@ A job can be scaled up using the `kubectl scale` command.  For example, the foll
 command sets `.spec.parallelism` of a job called `myjob` to 10:
 
 ```shell
-$ kubectl scale  --replicas=$N jobs/myjob
+$ kubectl scale  --replicas=10 jobs/myjob
 job "myjob" scaled
 ```
 


### PR DESCRIPTION
 A job can be scaled up using the `kubectl scale` command.  For example, the following
 command sets `.spec.parallelism` of a job called `myjob` to 10:

but，the code:

```shell
$ kubectl scale  --replicas=$N jobs/myjob
```
should be :

```shell
$ kubectl scale  --replicas=10 jobs/myjob
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5835)
<!-- Reviewable:end -->
