### PR TITLE
change the description of pod state on prestop hook

### DIFF
--- a/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/docs/concepts/containers/container-lifecycle-hooks.md
@@ -65,7 +65,7 @@ the Container cannot reach a `running` state.
 
 The behavior is similar for a `PreStop` hook.
 If the hook hangs during execution,
-the Pod phase stays in a `running` state and never reaches `failed`.
+the Pod phase stays in a `Terminating` state and is killed after `terminationGracePeriodSeconds` of pod ends.
 If a `PostStart` or `PreStop` hook fails,
 it kills the Container.
 


### PR DESCRIPTION
When the prestop hook hangs and pod is scheduled for termination, it changes to the `Terminating` state, but remains like that till the pod is forcefully killed since the `terminationGracePeriodSeconds` has ended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5938)
<!-- Reviewable:end -->
