### PR TITLE
deployment version in authenticating

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -185,7 +185,7 @@ talk to the API server. Accounts may be explicitly associated with pods using th
 NOTE: `serviceAccountName` is usually omitted because this is done automatically.
 
 ```
-apiVersion: apps/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: nginx-deployment


### PR DESCRIPTION
deployment for versions before 1.7.0 use apps/v1beta1,v1.8 become v1beta2!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5896)
<!-- Reviewable:end -->
