### PR TITLE
garbage-colleciton.md: add CronJob/Job that sets `ownerReference`

### DIFF
--- a/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/docs/concepts/workloads/controllers/garbage-collection.md
@@ -24,9 +24,10 @@ points to the owning object.
 
 Sometimes, Kubernetes sets the value of `ownerReference` automatically. For
 example, when you create a ReplicaSet, Kubernetes automatically sets the
-`ownerReference` field of each Pod in the ReplicaSet. In 1.6, Kubernetes
+`ownerReference` field of each Pod in the ReplicaSet. In 1.8, Kubernetes
 automatically sets the value of `ownerReference` for objects created or adopted
-by ReplicationController, ReplicaSet, StatefulSet, DaemonSet, and Deployment.
+by ReplicationController, ReplicaSet, StatefulSet, DaemonSet, Deployment, Job
+and CronJob.
 
 You can also specify relationships between owners and dependents by manually
 setting the `ownerReference` field.


### PR DESCRIPTION
From [CronJob Controller](https://github.com/kubernetes/kubernetes/blob/release-1.8/pkg/controller/cronjob/utils.go#L192) and [Job Controller](https://github.com/kubernetes/kubernetes/blob/release-1.8/pkg/controller/job/job_controller.go#L419), they will set `ownerReference` automatically.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5917)
<!-- Reviewable:end -->
