### PR TITLE
correct header level in static pods

### DIFF
--- a/docs/tasks/administer-cluster/static-pod.md
+++ b/docs/tasks/administer-cluster/static-pod.md
@@ -64,7 +64,7 @@ For example, this is how to start a simple web server as a static pod:
     [root@my-node1 ~] $ systemctl restart kubelet
     ```
 
-## Pods created via HTTP
+### Pods created via HTTP
 
 Kubelet periodically downloads a file specified by `--manifest-url=<URL>` argument and interprets it as a json/yaml file with a pod definition. It works the same as `--pod-manifest-path=<directory>`, i.e. it's reloaded every now and then and changes are applied to running static pods (see below).
 


### PR DESCRIPTION
> Static pod can be created in two ways: either by using configuration file(s) or by HTTP.

`Pods created via HTTP` should be in the same header level with `Configuration files`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5859)
<!-- Reviewable:end -->
