### PR TITLE
adding additional redirect for slight spelling delta in admin/addons

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -11,6 +11,7 @@
 
 /docs/admin/     /docs/concepts/cluster-administration/cluster-administration-overview/ 301
 /docs/admin/add-ons/     /docs/concepts/cluster-administration/addons/ 301
+/docs/admin/addons/     /docs/concepts/cluster-administration/addons/ 301
 /docs/admin/apparmor/     /docs/tutorials/clusters/apparmor/ 301
 /docs/admin/audit/     /docs/tasks/debug-application-cluster/audit/ 301
 /docs/admin/authorization/rbac.md     /docs/admin/authorization/rbac/ 301


### PR DESCRIPTION
- adds redirect for `http://kubernetes.io/docs/admin/addons/` to the already existing `http://kubernetes.io/docs/admin/add-ons/` to match content output by kubeadm
- resolves https://github.com/kubernetes/kubernetes.github.io/issues/5908

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5910)
<!-- Reviewable:end -->
