### PR TITLE
Fix typos and one mistake of document /docs/admin/kubeadm

### DIFF
--- a/docs/admin/kubeadm.md
+++ b/docs/admin/kubeadm.md
@@ -52,7 +52,7 @@ following steps:
 1. kubeadm "labels" and "taints" the master node so that only control plane
    components will run there.
 
-1. Kubeadm makes all the necessary configurations for allowing node joining with the
+1. kubeadm makes all the necessary configurations for allowing node joining with the
    [Bootstrap Tokens](https://kubernetes.io/docs/admin/bootstrap-tokens/) and
    [TLS Bootstrap](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/)
    mechanism:
@@ -88,7 +88,7 @@ steps:
    with the Kubernetes Master to submit a certificate signing request (CSR); by
    default the control plane will sign this CSR request automatically.
 
-1. Finally, kubeadm will configures the local kubelet to connect to the API
+1. Finally, kubeadm will configure the local kubelet to connect to the API
    server with the definitive identity assigned to the node.
 
 ## Usage
@@ -192,7 +192,7 @@ flags that can be used to customise the Kubernetes installation.
 - `--service-cidr` (default '10.96.0.0/12')
 
   You can use the `--service-cidr` flag to override the subnet Kubernetes uses to
-  assign pods IP addresses. If you do, you will also need to update the
+  assign services IP addresses. If you do, you will also need to update the
   `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` file to reflect this
   change else DNS will not function correctly.
 
@@ -489,7 +489,7 @@ at the cost of some usability.
 
 ### Turning off auto-approval of Node Client Certificates
 
-By default, there is an CSR auto-approver enabled that basically approves any client certificate request
+By default, there is a CSR auto-approver enabled that basically approves any client certificate request
 for a kubelet when a Bootstrap Token was used when authenticating. If you don't want the cluster to
 automatically approve kubelet client certs, you can turn it off by executing this command:
 
@@ -541,13 +541,13 @@ users: []
 
 You can then use the `cluster-info.yaml` file as an argument to `kubeadm join --discovery-file`.
 
-Turning of public access to the `cluster-info` ConfigMap:
+Turning off public access to the `cluster-info` ConfigMap:
 
 ```console
 $ kubectl -n kube-public delete rolebinding kubeadm:bootstrap-signer-clusterinfo
 ```
 
-These command should be run after `kubeadm init` but before `kubeadm join`.
+These commands should be run after `kubeadm init` but before `kubeadm join`.
 
 ## Managing Tokens {#manage-tokens}
 
@@ -752,7 +752,7 @@ This behaviour can be overridden by [using kubeadm with a configuration file](#c
 Allowed customization are:
 - provide an alternative `imageRepository` to be used instead of
   `gcr.io/google_containers` (NB. does not works for ci version)
-- provide an `unifiedControlPlaneImage` to be used instead of single images
+- provide an `unifiedControlPlaneImage` to be used instead of single image
   for control plane components
 - provide an `etcd.image` name to be used
 


### PR DESCRIPTION
The typo is no need to explain. But there is a mistake:

The origin ariticle tells that 
```
You can use the `--service-cidr` flag to override the subnet Kubernetes uses to assign pods IP addresses.
```

But --service-cidr should be used to assign service ip address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5909)
<!-- Reviewable:end -->
