### PR TITLE
The unified style

### DIFF
--- a/docs/tasks/configure-pod-container/memory-request-limit-2.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit-2.yaml
@@ -8,7 +8,7 @@ spec:
     image: vish/stress
     resources:
       requests:
-        memory: 50Mi
+        memory: "50Mi"
       limits:
         memory: "100Mi"
     args:


### PR DESCRIPTION
memory-request-limit.yaml

```
    resources:
      limits:
        memory: "200Mi"
```

memory-request-limit-3.yaml

```
    resources:
      limits:
        memory: "1000Gi"
```

But  memory-request-limit-2.yaml

```
    resources:
      requests:
        memory: 50Mi
```

Should be:

```
    resources:
      requests:
        memory: "50Mi"
```