### PR TITLE
Update syntax to be consistent with other docs

### DIFF
--- a/docs/concepts/services-networking/ingress.md
+++ b/docs/concepts/services-networking/ingress.md
@@ -212,7 +212,7 @@ metadata:
   name: no-rules-map
 spec:
   tls:
-    - secretName: testsecret
+  - secretName: testsecret
   backend:
     serviceName: s1
     servicePort: 80


### PR DESCRIPTION
All of the other docs start YAML lists with the dash not indented. Even though either syntax is valid, this makes the line consistent with the rest of the document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5842)
<!-- Reviewable:end -->
