### PR TITLE
Document allowing unsafe sysctls in minikube

### DIFF
--- a/docs/concepts/cluster-administration/sysctl-cluster.md
+++ b/docs/concepts/cluster-administration/sysctl-cluster.md
@@ -96,8 +96,9 @@ $ kubelet --experimental-allowed-unsafe-sysctls 'kernel.msg*,net.ipv4.route.min_
 For minikube, this can be done via the `extra-config` flag:
 
  ```shell
- $ minikube start --extra-config="kubelet.AllowedUnsafeSysctls=kernel.msg*,net.ipv4.route.min_pmtu"...
+ $ minikube start --extra-config="kubelet.AllowedUnsafeSysctls=kernel.msg*,net.ipv4.route.min_pmtu" ...
  ```
+ 
 Only _namespaced_ sysctls can be enabled this way.
 
 ## Setting Sysctls for a Pod

--- a/docs/concepts/cluster-administration/sysctl-cluster.md
+++ b/docs/concepts/cluster-administration/sysctl-cluster.md
@@ -93,7 +93,11 @@ flag of the kubelet, e.g.:
 ```shell
 $ kubelet --experimental-allowed-unsafe-sysctls 'kernel.msg*,net.ipv4.route.min_pmtu' ...
 ```
+For minikube, this can be done via the `extra-config` flag:
 
+ ```shell
+ $ minikube start --extra-config="kubelet.AllowedUnsafeSysctls=kernel.msg*,net.ipv4.route.min_pmtu"...
+ ```
 Only _namespaced_ sysctls can be enabled this way.
 
 ## Setting Sysctls for a Pod


### PR DESCRIPTION
Add guide on allowing unsafe sysctls when using minikube

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5897)
<!-- Reviewable:end -->
