### PR TITLE
Reduce documented minimum node memory.

### DIFF
--- a/docs/tasks/administer-cluster/memory-default-namespace.md
+++ b/docs/tasks/administer-cluster/memory-default-namespace.md
@@ -15,7 +15,7 @@ Kubernetes assigns a default memory request under certain conditions that are ex
 
 {% include task-tutorial-prereqs.md %}
 
-Each node in your cluster must have at least 300 GiB of memory.
+Each node in your cluster must have at least 2 GiB of memory.
 
 {% endcapture %}
 


### PR DESCRIPTION
In "Configure Default Memory Requests and Limits for a Namespace", reduce documented minimum node memory from 300 GiB to 2 GiB.

Fixes https://github.com/kubernetes/kubernetes.github.io/issues/5900.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5901)
<!-- Reviewable:end -->
