### PR TITLE
Update misspelled word Enviornment to Environment

### DIFF
--- a/docs/tutorials/stateful-application/zookeeper.md
+++ b/docs/tutorials/stateful-application/zookeeper.md
@@ -535,7 +535,7 @@ Get the `zk` StatefulSet.
 ```{% endraw %}
 
 Notice that the command used to start the ZooKeeper servers passed the configuration 
-as command line parameter. Enviornment variables are another, equally good, way to 
+as command line parameter. Environment variables are another, equally good, way to 
 pass configuration to ensemble.
 
 ### Configuring Logging


### PR DESCRIPTION
Update misspelled word Enviornment to Environment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5845)
<!-- Reviewable:end -->
